### PR TITLE
fix: rewrite save_init_info to simplify its logic and preserve init args

### DIFF
--- a/igibson/utils/python_utils.py
+++ b/igibson/utils/python_utils.py
@@ -1,12 +1,13 @@
 """
 A set of utility functions for general python usage
 """
+import inspect
 from abc import ABCMeta
 from copy import deepcopy
-from importlib import import_module
-import inspect
-import numpy as np
 from functools import wraps
+from importlib import import_module
+
+import numpy as np
 
 # Global dictionary storing all unique names
 NAMES = set()


### PR DESCRIPTION
Rewrite save_init_info to simplify its logic and preserve init args.