### PR TITLE
Optionally keep skipped objects still during load state

### DIFF
--- a/OmniGibson/omnigibson/envs/data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/data_wrapper.py
@@ -11,7 +11,7 @@ import torch as th
 import omnigibson as og
 import omnigibson.lazy as lazy
 from omnigibson.envs.env_wrapper import EnvironmentWrapper, create_wrapper
-from omnigibson.macros import gm
+from omnigibson.macros import gm, macros
 from omnigibson.objects.object_base import BaseObject
 from omnigibson.sensors.vision_sensor import VisionSensor
 from omnigibson.utils.config_utils import TorchEncoder
@@ -830,6 +830,12 @@ class DataPlaybackWrapper(DataWrapper):
         """
         # Make sure transition rules are DISABLED for playback since we manually propagate transitions
         assert not gm.ENABLE_TRANSITION_RULES, "Transition rules must be disabled for DataPlaybackWrapper env!"
+        
+        # Stabilize skipped objects
+        # we can do this here because we know that whatever's skipped during load state must have been asleep during data collection
+        # which means they're not moving and we can safely keep them still
+        with macros.unlocked():
+            macros.utils.registry_utils.STABILIZE_SKIPPED_OBJECTS = True
 
         # Store scene file so we can restore the data upon each episode reset
         self.input_hdf5 = h5py.File(input_path, "r")

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -492,7 +492,7 @@ def _launch_simulator(*args, **kwargs):
             lazy.carb.settings.get_settings().set_bool("/rtx/ambientOcclusion/enabled", True)
             lazy.carb.settings.get_settings().set_bool("/rtx/directLighting/sampledLighting/enabled", True)
             lazy.carb.settings.get_settings().set_int("/rtx/raytracing/showLights", 1)
-            lazy.carb.settings.get_settings().set_float("/rtx/sceneDb/ambientLightIntensity", 0.1)
+            lazy.carb.settings.get_settings().set_float("/rtx/sceneDb/ambientLightIntensity", 1.0)
             lazy.carb.settings.get_settings().set_bool("/app/renderer/skipMaterialLoading", False)
             lazy.carb.settings.get_settings().set_bool("/rtx/flow/enabled", True)
 

--- a/OmniGibson/omnigibson/utils/registry_utils.py
+++ b/OmniGibson/omnigibson/utils/registry_utils.py
@@ -10,6 +10,7 @@ import torch as th
 from omnigibson.macros import create_module_macros
 from omnigibson.utils.python_utils import Serializable, SerializableNonInstance, get_uuid
 from omnigibson.utils.ui_utils import create_module_logger
+from omnigibson.objects.object_base import BaseObject
 
 # Create module logger
 log = create_module_logger(module_name=__name__)
@@ -19,6 +20,8 @@ m = create_module_macros(module_path=__file__)
 
 # Token identifier for default values if a key doesn't exist in a given object
 m.DOES_NOT_EXIST = "DOES_NOT_EXIST"
+
+m.STABILIZE_SKIPPED_OBJECTS = False
 
 
 class Registry:
@@ -437,6 +440,8 @@ class SerializableRegistry(Registry, Serializable):
             if self._load_filter(obj):
                 if obj.name not in state:
                     log.debug(f"Object '{obj.name}' is not in the state dict to load from. Skip loading its state.")
+                    if m.STABILIZE_SKIPPED_OBJECTS and isinstance(obj, BaseObject) and not obj.kinematic_only:
+                        obj.keep_still()
                     continue
                 obj.load_state(state[obj.name], serialized=False)
 


### PR DESCRIPTION
- Add macro to keep skipped objects still during object registry load state (for data playback)
- Make environment light brighter 0.1 -> 1.0