### PR TITLE
Specify version for PyQt6 dependency

### DIFF
--- a/joylo/setup.py
+++ b/joylo/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "pybullet",
         "pygame",
         "pyglm",
-        "PyQt6",
+        "PyQt6==6.9.1",
         "pyquaternion",
         "pure-python-adb",
         "quaternion",


### PR DESCRIPTION
A new version is out and its not easy to install!