### PR TITLE
Fixed right gripper range

### DIFF
--- a/OmniGibson/omnigibson/learning/utils/eval_utils.py
+++ b/OmniGibson/omnigibson/learning/utils/eval_utils.py
@@ -166,7 +166,7 @@ JOINT_RANGE = {
             th.tensor([-4.4506, -3.1416, -2.3562, -2.0944, -2.3562, -1.0472, -1.5708], dtype=th.float32),
             th.tensor([1.3090, 0.1745, 2.3562, 0.3491, 2.3562, 1.0472, 1.5708], dtype=th.float32),
         ),
-        "right_gripper": (th.tensor([0.00], dtype=th.float32), th.tensor([0.05], dtype=th.float32)),
+        "right_gripper": (th.tensor([-1], dtype=th.float32), th.tensor([1], dtype=th.float32)),
     },
 }
 


### PR DESCRIPTION
It is a tiny fix.

For some reason, the left gripper has a range from -1 to +1:
https://github.com/StanfordVL/BEHAVIOR-1K/blob/12b0aeeeb755e39aee820a365da01673ec34f739/OmniGibson/omnigibson/learning/utils/eval_utils.py#L164

But the right gripper is from 0 to 0.05:
https://github.com/StanfordVL/BEHAVIOR-1K/blob/12b0aeeeb755e39aee820a365da01673ec34f739/OmniGibson/omnigibson/learning/utils/eval_utils.py#L169

I think the correct one is -1 to 1 for both, based on the range of actions in the training data.

The PR is just this simple fix that makes it -1 to 1 for the right gripper.