### PR TITLE
Fix colorize_bbox_3d to return correct shape

### DIFF
--- a/OmniGibson/omnigibson/utils/vision_utils.py
+++ b/OmniGibson/omnigibson/utils/vision_utils.py
@@ -261,7 +261,7 @@ def colorize_bboxes_3d(bbox_3d_data, rgb_image, camera_params):
         view_mat = camera_params["cameraViewTransform"].reshape(4, 4)
         view_proj_mat = view_mat @ proj_mat
         world_points_homo = th.nn.functional.pad(world_points, (0, 1, 0, 0), value=1.0)
-        tf_points = th.dot(world_points_homo, view_proj_mat)
+        tf_points = th.matmul(world_points_homo, view_proj_mat)
         tf_points = tf_points / (tf_points[..., -1:])
         return 0.5 * (tf_points[..., :2] + 1)
 


### PR DESCRIPTION
The `colorize_bbox_3d` function is expected to return an array of shape `(N, 8, 3)`.
Since `world_points_homo` is shape `(N, 4)` and `view_proj_mat` is `(4, 4)`, the matrix multiplication is required.