### PR TITLE
[WIP] Refactor Conjunction and Disjunction for lazy evaluation

### DIFF
--- a/bddl/bddl/condition_evaluation.py
+++ b/bddl/bddl/condition_evaluation.py
@@ -32,15 +32,22 @@ class Conjunction(Expression):
         if generate_ground_options:
             self.get_ground_options()
 
+    # def evaluate(self):
+    #     self.child_values = [child.evaluate() for child in self.children]
+    #     assert all([val is not None for val in self.child_values]), "child_values has NoneTypes"
+    #     return all(self.child_values)
+
     def evaluate(self):
-        self.child_values = [child.evaluate() for child in self.children]
-        assert all([val is not None for val in self.child_values]), "child_values has NoneTypes"
-        return all(self.child_values)
+        # instead of storing child values, just return the and of all children
+        return all(child.evaluate() for child in self.children)
 
     def get_ground_options(self):
-        options = list(itertools.product(*[child.flattened_condition_options for child in self.children]))
+        # options = list(itertools.product(*[child.flattened_condition_options for child in self.children]))
         self.flattened_condition_options = []
-        for option in options:
+        # just taking the cartesian product of all child options
+        # could be very large, but not sure how else to do it
+        # could subsample if it gets too large
+        for option in itertools.product(*[child.flattened_condition_options for child in self.children]):
             self.flattened_condition_options.append(list(itertools.chain(*option)))
 
 
@@ -65,10 +72,14 @@ class Disjunction(Expression):
         if generate_ground_options:
             self.get_ground_options()
 
+    # def evaluate(self):
+    #     self.child_values = [child.evaluate() for child in self.children]
+    #     assert all([val is not None for val in self.child_values]), "child_values has NoneTypes"
+    #     return any(self.child_values)
+
     def evaluate(self):
-        self.child_values = [child.evaluate() for child in self.children]
-        assert all([val is not None for val in self.child_values]), "child_values has NoneTypes"
-        return any(self.child_values)
+        # instead of storing child values, just return the or of all children
+        return any(child.evaluate() for child in self.children)
 
     def get_ground_options(self):
         self.flattened_condition_options = []


### PR DESCRIPTION
Fixes #1845 

## Hello this is a **Draft Pull Request** to get some early feedback on my approach on the issue #1845.
My goal is to refactor the eager evaluation patterns into lazy ones using generators.

### Changes
I have started by refactoring the `Conjunction` and `Disjunction` classes.
- **`evaluate()` method**: Removed `List` library in `Conjunction.evaluate()` and `Disjunction.evaluate()`. This allow `all()` and `any()` to utilize short-circuit evaluation, improving performance.
- **`Conjunction.get_ground_options()`**: Refactored to iterate directly over `itertools.product` instead of creating a large list in memory.

### Question
In the original `evaluate()` method, there was an `assert` statement to check for `None` values.
`assert all([val is not None for val in self.child_values])`
My current refactoring removes this explicit check for simplicity.
If this `assert` check is important, I can implement a helper function to accommodate this feature

What are your thoughts on this approach? Please let me know your preference.