### PR TITLE
fix segfault when importing certain objects (e.g. Rs_int + Fetch + cauldron with a small scale (<0.8))

### DIFF
--- a/igibson/macros.py
+++ b/igibson/macros.py
@@ -39,8 +39,10 @@ gm.ENABLE_FLATCACHE = False
 # objects from tunneling through each other)
 gm.ENABLE_CCD = False
 
+# Pairs setting -- USD default is 256 * 1024, physx default apparently is 32 * 1024.
+gm.GPU_PAIRS_CAPACITY = 256 * 1024
 # Aggregate pairs setting -- default is 1024, but is often insufficient for large scenes
-gm.GPU_PAIRS_CAPACITY = 32 * 1024
+gm.GPU_AGGR_PAIRS_CAPACITY = 1024 * 1024
 
 # Maximum particle contacts allowed
 gm.GPU_MAX_PARTICLE_CONTACTS = 1024 * 1024

--- a/igibson/simulator.py
+++ b/igibson/simulator.py
@@ -242,9 +242,9 @@ class Simulator(SimulationContext, Serializable):
             self._physics_context.set_broadphase_type("MBP")
 
         # Set GPU Pairs capacity and other GPU settings
-        self._physics_context.set_gpu_found_lost_aggregate_pairs_capacity(gm.GPU_PAIRS_CAPACITY)
         self._physics_context.set_gpu_found_lost_pairs_capacity(gm.GPU_PAIRS_CAPACITY)
-        self._physics_context.set_gpu_total_aggregate_pairs_capacity(gm.GPU_PAIRS_CAPACITY)
+        self._physics_context.set_gpu_found_lost_aggregate_pairs_capacity(gm.GPU_AGGR_PAIRS_CAPACITY)
+        self._physics_context.set_gpu_total_aggregate_pairs_capacity(gm.GPU_AGGR_PAIRS_CAPACITY)
         self._physics_context.set_gpu_max_particle_contacts(gm.GPU_MAX_PARTICLE_CONTACTS)
 
     @property


### PR DESCRIPTION
This PR is aiming to fix the following issue:

When importing the Rs_int scene + a Fetch robot + a cauldron (cauldron_000 model) with a small scale (<0.8), sim.play() will leads to segfault. This only happens when gpu dynamics is enabled.  

It's unclear what the reason is. It might be because the number of vertices per cubic meter exceeds some sort of limits. 

The solution is to increase the gpu (aggregate) pairs. 