### PR TITLE
fix(setup.sh): expand --cuda-version arg instead of literal $2

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,12 +32,12 @@ while [[ $# -gt 0 ]]; do
         --eval) EVAL=true; shift ;;
         --asset-pipeline) ASSET_PIPELINE=true; shift ;;
         --dev) DEV=true; shift ;;
-        --cuda-version) CUDA_VERSION="\$2"; shift 2 ;;
+        --cuda-version) CUDA_VERSION="$2"; shift 2 ;;
         --accept-conda-tos) ACCEPT_CONDA_TOS=true; shift ;;
         --accept-nvidia-eula) ACCEPT_NVIDIA_EULA=true; shift ;;
         --accept-dataset-tos) ACCEPT_DATASET_TOS=true; shift ;;
         --confirm-no-conda) CONFIRM_NO_CONDA=true; shift ;;
-        *) echo "Unknown option: \$1"; exit 1 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
 


### PR DESCRIPTION
prev line used `CUDA_VERSION="\$2"` preventing variable expansion and left `$2` as a literal string so setting `--cuda-version` flag didn't properly override default 12.4 value

found it while testing on cuda 13, wheel url came out as cu$2