### PR TITLE
Visual-only macro for data replay

### DIFF
--- a/OmniGibson/omnigibson/envs/data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/data_wrapper.py
@@ -738,8 +738,8 @@ class DataPlaybackWrapper(DataWrapper):
             config["env"]["action_frequency"] = 30.0
             config["env"]["rendering_frequency"] = 30.0
             config["env"]["physics_frequency"] = 120.0
-            # Disable gravity
-            gm.GRAVITY = 0.0
+            # Simulator-level visual-only set to True
+            gm.VISUAL_ONLY = True
 
         # Make sure obs space is flattened for recording
         config["env"]["flatten_obs_space"] = True
@@ -781,11 +781,6 @@ class DataPlaybackWrapper(DataWrapper):
 
         # Load env
         env = og.Environment(configs=config)
-
-        if not include_contacts:
-            with og.sim.stopped():
-                for obj in env.scene.objects:
-                    obj.visual_only = True
 
         # Optionally include the desired environment wrapper specified in the config
         if include_env_wrapper:
@@ -985,8 +980,6 @@ class DataPlaybackWrapper(DataWrapper):
                     obj = create_object_from_init_info(add_obj_info)
                     scene.add_object(obj)
                     obj.set_position(th.ones(3) * 100.0 + th.ones(3) * 5 * j)
-                    if not self.include_contacts:
-                        obj.visual_only = True
                 # Step physics to initialize any new objects
                 og.sim.step()
 
@@ -994,7 +987,7 @@ class DataPlaybackWrapper(DataWrapper):
             # properly propagated after the sim state update
             og.sim.load_state(s[: int(ss)], serialized=True)
             if not self.include_contacts:
-                # When all objects are visual-only, keep them still on every step
+                # When all objects/systems are visual-only, keep them still on every step
                 for obj in self.scene.objects:
                     obj.keep_still()
                 for system in self.scene.systems:

--- a/OmniGibson/omnigibson/macros.py
+++ b/OmniGibson/omnigibson/macros.py
@@ -222,8 +222,8 @@ gm.FORCE_ROUGHNESS = 0.7
 # mass from the category-level density and the volume of the object.
 gm.FORCE_CATEGORY_MASS = True
 
-# Gavity on z direction
-gm.GRAVITY = 9.81
+# Disable collision and gravity for the simulator, should default to False
+gm.VISUAL_ONLY = False
 
 
 # Create helper function for generating sub-dictionaries

--- a/OmniGibson/omnigibson/macros.py
+++ b/OmniGibson/omnigibson/macros.py
@@ -222,6 +222,9 @@ gm.FORCE_ROUGHNESS = 0.7
 # mass from the category-level density and the volume of the object.
 gm.FORCE_CATEGORY_MASS = True
 
+# Gavity on z direction
+gm.GRAVITY = 9.81
+
 
 # Create helper function for generating sub-dictionaries
 def create_module_macros(module_path):

--- a/OmniGibson/omnigibson/prims/entity_prim.py
+++ b/OmniGibson/omnigibson/prims/entity_prim.py
@@ -136,7 +136,7 @@ class EntityPrim(XFormPrim):
             self._load_config["visual_only"]
             if "visual_only" in self._load_config and self._load_config["visual_only"] is not None
             else False
-        )
+        ) or gm.VISUAL_ONLY
 
         if self._prim_type == PrimType.CLOTH:
             assert not self._visual_only, "Cloth cannot be visual-only."

--- a/OmniGibson/omnigibson/prims/geom_prim.py
+++ b/OmniGibson/omnigibson/prims/geom_prim.py
@@ -345,6 +345,8 @@ class CollisionGeomPrim(GeomPrim):
             # Set the approximation to be convex hull by default
             self.set_collision_approximation(approximation_type="convexHull")
 
+        self.collision_enabled = not gm.VISUAL_ONLY
+
     @property
     def collision_enabled(self):
         """

--- a/OmniGibson/omnigibson/prims/rigid_prim.py
+++ b/OmniGibson/omnigibson/prims/rigid_prim.py
@@ -6,6 +6,7 @@ import torch as th
 from scipy.spatial import ConvexHull
 
 import omnigibson as og
+from omnigibson.macros import gm
 import omnigibson.lazy as lazy
 import omnigibson.utils.transform_utils as T
 from omnigibson.macros import create_module_macros
@@ -125,7 +126,7 @@ class RigidPrim(XFormPrim):
 
         # Set the visual-only attribute
         # This automatically handles setting collisions / gravity appropriately
-        self.visual_only = self._visual_only
+        self.visual_only = self._visual_only or gm.VISUAL_ONLY
 
     def _initialize(self):
         # Run super method first

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -281,7 +281,7 @@ def _launch_simulator(*args, **kwargs):
 
         def __init__(
             self,
-            gravity=gm.GRAVITY,
+            gravity=9.81 if not gm.VISUAL_ONLY else 0.0,
             physics_dt=None,
             rendering_dt=None,
             sim_step_dt=None,

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -281,7 +281,7 @@ def _launch_simulator(*args, **kwargs):
 
         def __init__(
             self,
-            gravity=9.81,
+            gravity=gm.GRAVITY,
             physics_dt=None,
             rendering_dt=None,
             sim_step_dt=None,


### PR DESCRIPTION
TODO:

- [x] how do we make particle systems visual-only?
  - [x] Gravity: set gravity to 0.0 during visual-only replay
  - [x] Collision: for MacroPhysicalParticleSystem, we can disable collision via CollisionVisualGeomPrim, but how do we keep setting all new particles?