### PR TITLE
Add example pick-place script based on primitives

### DIFF
--- a/omnigibson/action_primitives/pick_place_semantic_action_primitives.py
+++ b/omnigibson/action_primitives/pick_place_semantic_action_primitives.py
@@ -1,0 +1,261 @@
+from aenum import IntEnum, auto
+import numpy as np
+import torch as th
+
+import omnigibson as og
+from omnigibson.action_primitives.starter_semantic_action_primitives import (
+    StarterSemanticActionPrimitives)
+from omnigibson.controllers.controller_base import ControlType
+from omnigibson.macros import create_module_macros
+import omnigibson.utils.transform_utils as T
+
+
+m = create_module_macros(module_path=__file__)
+
+m.DEFAULT_BODY_OFFSET_FROM_FLOOR = 0.05
+m.MAX_CARTESIAN_HAND_STEP = 0.07
+m.MAX_STEPS_FOR_HAND_MOVE_IK = 50
+m.JOINT_POS_DIFF_THRESHOLD = 0.005
+m.MOVE_HAND_POS_THRESHOLD = 0.02
+
+
+class PickPlaceSemanticActionPrimitives(StarterSemanticActionPrimitives):
+    def __init__(
+        self,
+        env,
+        vid_logger,
+        add_context=False,
+        enable_head_tracking=True,
+        always_track_eef=False,
+        task_relevant_objects_only=False,
+    ):
+        super().__init__(env)
+        self.vid_logger = vid_logger
+        self.reset_state_info()
+
+    def _update_macros(self):
+        # update superclass macros with m from this file.
+        self.m.update(m)
+
+    def reset_state_info(self):
+        """
+        Called upon each env.reset().
+        TODO: This stuff should probably be moved to another Semantic Env-side class
+        """
+        self.state_info = dict(
+            gripper_closed=False,
+        )
+
+    def _grasp(self, obj_name):
+        # Set grasp pose
+        # quat is hardcoded (a somewhat top-down pose)
+        org_quat = th.tensor([ 0.79082719, -0.20438075, -0.55453328, -0.15910284])
+        obj = self.env.scene.object_registry("name", obj_name)
+        org_pos = obj.get_position_orientation()[0]
+        print("pos, ori:", org_pos, org_quat)
+
+        im = og.sim.viewer_camera._get_obs()[0]['rgb'][:, :, :3]
+        obs, obs_info = self.env.get_obs()
+        im_robot_view = obs['robot0']['robot0:eyes:Camera:0']['rgb'][:, :, :3]
+
+        # If want to keep the original target pose
+        new_pos, new_quat = org_pos, org_quat
+        print("obj pos", obj.get_position_orientation()[0])
+
+        # 1. Move to pregrasp pose
+        pre_grasp_pose = (
+            th.tensor(new_pos) + th.tensor([0.0, 0.0, 0.2]),
+            th.tensor(new_quat))
+        self.state_info['gripper_closed'] = self.execute_controller(
+            self._move_hand_linearly_cartesian(
+                pre_grasp_pose,
+                stop_if_stuck=False,
+                ignore_failure=True,
+                gripper_closed=self.state_info['gripper_closed'],
+                move_hand_pos_thresh=m.MOVE_HAND_POS_THRESHOLD,
+            ),
+            self.state_info['gripper_closed'],
+            self.vid_logger,
+        )
+
+        init_obj_pos = obj.get_position_orientation()[0]
+
+        # 2. Move to grasp pose
+        grasp_pose = (th.tensor(new_pos), th.tensor(new_quat))
+        self.state_info['gripper_closed'] = self.execute_controller(
+            self._move_hand_linearly_cartesian(
+                grasp_pose,
+                stop_if_stuck=False,
+                ignore_failure=True,
+                gripper_closed=self.state_info['gripper_closed'],
+                move_hand_pos_thresh=m.MOVE_HAND_POS_THRESHOLD,
+            ),
+            self.state_info['gripper_closed'],
+            self.vid_logger,
+        )
+
+        # 3. Perform grasp
+        self.state_info['gripper_closed'] = True
+        action = self._empty_action()
+        action[20] = -1
+        _ = self.execute_controller(
+            [action],
+            self.state_info['gripper_closed'],
+            self.vid_logger,
+        )
+
+        # step the simulator a few steps to let the gripper close completely
+        for _ in range(40):
+            og.sim.step()
+            self.vid_logger.save_im_text()
+
+        action_to_add = np.concatenate((np.array([0.0, 0.0, 0.0]), np.array(action[12:19])))     
+
+        # 4. Move to a random pose in a neighbourhood
+        x, y = org_pos[:2]
+        z = org_pos[2] + 0.15
+        neighbourhood_pose = (th.tensor([x, y, z]), grasp_pose[1])
+        self.state_info['gripper_closed'] = self.execute_controller(
+            self._move_hand_linearly_cartesian(
+                neighbourhood_pose,
+                stop_if_stuck=False,
+                ignore_failure=True,
+                gripper_closed=self.state_info['gripper_closed'],
+                move_hand_pos_thresh=m.MOVE_HAND_POS_THRESHOLD,
+            ),
+            self.state_info['gripper_closed'],
+            self.vid_logger,
+        )
+
+        final_obj_pos = obj.get_position_orientation()[0]
+        # Adding all 0 action for the last step
+        success = (final_obj_pos[2] - init_obj_pos[2]) > 0.02
+
+        return success
+
+    def _place_on_top(self, obj_name, dest_obj_name):
+        """
+        obj_name (str): success depends on this obj being on the target location
+        dest_obj_name (str): obj to place obj_name on
+        xyz_pos (torch.tensor): point the gripper should move to to open.
+        """
+        dest_obj = self.env.scene.object_registry("name", dest_obj_name)
+
+        # 1. Move to a drop point
+        obj_place_loc = dest_obj.get_position_orientation()[0]
+        xyz_pos = th.tensor(obj_place_loc + np.array([0.0, 0.0, 0.2]))
+        quat = th.tensor([ 0.79082719, -0.20438075, -0.55453328, -0.15910284])
+        open_gripper_pose = (xyz_pos, quat)
+        self.state_info['gripper_closed'] = self.execute_controller(
+            self._move_hand_linearly_cartesian(
+                open_gripper_pose,
+                stop_if_stuck=False,
+                ignore_failure=True,
+                gripper_closed=self.state_info['gripper_closed'],
+                move_hand_pos_thresh=m.MOVE_HAND_POS_THRESHOLD,
+            ),
+            self.state_info['gripper_closed'],
+            self.vid_logger,
+        )
+
+        # 2. Open Gripper
+        self.state_info['gripper_closed'] = False
+        action = self._empty_action()
+        # action[20] = 1
+        _ = self.execute_controller(
+            [action],
+            self.state_info['gripper_closed'],
+            self.vid_logger,
+        )
+
+        # step the simulator a few steps to let the gripper open completely
+        for _ in range(40):
+            og.sim.step()
+            self.vid_logger.save_im_text()
+
+        obj = self.env.scene.object_registry("name", obj_name)
+        obj_pos = obj.get_position_orientation()[0]
+        obj_place_loc = dest_obj.get_position_orientation()[0]
+        obj_z_dist = th.norm(obj_pos[2] - obj_place_loc[2])
+        obj_xy_dist = th.norm(obj_pos[:2] - obj_place_loc[:2])
+        print(f"obj_xy_dist, obj_z_dist: {obj_xy_dist} {obj_z_dist}")
+        success = bool((obj_z_dist <= 0.07).item() and (obj_xy_dist <= 0.06).item())
+        return success
+
+    def execute_controller(
+            self,
+            ctrl_gen,
+            gripper_closed,
+            arr=None
+    ):
+        actions = []
+        counter = 0
+        for action in ctrl_gen:
+            if action == 'Done':
+                obs, obs_info = self.env.get_obs()
+
+                proprio = self.robot._get_proprioception_dict()
+                # add eef pose and base pose to proprio
+                proprio['left_eef_pos'], proprio['left_eef_orn'] = self.robot.get_relative_eef_pose(arm='left')
+                proprio['right_eef_pos'], proprio['right_eef_orn'] = self.robot.get_relative_eef_pose(arm='right')
+                proprio['base_pos'], proprio['base_orn'] = self.robot.get_position_orientation()
+
+                is_contact = detect_robot_collision_in_sim(self.robot)
+
+                continue
+
+            wait = False
+
+            if gripper_closed:
+                action[20] = -1
+            else: 
+                action[20] = 1
+
+            o, r, te, tr, info = self.env.step(action)
+            self.vid_logger.save_im_text()
+
+            if wait:
+                for _ in range(60):
+                    og.sim.step()
+        
+            counter += 1
+        
+        print("total steps: ", counter)
+        return gripper_closed
+
+    def _empty_action(self):
+        """
+        Get a no-op action that allows us to run simulation without changing robot configuration.
+
+        Returns:
+            np.array or None: Action array for one step for the robot to do nothing
+        """
+        action = th.zeros(self.robot.action_dim)
+        for name, controller in self.robot._controllers.items():
+            joint_idx = controller.dof_idx.long()
+            action_idx = self.robot.controller_action_idx[name]
+            if controller.control_type == ControlType.POSITION and len(joint_idx) == len(action_idx) and not controller.use_delta_commands:
+                action[action_idx] = self.robot.get_joint_positions()[joint_idx]
+            elif self.robot._controller_config[name]["name"] == "InverseKinematicsController":
+                if self.robot._controller_config["arm_" + self.arm]["mode"] == "pose_absolute_ori":
+                    current_quat = self.robot.get_relative_eef_orientation()
+                    current_ori = T.quat2axisangle(current_quat)
+                    control_idx = self.robot.controller_action_idx["arm_" + self.arm]
+                    action[control_idx[3:]] = current_ori
+
+        return action
+
+    def _move_hand_direct_ik(
+        self,
+        target_pose,
+        pos_thresh=0.01,
+        ori_thresh=0.1,
+        **kwargs,
+    ):
+        # change pos and ori thresh
+        return super()._move_hand_direct_ik(
+            target_pose,
+            pos_thresh=pos_thresh,
+            ori_thresh=ori_thresh,
+            **kwargs,
+        )

--- a/omnigibson/action_primitives/starter_semantic_action_primitives.py
+++ b/omnigibson/action_primitives/starter_semantic_action_primitives.py
@@ -1153,8 +1153,10 @@ class StarterSemanticActionPrimitives(BaseActionPrimitiveSet):
         assert (
             controller_config["name"] == "InverseKinematicsController"
         ), "Controller must be InverseKinematicsController"
-        assert controller_config["mode"] in ["pose_absolute_ori", "pose_delta_ori"], (
-            "Controller must be in pose_absolute_ori or pose_delta_ori mode")
+        assert controller_config["mode"] in [
+            "pose_absolute_ori",
+            "pose_delta_ori",
+        ], "Controller must be in pose_absolute_ori or pose_delta_ori mode"
         if in_world_frame:
             target_pose = self._get_pose_in_robot_frame(target_pose)
         else:
@@ -1198,9 +1200,9 @@ class StarterSemanticActionPrimitives(BaseActionPrimitiveSet):
             prev_pos = current_pos
             prev_orn = current_orn
 
-            if self.robot._controller_config["arm_" + self.arm]["mode"] == 'pose_absolute_ori':
+            if self.robot._controller_config["arm_" + self.arm]["mode"] == "pose_absolute_ori":
                 action[control_idx] = th.cat([delta_pos, target_orn_axisangle])
-            elif self.robot._controller_config["arm_" + self.arm]["mode"] == 'pose_delta_ori':
+            elif self.robot._controller_config["arm_" + self.arm]["mode"] == "pose_delta_ori":
                 action[control_idx] = th.cat([delta_pos, delta_ori])
 
             yield self._postprocess_action(action)

--- a/omnigibson/action_primitives/starter_semantic_action_primitives.py
+++ b/omnigibson/action_primitives/starter_semantic_action_primitives.py
@@ -187,6 +187,7 @@ class PlanningContext(object):
                     if link_name in arm_links
                     else self.robot_copy.links_relative_poses[self.robot_copy_type][link_name]
                 )
+                link_pose = [th.tensor(arr) for arr in link_pose]
                 mesh_copy_pose = T.pose_transform(
                     *link_pose, *self.robot_copy.relative_poses[self.robot_copy_type][link_name][mesh_name]
                 )
@@ -1040,7 +1041,7 @@ class StarterSemanticActionPrimitives(BaseActionPrimitiveSet):
         indented_print("Plan has %d steps", len(plan))
         for i, target_pose in enumerate(plan):
             target_pos = target_pose[:3]
-            target_quat = T.axisangle2quat(target_pose[3:])
+            target_quat = T.axisangle2quat(th.tensor(target_pose[3:]))
             indented_print("Executing grasp plan step %d/%d", i + 1, len(plan))
             yield from self._move_hand_direct_ik(
                 (target_pos, target_quat), ignore_failure=True, in_world_frame=False, stop_if_stuck=stop_if_stuck
@@ -1146,6 +1147,8 @@ class StarterSemanticActionPrimitives(BaseActionPrimitiveSet):
         assert controller_config["mode"] == "pose_absolute_ori", "Controller must be in pose_absolute_ori mode"
         if in_world_frame:
             target_pose = self._get_pose_in_robot_frame(target_pose)
+        else:
+            target_pose = [th.tensor(arr) for arr in target_pose]
         target_pos = target_pose[0]
         target_orn = target_pose[1]
         target_orn_axisangle = T.quat2axisangle(target_pose[1])
@@ -1759,8 +1762,8 @@ class StarterSemanticActionPrimitives(BaseActionPrimitiveSet):
                 distance_lo, distance_hi = 0.0, 5.0
                 distance = (th.rand(1) * (distance_hi - distance_lo) + distance_lo).item()
                 yaw_lo, yaw_hi = -math.pi, math.pi
-                yaw = (th.rand(1) * (yaw_hi - yaw_lo) + yaw_lo).item()
-                avg_arm_workspace_range = th.mean(self.robot.arm_workspace_range[self.arm])
+                yaw = th.rand(1) * (yaw_hi - yaw_lo) + yaw_lo
+                avg_arm_workspace_range = th.mean(th.tensor(self.robot.arm_workspace_range[self.arm]))
                 pose_2d = th.tensor(
                     [
                         pose_on_obj[0][0] + distance * th.cos(yaw),

--- a/omnigibson/configs/tiago_primitives.yaml
+++ b/omnigibson/configs/tiago_primitives.yaml
@@ -1,0 +1,69 @@
+env:
+  action_frequency: 30                  # (int): environment executes action at the action_frequency rate
+  physics_frequency: 120                # (int): physics frequency (1 / physics_timestep for physx)
+  device: null                          # (None or str): specifies the device to be used if running on the gpu with torch backend
+  automatic_reset: false                # (bool): whether to automatic reset after an episode finishes
+  flatten_action_space: false           # (bool): whether to flatten the action space as a sinle 1D-array
+  flatten_obs_space: false              # (bool): whether the observation space should be flattened when generated
+  use_external_obs: false               # (bool): Whether to use external observations or not
+  initial_pos_z_offset: 0.1
+  external_sensors: null                # (None or list): If specified, list of sensor configurations for external sensors to add. Should specify sensor "type" and any additional kwargs to instantiate the sensor. Each entry should be the kwargs passed to @create_sensor, in addition to position, orientation
+
+render:
+  viewer_width: 1280
+  viewer_height: 720
+
+scene:
+  type: InteractiveTraversableScene
+  scene_model: Rs_int
+  trav_map_resolution: 0.1
+  default_erosion_radius: 0.0
+  trav_map_with_objects: true
+  num_waypoints: 1
+  waypoint_resolution: 0.2
+  load_object_categories: null
+  not_load_object_categories: null
+  load_room_types: null
+  load_room_instances: null
+  load_task_relevant_only: false
+  seg_map_resolution: 0.1
+  scene_source: OG
+  include_robots: false
+
+robots:
+  - type: Tiago
+    # obs_modalities: [rgb, depth, seg_semantic, normal, seg_instance, seg_instance_id]
+    obs_modalities: [rgb]
+    scale: 1.0
+    self_collisions: true
+    action_normalize: false
+    action_type: continuous
+    grasping_mode: physical
+    rigid_trunk: true
+    default_trunk_offset: 0.15
+    default_arm_pose: vertical
+    default_arm_side: right
+    sensor_config:
+      VisionSensor:
+        sensor_kwargs:
+          image_height: 128 #720
+          image_width: 128 #720
+    controller_config:
+      base:
+        name: JointController
+      arm_left:
+        name: NullJointController
+      arm_right:
+        name: InverseKinematicsController
+      gripper_left:
+        name: MultiFingerGripperController
+        mode: binary
+      gripper_right:
+        name: MultiFingerGripperController
+      camera:
+        name: JointController
+
+objects: []
+
+task:
+  type: DummyTask

--- a/omnigibson/controllers/controller_base.py
+++ b/omnigibson/controllers/controller_base.py
@@ -133,8 +133,8 @@ class BaseController(Serializable, Registerable, Recreatable):
         )
         command_output_limits = (
             (
-                self._control_limits[self.control_type][0][self.dof_idx],
-                self._control_limits[self.control_type][1][self.dof_idx],
+                th.tensor(self._control_limits[self.control_type][0])[self.dof_idx.long()],
+                th.tensor(self._control_limits[self.control_type][1])[self.dof_idx.long()],
             )
             if type(command_output_limits) == str and command_output_limits == "default"
             else command_output_limits
@@ -281,11 +281,11 @@ class BaseController(Serializable, Registerable, Recreatable):
             Array[float]: Clipped control signal
         """
         clipped_control = control.clip(
-            self._control_limits[self.control_type][0][self.dof_idx],
-            self._control_limits[self.control_type][1][self.dof_idx],
+            self._control_limits[self.control_type][0][self.dof_idx.long()],
+            self._control_limits[self.control_type][1][self.dof_idx.long()],
         )
         idx = (
-            self._dof_has_limits[self.dof_idx]
+            self._dof_has_limits[self.dof_idx.long()]
             if self.control_type == ControlType.POSITION
             else [True] * self.control_dim
         )

--- a/omnigibson/controllers/ik_controller.py
+++ b/omnigibson/controllers/ik_controller.py
@@ -312,7 +312,7 @@ class InverseKinematicsController(JointController, ManipulationController):
         target_quat = goal_dict["target_quat"]
 
         # Calculate and return IK-backed out joint angles
-        current_joint_pos = control_dict["joint_position"][self.dof_idx]
+        current_joint_pos = control_dict["joint_position"][self.dof_idx.long()]
 
         # If the delta is really small, we just keep the current joint position. This avoids joint
         # drift caused by IK solver inaccuracy even when zero delta actions are provided.
@@ -326,15 +326,15 @@ class InverseKinematicsController(JointController, ManipulationController):
             err = th.cat([pos_err, ori_err])
 
             # Use the jacobian to compute a local approximation
-            j_eef = control_dict[f"{self.task_name}_jacobian_relative"][:, self.dof_idx]
+            j_eef = control_dict[f"{self.task_name}_jacobian_relative"][:, self.dof_idx.long()]
             j_eef_pinv = th.linalg.pinv(j_eef)
             delta_j = j_eef_pinv @ err
             target_joint_pos = current_joint_pos + delta_j
 
             # Clip values to be within the joint limits
             target_joint_pos = target_joint_pos.clamp(
-                min=self._control_limits[ControlType.get_type("position")][0][self.dof_idx],
-                max=self._control_limits[ControlType.get_type("position")][1][self.dof_idx],
+                min=self._control_limits[ControlType.get_type("position")][0][self.dof_idx.long()],
+                max=self._control_limits[ControlType.get_type("position")][1][self.dof_idx.long()],
             )
 
         # Optionally pass through smoothing filter for better stability

--- a/omnigibson/controllers/multi_finger_gripper_controller.py
+++ b/omnigibson/controllers/multi_finger_gripper_controller.py
@@ -159,20 +159,20 @@ class MultiFingerGripperController(GripperController):
             Array[float]: outputted (non-clipped!) control signal to deploy
         """
         target = goal_dict["target"]
-        joint_pos = control_dict["joint_position"][self.dof_idx]
+        joint_pos = control_dict["joint_position"][self.dof_idx.long()]
         # Choose what to do based on control mode
         if self._mode == "binary":
             # Use max control signal
             should_open = target[0] >= 0.0 if not self._inverted else target[0] > 0.0
             if should_open:
                 u = (
-                    self._control_limits[ControlType.get_type(self._motor_type)][1][self.dof_idx]
+                    self._control_limits[ControlType.get_type(self._motor_type)][1][self.dof_idx.long()]
                     if self._open_qpos is None
                     else self._open_qpos
                 )
             else:
                 u = (
-                    self._control_limits[ControlType.get_type(self._motor_type)][0][self.dof_idx]
+                    self._control_limits[ControlType.get_type(self._motor_type)][0][self.dof_idx.long()]
                     if self._closed_qpos is None
                     else self._closed_qpos
                 )
@@ -183,10 +183,10 @@ class MultiFingerGripperController(GripperController):
         # If we're near the joint limits and we're using velocity / torque control, we zero out the action
         if self._motor_type in {"velocity", "torque"}:
             violate_upper_limit = (
-                joint_pos > self._control_limits[ControlType.POSITION][1][self.dof_idx] - self._limit_tolerance
+                joint_pos > self._control_limits[ControlType.POSITION][1][self.dof_idx.long()] - self._limit_tolerance
             )
             violate_lower_limit = (
-                joint_pos < self._control_limits[ControlType.POSITION][0][self.dof_idx] + self._limit_tolerance
+                joint_pos < self._control_limits[ControlType.POSITION][0][self.dof_idx.long()] + self._limit_tolerance
             )
             violation = th.logical_or(violate_upper_limit * (u > 0), violate_lower_limit * (u < 0))
             u *= ~violation
@@ -228,7 +228,7 @@ class MultiFingerGripperController(GripperController):
             is_grasping = IsGraspingState.UNKNOWN
 
         else:
-            finger_pos = control_dict["joint_position"][self.dof_idx]
+            finger_pos = control_dict["joint_position"][self.dof_idx.long()]
 
             # For joint position control, if the desired positions are the same as the current positions, is_grasping unknown
             if self._motor_type == "position" and th.mean(th.abs(finger_pos - self._control)) < m.POS_TOLERANCE:
@@ -240,9 +240,9 @@ class MultiFingerGripperController(GripperController):
 
             # Otherwise, the last control signal intends to "move" the gripper
             else:
-                finger_vel = control_dict["joint_velocity"][self.dof_idx]
-                min_pos = self._control_limits[ControlType.POSITION][0][self.dof_idx]
-                max_pos = self._control_limits[ControlType.POSITION][1][self.dof_idx]
+                finger_vel = control_dict["joint_velocity"][self.dof_idx.long()]
+                min_pos = self._control_limits[ControlType.POSITION][0][self.dof_idx.long()]
+                max_pos = self._control_limits[ControlType.POSITION][1][self.dof_idx.long()]
 
                 # Make sure we don't have any invalid values (i.e.: fingers should be within the limits)
                 finger_pos = th.clip(finger_pos, min_pos, max_pos)

--- a/omnigibson/examples/action_primitives/pick_place_example.py
+++ b/omnigibson/examples/action_primitives/pick_place_example.py
@@ -1,0 +1,173 @@
+from argparse import ArgumentParser
+from collections import Counter
+import os
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+import time
+import torch as th
+import yaml
+
+import omnigibson as og
+from omnigibson.action_primitives.pick_place_semantic_action_primitives import (
+    PickPlaceSemanticActionPrimitives)
+from omnigibson.utils.motion_planning_utils import detect_robot_collision_in_sim
+from omnigibson.utils.video_logging_utils import VideoLogger
+
+
+def custom_reset(env, robot, args, vid_logger):
+    proprio = robot._get_proprioception_dict()
+    # curr_right_arm_joints = th.tensor(proprio['arm_right_qpos'])
+    reset_right_arm_joints = th.tensor(
+        [0.85846, -0.44852, 1.81008, 1.63368, 0.43764, -1.32488, -0.68415])
+
+    noise_1 = np.random.uniform(-0.2, 0.2, 3)
+    noise_2 = np.random.uniform(-0.01, 0.01, 4)
+    noise = th.tensor(np.concatenate((noise_1, noise_2)))
+    right_hand_joints_pos = reset_right_arm_joints + noise
+    # right_hand_joints_pos = curr_right_arm_joints + noise
+
+    scene_initial_state = env.scene._initial_state
+    # for manipulation
+    base_pos = np.array([-0.05, -0.4, 0.0])
+    base_x_noise = np.random.uniform(-0.15, 0.15)
+    base_y_noise = np.random.uniform(-0.15, 0.15)
+    base_noise = np.array([base_x_noise, base_y_noise, 0.0])
+    base_pos += base_noise 
+    scene_initial_state['object_registry']['robot0']['root_link']['pos'] = base_pos
+    
+    base_yaw = -120
+    base_yaw_noise = np.random.uniform(-15, 15)
+    base_yaw += base_yaw_noise
+    r_euler = R.from_euler('z', base_yaw, degrees=True) # or -120
+    r_quat = R.as_quat(r_euler)
+    scene_initial_state['object_registry']['robot0']['root_link']['ori'] = r_quat
+
+    default_head_joints = th.tensor([-0.5031718015670776, -0.9972541332244873])
+    noise_1 = np.random.uniform(-0.1, 0.1, 1)
+    noise_2 = np.random.uniform(-0.1, 0.1, 1)
+    noise = th.tensor(np.concatenate((noise_1, noise_2)))
+    head_joints = default_head_joints + noise
+
+    # Reset environment and robot
+    obs, info = env.reset()
+    robot.reset(right_hand_joints_pos=right_hand_joints_pos, head_joints_pos=head_joints)
+
+    # Step simulator a few times so that the effects of "reset" take place
+    for _ in range(10):
+        og.sim.step()
+
+    obs, obs_info = env.get_obs()
+
+    proprio = robot._get_proprioception_dict()
+    # add eef pose and base pose to proprio
+    proprio['left_eef_pos'], proprio['left_eef_orn'] = robot.get_relative_eef_pose(arm='left')
+    proprio['right_eef_pos'], proprio['right_eef_orn'] = robot.get_relative_eef_pose(arm='right')
+    proprio['base_pos'], proprio['base_orn'] = robot.get_position_orientation()
+
+    is_contact = detect_robot_collision_in_sim(robot)
+
+
+def main(args):
+    np.random.seed(6)
+    # Load the config
+    config_filename = os.path.join(og.example_config_path, "tiago_primitives.yaml")
+    config = yaml.load(open(config_filename, "r"), Loader=yaml.FullLoader)
+
+    # Update it to create a custom environment and run some actions
+    config["scene"]["scene_model"] = "Rs_int"
+    config["scene"]["load_object_categories"] = ["floors", "ceilings", "walls", "coffee_table"]
+ 
+    config["objects"] = [
+        {
+            "type": "PrimitiveObject",
+            "name": "box",
+            "primitive_type": "Cube",
+            "manipulable": True,
+            # ^ Should the robot be allowed to interact w/ this object?
+            # Used if need to randomly select object in DialogEnvironment
+            "rgba": [1.0, 0, 0, 1.0],
+            "scale": [0.1, 0.05, 0.1],
+            # "size": 0.05,
+            "position": [-0.5, -0.7, 0.5],
+            "orientation": [
+                0.0004835024010390043,
+                -0.00029672126402147114,
+                -0.11094563454389572,
+                0.9938263297080994],
+        },
+        {
+            "type": "DatasetObject",
+            "name": "table",
+            "category": "breakfast_table",
+            "model": "rjgmmy",
+            "manipulable": False,
+            "scale": [0.3, 0.3, 0.3],
+            "position": [-0.7, 0.5, 0.2],
+            "orientation": [0, 0, 0, 1]
+        },
+        {
+            "type": "PrimitiveObject",
+            "name": "pad",
+            "primitive_type": "Disk",
+            "rgba": [0.0, 0, 1.0, 1.0],
+            "radius": 0.08,
+            "position": [-0.3, -0.8, 0.5],
+        },
+    ]
+
+    # Load the environment
+    env = og.Environment(configs=config)
+    scene = env.scene
+    robot = env.robots[0]
+
+    vid_logger = VideoLogger(args, env)
+    action_primitives = PickPlaceSemanticActionPrimitives(env, vid_logger, enable_head_tracking=False)
+
+    subtask_success_counter = Counter()
+    for i in range(args.num_trajs):
+        print(f"---------------- Episode {i} ------------------")
+        start_time = time.time()
+
+        custom_reset(env, robot, args, vid_logger)
+
+        obs, obs_info = env.get_obs()
+
+        for _ in range(50):
+            og.sim.step()
+            vid_logger.save_im_text()
+
+        pick_success = action_primitives._grasp("box")
+        place_success = action_primitives._place_on_top("box", "pad")
+
+        task_success = pick_success and place_success
+        num_subtasks_completed = [int(pick_success), int(place_success), 0].index(0)
+        vid_logger.make_video(prefix=f"rew{num_subtasks_completed}")
+        subtask_success_counter["entire"] += int(task_success)
+        subtask_success_counter["pick"] += int(pick_success)
+        subtask_success_counter["place"] += int(place_success)
+
+        print(f"num successes: {subtask_success_counter['entire']} / {i + 1}\n{subtask_success_counter}")
+
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        print(f"Episode {i}: execution time: {elapsed_time:.2f} seconds")
+
+
+if __name__ == "__main__":
+    """
+    Example usage:
+    python omnigibson/examples/action_primitives/pick_place_example.py --out-dir /home/albert/scratch/20240924 --num-trajs 1
+    """
+    start_time = time.time()
+    parser = ArgumentParser()
+    parser.add_argument("--out-dir", type=str, required=True)
+    parser.add_argument("--num-trajs", type=int, required=True)
+    parser.add_argument("--vid-downscale-factor", type=float, default=2.0)
+    parser.add_argument("--vid-speedup", type=float, default=2)
+    args = parser.parse_args()
+    main(args)
+    end_time = time.time()
+
+    elapsed_time = end_time - start_time
+    print(f"Total execution time: {elapsed_time:.2f} seconds")

--- a/omnigibson/examples/action_primitives/pick_place_example.py
+++ b/omnigibson/examples/action_primitives/pick_place_example.py
@@ -1,16 +1,15 @@
+import os
+import time
 from argparse import ArgumentParser
 from collections import Counter
-import os
 
 import numpy as np
-from scipy.spatial.transform import Rotation as R
-import time
 import torch as th
 import yaml
+from scipy.spatial.transform import Rotation as R
 
 import omnigibson as og
-from omnigibson.action_primitives.pick_place_semantic_action_primitives import (
-    PickPlaceSemanticActionPrimitives)
+from omnigibson.action_primitives.pick_place_semantic_action_primitives import PickPlaceSemanticActionPrimitives
 from omnigibson.utils.motion_planning_utils import detect_robot_collision_in_sim
 from omnigibson.utils.video_logging_utils import VideoLogger
 
@@ -18,8 +17,7 @@ from omnigibson.utils.video_logging_utils import VideoLogger
 def custom_reset(env, robot, args, vid_logger):
     proprio = robot._get_proprioception_dict()
     # curr_right_arm_joints = th.tensor(proprio['arm_right_qpos'])
-    reset_right_arm_joints = th.tensor(
-        [0.85846, -0.44852, 1.81008, 1.63368, 0.43764, -1.32488, -0.68415])
+    reset_right_arm_joints = th.tensor([0.85846, -0.44852, 1.81008, 1.63368, 0.43764, -1.32488, -0.68415])
 
     noise_1 = np.random.uniform(-0.2, 0.2, 3)
     noise_2 = np.random.uniform(-0.01, 0.01, 4)
@@ -33,15 +31,15 @@ def custom_reset(env, robot, args, vid_logger):
     base_x_noise = np.random.uniform(-0.15, 0.15)
     base_y_noise = np.random.uniform(-0.15, 0.15)
     base_noise = np.array([base_x_noise, base_y_noise, 0.0])
-    base_pos += base_noise 
-    scene_initial_state['object_registry']['robot0']['root_link']['pos'] = base_pos
-    
+    base_pos += base_noise
+    scene_initial_state["object_registry"]["robot0"]["root_link"]["pos"] = base_pos
+
     base_yaw = -120
     base_yaw_noise = np.random.uniform(-15, 15)
     base_yaw += base_yaw_noise
-    r_euler = R.from_euler('z', base_yaw, degrees=True) # or -120
+    r_euler = R.from_euler("z", base_yaw, degrees=True)  # or -120
     r_quat = R.as_quat(r_euler)
-    scene_initial_state['object_registry']['robot0']['root_link']['ori'] = r_quat
+    scene_initial_state["object_registry"]["robot0"]["root_link"]["ori"] = r_quat
 
     default_head_joints = th.tensor([-0.5031718015670776, -0.9972541332244873])
     noise_1 = np.random.uniform(-0.1, 0.1, 1)
@@ -61,9 +59,9 @@ def custom_reset(env, robot, args, vid_logger):
 
     proprio = robot._get_proprioception_dict()
     # add eef pose and base pose to proprio
-    proprio['left_eef_pos'], proprio['left_eef_orn'] = robot.get_relative_eef_pose(arm='left')
-    proprio['right_eef_pos'], proprio['right_eef_orn'] = robot.get_relative_eef_pose(arm='right')
-    proprio['base_pos'], proprio['base_orn'] = robot.get_position_orientation()
+    proprio["left_eef_pos"], proprio["left_eef_orn"] = robot.get_relative_eef_pose(arm="left")
+    proprio["right_eef_pos"], proprio["right_eef_orn"] = robot.get_relative_eef_pose(arm="right")
+    proprio["base_pos"], proprio["base_orn"] = robot.get_position_orientation()
 
     is_contact = detect_robot_collision_in_sim(robot)
 
@@ -77,7 +75,7 @@ def main(args):
     # Update it to create a custom environment and run some actions
     config["scene"]["scene_model"] = "Rs_int"
     config["scene"]["load_object_categories"] = ["floors", "ceilings", "walls", "coffee_table"]
- 
+
     config["objects"] = [
         {
             "type": "PrimitiveObject",
@@ -90,11 +88,7 @@ def main(args):
             "scale": [0.1, 0.05, 0.1],
             # "size": 0.05,
             "position": [-0.5, -0.7, 0.5],
-            "orientation": [
-                0.0004835024010390043,
-                -0.00029672126402147114,
-                -0.11094563454389572,
-                0.9938263297080994],
+            "orientation": [0.0004835024010390043, -0.00029672126402147114, -0.11094563454389572, 0.9938263297080994],
         },
         {
             "type": "DatasetObject",
@@ -104,7 +98,7 @@ def main(args):
             "manipulable": False,
             "scale": [0.3, 0.3, 0.3],
             "position": [-0.7, 0.5, 0.2],
-            "orientation": [0, 0, 0, 1]
+            "orientation": [0, 0, 0, 1],
         },
         {
             "type": "PrimitiveObject",

--- a/omnigibson/objects/controllable_object.py
+++ b/omnigibson/objects/controllable_object.py
@@ -436,7 +436,7 @@ class ControllableObject(BaseObject):
         # By default, the control type is None and the control value is 0 (th.zeros) - i.e. no control applied
         u_type_vec = th.tensor([ControlType.NONE] * self.n_dof)
         for group, ctrl in control.items():
-            idx = self._controllers[group].dof_idx
+            idx = self._controllers[group].dof_idx.long()
             u_vec[idx] = ctrl["value"]
             u_type_vec[idx] = ctrl["type"]
 

--- a/omnigibson/prims/entity_prim.py
+++ b/omnigibson/prims/entity_prim.py
@@ -1018,7 +1018,7 @@ class EntityPrim(XFormPrim):
             frame (Literal): The frame in which to set the position and orientation. Defaults to world.
                 scene frame sets position relative to the scene.
         """
-        assert frame in ["world", "scene"], f"Invalid frame '{frame}'. Must be 'world', or 'scene'."
+        assert frame in ["world", "scene", "parent"], f"Invalid frame '{frame}'. Must be 'world', 'scene', or 'parent'"
 
         # If kinematic only, clear cache for the root link
         if self.kinematic_only:

--- a/omnigibson/prims/xform_prim.py
+++ b/omnigibson/prims/xform_prim.py
@@ -344,7 +344,7 @@ class XFormPrim(BasePrim):
         logger.warning(
             'get_local_pose is deprecated and will be removed in a future release. Use get_position_orientation(frame="parent") instead'
         )
-        return self.get_position_orientation(self.prim_path, frame="parent")
+        return self.get_position_orientation(frame="parent")
 
     def set_local_pose(self, position=None, orientation=None):
         """
@@ -359,7 +359,7 @@ class XFormPrim(BasePrim):
         logger.warning(
             'set_local_pose is deprecated and will be removed in a future release. Use set_position_orientation(position=position, orientation=orientation, frame="parent") instead'
         )
-        return self.set_position_orientation(self.prim_path, position, orientation, frame="parent")
+        return self.set_position_orientation(position, orientation, frame="parent")
 
     def get_world_scale(self):
         """

--- a/omnigibson/robots/manipulation_robot.py
+++ b/omnigibson/robots/manipulation_robot.py
@@ -1306,7 +1306,7 @@ class ManipulationRobot(BaseRobot):
             # stays the same across different controllers and control modes (absolute / delta). This way,
             # a zero action will actually keep the AG setting where it already is.
             controller = self._controllers[f"gripper_{arm}"]
-            controlled_joints = controller.dof_idx
+            controlled_joints = controller.dof_idx.long()
             threshold = th.mean(
                 th.stack([self.joint_lower_limits[controlled_joints], self.joint_upper_limits[controlled_joints]]),
                 dim=0,

--- a/omnigibson/robots/tiago.py
+++ b/omnigibson/robots/tiago.py
@@ -227,7 +227,7 @@ class Tiago(HolonomicBaseRobot, ArticulatedTrunkRobot, UntuckedArmPoseRobot, Act
 
         # reset the hand joints to a specific position
         if right_hand_joints_pos is not None:
-            self.set_joint_positions(right_hand_joints_pos, indices=self.arm_control_idx['right'])
+            self.set_joint_positions(right_hand_joints_pos, indices=self.arm_control_idx["right"])
 
     def _post_load(self):
         super()._post_load()
@@ -242,7 +242,6 @@ class Tiago(HolonomicBaseRobot, ArticulatedTrunkRobot, UntuckedArmPoseRobot, Act
     @property
     def base_footprint_link_name(self):
         return "base_footprint"
-
 
     def _get_proprioception_dict(self):
         dic = super()._get_proprioception_dict()

--- a/omnigibson/utils/deprecated_utils.py
+++ b/omnigibson/utils/deprecated_utils.py
@@ -529,9 +529,10 @@ class ArticulationView(_ArticulationView):
             carb.log_warn("ArticulationView needs to be initialized.")
             return
         if not omni.timeline.get_timeline_interface().is_stopped() and self._physics_view is not None:
+            positions = positions.float()
             indices = self._backend_utils.resolve_indices(indices, self.count, self._device)
             joint_indices = self._backend_utils.resolve_indices(joint_indices, self.num_dof, self._device)
-            new_dof_pos = self._physics_view.get_dof_positions()
+            new_dof_pos = self._physics_view.get_dof_positions().float()
             new_dof_pos = self._backend_utils.assign(
                 self._backend_utils.move_data(positions, device=self._device),
                 new_dof_pos,

--- a/omnigibson/utils/motion_planning_utils.py
+++ b/omnigibson/utils/motion_planning_utils.py
@@ -106,6 +106,7 @@ def plan_base_motion(
             segment = []
             segment.append(p2[0] - p1[0])
             segment.append(p2[1] - p1[1])
+            segment = th.tensor(segment)
             return th.arctan2(segment[1], segment[0])
 
     def create_state(space, x, y, yaw):
@@ -122,7 +123,7 @@ def plan_base_motion(
         x = q.getX()
         y = q.getY()
         yaw = q.getYaw()
-        pose = ([x, y, 0.0], T.euler2quat((0, 0, yaw)))
+        pose = ([x, y, 0.0], T.euler2quat(th.tensor([0, 0, yaw])))
         return not set_base_and_detect_collision(context, pose)
 
     def remove_unnecessary_rotations(path):
@@ -364,7 +365,7 @@ def plan_arm_motion_ik(
         eef_pose = [q[i] for i in range(6)]
         control_joint_pos = ik_solver.solve(
             target_pos=eef_pose[:3],
-            target_quat=T.axisangle2quat(eef_pose[3:]),
+            target_quat=T.axisangle2quat(th.tensor(eef_pose[3:])),
             max_iterations=1000,
         )
 
@@ -479,6 +480,7 @@ def set_arm_and_detect_collision(context, joint_pos):
         if link in robot_copy.meshes[robot_copy_type].keys():
             for mesh_name, mesh in robot_copy.meshes[robot_copy_type][link].items():
                 relative_pose = robot_copy.relative_poses[robot_copy_type][link][mesh_name]
+                pose = [th.tensor(arr) for arr in pose]
                 mesh_pose = T.pose_transform(*pose, *relative_pose)
                 translation = lazy.pxr.Gf.Vec3d(*th.tensor(mesh_pose[0], dtype=th.float32).tolist())
                 mesh.GetAttribute("xformOp:translate").Set(translation)

--- a/omnigibson/utils/video_logging_utils.py
+++ b/omnigibson/utils/video_logging_utils.py
@@ -1,0 +1,205 @@
+import datetime
+import os
+
+import cv2
+from matplotlib import font_manager
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+import torch as th
+
+import omnigibson as og
+
+class VideoLogger:
+    def __init__(self, args, env=None):
+        self.vid_downscale_factor = args.vid_downscale_factor
+        assert isinstance(args.vid_speedup, int)
+        self.vid_speedup = args.vid_speedup
+        self.env = env
+        # ^ only needed if using save_im_text(...) instead of save_obs(...)
+        now = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        self.out_dir = os.path.join(args.out_dir, now)
+        os.makedirs(self.out_dir, exist_ok=False)
+        self.clear_ims()
+
+        # Text settings
+        self.text_font_size = 36
+        self.line_spacing = 1.2
+        self.num_frames_to_show_text = 45 * args.vid_speedup # num frames to keep text on for the video
+        self.text_to_num_frames_remaining_map = {}
+        font = font_manager.FontProperties(family='Ubuntu', style="italic")
+        italics = ImageFont.truetype(font_manager.findfont(font), self.text_font_size)
+        font = font_manager.FontProperties(family='Ubuntu')
+        non_italics = ImageFont.truetype(font_manager.findfont(font), self.text_font_size)
+        self.fonts = dict(
+            italics=italics,
+            non_italics=non_italics,
+        )
+        self.text_align = "top-left"
+
+    def save_im_text(self, text=""):
+        im = og.sim.viewer_camera._get_obs()[0]['rgb'][:, :, :3]
+        obs, obs_info = self.env.get_obs()
+        im_robot_view = obs['robot0']['robot0:eyes:Camera:0']['rgb'][:, :, :3]
+        self.save_obs(im, im_robot_view, text)
+
+
+    def save_obs(self, im_arr, im_arr_robot_view, text=""):
+        def resize_im_arr(im_arr, downscale_factor=1):
+            # assumes im_arr is (H, W, 3)
+            im_arr = cv2.resize(
+                im_arr,
+                tuple([
+                    int(x)
+                    for x in (
+                        np.array(im_arr.shape[:2][::-1])
+                        // downscale_factor)]))
+            return im_arr
+
+        if th.is_tensor(im_arr):
+            im_arr = im_arr.cpu().numpy()
+        if th.is_tensor(im_arr_robot_view):
+            im_arr_robot_view = im_arr_robot_view.cpu().numpy()
+
+        im_arr = resize_im_arr(
+            im_arr, self.vid_downscale_factor)
+        im_arr_robot_view = resize_im_arr(im_arr_robot_view)
+        im_arr_w_robot_view = self.overlay_robot_view_on_imgs(im_arr, im_arr_robot_view)
+        im_arr_w_robot_view = self.maybe_add_text(im_arr_w_robot_view, text)
+        self.ims.append(im_arr)
+        self.robot_view_ims.append(im_arr_robot_view)
+        self.ims_w_robot_view.append(im_arr_w_robot_view)
+
+    def save_obs_batch(self, im_arr_list, im_arr_robot_view):
+        assert len(im_arr_list) == len(im_arr_robot_view)
+        for im_arr, im_arr_robot_view in zip(im_arr_list, im_arr_robot_view):
+            self.save_obs(im_arr, im_arr_robot_view)
+
+    def get_textbox_size(self, text, font):
+        # Get image text size on dummy image
+        im_dummy = Image.new(mode="P", size=(0, 0))
+        draw_dummy = ImageDraw.Draw(im_dummy)
+        _, _, text_w, text_h = draw_dummy.textbbox(
+            (0, 0), text=text, font=self.fonts['italics'])
+        return text_w, text_h
+
+    def maybe_add_text(self, im_arr, new_text=""):
+        if new_text:
+            self.text_to_num_frames_remaining_map[new_text] = (
+                self.num_frames_to_show_text)
+
+        im = Image.fromarray(im_arr)
+        im_w, im_h = im.size
+        draw = ImageDraw.Draw(im)
+
+        # Draw speedup
+        speedup_text = f"{self.vid_speedup}x"
+        text_w, text_h = self.get_textbox_size(speedup_text, self.fonts['non_italics'])
+        draw.text(
+            (0.98 * (im_w - text_w), 0.98 * (im_h - text_h)),
+            speedup_text, font=self.fonts['non_italics'], fill="white")
+
+        # Refresh counters at the end
+        keys_to_remove = []
+        num_active_texts = len([
+            (text, num_frames_left)
+            for text, num_frames_left in self.text_to_num_frames_remaining_map.items()
+            if num_frames_left > 0])
+
+        texts_to_draw = []
+        active_text_idx = 0
+        for text, num_frames_left in (
+                self.text_to_num_frames_remaining_map.items()):
+
+            # No longer an active word; was placed on enough frames already.
+            if num_frames_left <= 0:
+                keys_to_remove.append(text)
+                continue
+
+            # Center the text
+            # Get image text size on dummy image
+            text_w, text_h = self.get_textbox_size(text, self.fonts['italics'])
+            if self.text_align == "center":
+                x = 0.5 * (im_w - text_w)
+                y = 0.5 * (im_h - (
+                    num_active_texts - active_text_idx) * self.line_spacing * text_h)
+            elif self.text_align == "top-left":
+                x = 0.05 * im_w
+                y = 0.05 * im_h + active_text_idx * self.line_spacing * text_h
+            else:
+                raise NotImplementedError
+
+            color = (
+                (0xf4, 0xe5, 0xbb) if "robot" in text.lower()
+                else (0xbb, 0xca, 0xf4))
+            # draw.text((x, y), text, font=self.fonts['italics'], fill=color)
+            texts_to_draw.append((text, (x, y), (text_w, text_h), self.fonts['italics'], color))
+
+            active_text_idx += 1
+            self.text_to_num_frames_remaining_map[text] -= 1
+
+        if len(texts_to_draw) > 0:
+            # Draw translucent box behind text
+            draw = ImageDraw.Draw(im, "RGBA")
+            pad = 0.2 * self.text_font_size
+
+            top_text_xy_pos = texts_to_draw[0][1]
+            bottom_text_xy_pos = texts_to_draw[-1][1]
+            largest_width_text_pos_box_size = max(
+                [(pos, box_size) for _, pos, box_size, _, _ in texts_to_draw],
+                key=lambda pos_size: pos_size[1][0])
+            largest_width_text_xy_pos, largest_width_text_xy_size = largest_width_text_pos_box_size
+
+            bottom_text_xy_size = texts_to_draw[-1][2]
+            min_x, min_y = np.array([largest_width_text_xy_pos[0], top_text_xy_pos[1]]) - pad
+            max_x = largest_width_text_xy_pos[0] + largest_width_text_xy_size[0] + pad
+            max_y = bottom_text_xy_pos[1] + bottom_text_xy_size[1] + pad
+            draw.rectangle(((min_x, min_y), (max_x, max_y)), fill=(0, 0, 0, 64))
+
+            # Actually draw the text over the box
+            for text, pos, _, font, color in texts_to_draw:
+                draw.text(pos, text, font=font, fill=color)
+
+        for key in keys_to_remove:
+            self.text_to_num_frames_remaining_map.pop(key)
+
+        return np.asarray(im)
+
+    def overlay_robot_view_on_imgs(self, im, robot_view_im):
+        assert im.shape[:2] > robot_view_im.shape[:2]
+        im_w_robot_view = np.copy(im)
+        h, w = robot_view_im.shape[:2]
+        # Make patch in upper right
+        im_w_robot_view[:h, -w:, :] = robot_view_im
+        return im_w_robot_view
+
+    def clear_ims(self):
+        self.ims = []
+        self.robot_view_ims = []
+        self.ims_w_robot_view = []
+
+
+    def make_video(self, prefix):
+        imgs = np.array(self.ims_w_robot_view)
+        self.save_video(imgs, prefix)
+        self.clear_ims()
+
+    def save_video(self, imgs, prefix):
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        frame_height, frame_width = imgs[0].shape[:2]
+        now = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        out_dir = os.path.join(self.out_dir, prefix)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        out_path = os.path.join(out_dir, f"{prefix}_{now}.mp4")
+        out = cv2.VideoWriter(
+            out_path,
+            fourcc, 30.0, (frame_width, frame_height))
+        for i, frame in enumerate(imgs):
+            if i % self.vid_speedup != 0:
+                # Drop the frames to cause speedup.
+                continue
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+            out.write(frame)
+        out.release()
+        cv2.destroyAllWindows()
+        print(f"saved video to {out_path}")

--- a/omnigibson/utils/vision_utils.py
+++ b/omnigibson/utils/vision_utils.py
@@ -129,7 +129,7 @@ class Remapper:
                 self.key_array[key] = new_key
 
         # Apply remapping
-        remapped_img = self.key_array[image]
+        remapped_img = self.key_array[image.long()]
         # Make sure all values are correctly remapped and not equal to the default value
         assert th.all(remapped_img != th.iinfo(th.int32).max), "Not all keys in the image are in the key array!"
         remapped_labels = {}


### PR DESCRIPTION
Made this standalone pick-and-place example script since `rs_int_example.py` on `og-develop` (at least, as it was a couple weeks ago) wasn't easy to debug for me. Some of the code (such as env configs, reset functions) is based on @Arpitrf's OG fork.

- Gets ~90% scripted accuracy on stationary pick-and-place.
- Includes utilities for logging videos for each episode.
- This PR includes the changes from PR #903 which I'd recommend merging first before merging this one.

You can test this script by running:
```
python omnigibson/examples/action_primitives/pick_place_example.py --out-dir [.../video-out-dir] --num-trajs 1
```