### PR TITLE
Small Misc. Fixes

### DIFF
--- a/OmniGibson/omnigibson/robots/franka.py
+++ b/OmniGibson/omnigibson/robots/franka.py
@@ -314,7 +314,7 @@ class FrankaPanda(ManipulationRobot):
 
     @property
     def _assisted_grasp_end_points(self):
-        return {self.default_arm: self._ag_start_points}
+        return {self.default_arm: self._ag_end_points}
 
     @property
     def disabled_collision_pairs(self):

--- a/OmniGibson/omnigibson/robots/franka_mounted.py
+++ b/OmniGibson/omnigibson/robots/franka_mounted.py
@@ -32,3 +32,11 @@ class FrankaMounted(FrankaPanda):
         return os.path.join(
             gm.ASSET_PATH, "models/franka/franka_mounted/curobo/franka_mounted_description_curobo_default.yaml"
         )
+
+    @property
+    def _assisted_grasp_start_points(self):
+        return None        # automatically inferred with this gripper
+
+    @property
+    def _assisted_grasp_end_points(self):
+        return None        # automatically inferred with this gripper

--- a/OmniGibson/omnigibson/robots/manipulation_robot.py
+++ b/OmniGibson/omnigibson/robots/manipulation_robot.py
@@ -1228,7 +1228,7 @@ class ManipulationRobot(BaseRobot):
         )
         # Stack the start points and repeat the end points, and add these values to the raycast dicts
         raycast_startpoints = th.tile(start_and_end_points[:n_start_points], (n_end_points, 1))
-        raycast_endpoints = th.repeat_interleave(start_and_end_points[n_start_points:], n_start_points, dim=0)
+        raycast_endpoints = th.repeat_interleave(start_and_end_points[n_start_points:], n_start_points, dim=0) + 1e-8
         ray_data = set()
         # Calculate raycasts from each start point to end point -- this is n_startpoints * n_endpoints total rays
         for result in raytest_batch(raycast_startpoints, raycast_endpoints, only_closest=True):

--- a/OmniGibson/omnigibson/utils/coacd_runner.py
+++ b/OmniGibson/omnigibson/utils/coacd_runner.py
@@ -10,7 +10,12 @@ try:
     with open(sys.argv[1], "rb") as f:
         vertices, faces, hull_count = pickle.load(f)
     mesh = coacd.Mesh(vertices, faces)
-    result = coacd.run_coacd(mesh, max_convex_hull=hull_count, max_ch_vertex=60)
+    result = coacd.run_coacd(
+        mesh,
+        max_convex_hull=hull_count,
+        decimate=True,
+        max_ch_vertex=60,
+    )
     with open(sys.argv[2], "wb") as f:
         pickle.dump(result, f)
     sys.exit(0)


### PR DESCRIPTION
Random fixes observed:

- CoACD: Set `decimate=True` to enforce that our `max_ch_vertices` arg is respected. See official [CoACD README docs](https://github.com/SarahWeiii/CoACD?tab=readme-ov-file#parameters) about their args
- `franka.py` / `franka_mounted.py`: Update typo in ag_start_/end_point property causing raycast errors, update franka mounted to use default (auto-generated) ag points instead of hardcoded franka ones since the gripper morphology is different
- `manipulation_robot.py`: Make gripper raycast checking numerically stable by adding small epsilon to raycast end points to avoid start / end point overlap 