### PR TITLE
Add storage requirements to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ BEHAVIOR-1K provides an installation script that handles all dependencies and co
 - **RAM**: 32GB+ recommended
 - **VRAM**: 8GB+
 - **GPU**: NVIDIA RTX 2080+
+- **DISK:** 100GB+ free space
 
 ## Quick Start
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -8,6 +8,7 @@ Please make sure your system meets the following specs:
 - [x] **RAM:** 32GB+
 - [x] **GPU:** NVIDIA RTX 2070+
 - [x] **VRAM:** 8GB+
+- [x] **DISK:** 100GB+ free space
 
 ??? question "Why these specs?"
     


### PR DESCRIPTION
I ran out of disk space running the installation steps on a fresh VM with 100GB. Got out of disk error. After installation the final size required is about 70GB, but during the process it requires more.