### PR TITLE
Prevent joylo forcing numpy upgrade

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -371,7 +371,10 @@ fi
 if [ "$JOYLO" = true ]; then
     echo "Installing JoyLo..."
     [ ! -d "joylo" ] && { echo "ERROR: joylo directory not found"; exit 1; }
-    pip install -e "$WORKDIR/joylo"
+    CONSTRAINTS="$(mktemp)"
+    printf "numpy<2\n" > "$CONSTRAINTS"
+    pip install -c "$CONSTRAINTS" -e "$WORKDIR/joylo"
+    rm -f "$CONSTRAINTS"
 fi
 
 # Install Eval


### PR DESCRIPTION
Joylo is forcing numpy>2 upgrade, which is not compatible with isaacsim-core 4.5.0.0 & omnigibson 3.7.2.

So when I do a full install with the following command (on my Ubuntu 22.04.5 PC with miniforge3-25.11):
`./setup.sh --new-env --omnigibson --bddl --joylo --dataset --eval --primitives`

I get the following error:
_ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts._

To fix this error, I have added "numpy<2" constrain for joylo, which made setup.sh finish the installation in one go, without errors.

If required, feel free to make modification to the installation setup anywhere, to accomplish the same goal too.