### PR TITLE
Small fix for robot_control_example quickstart behavior

### DIFF
--- a/OmniGibson/omnigibson/examples/robots/robot_control_example.py
+++ b/OmniGibson/omnigibson/examples/robots/robot_control_example.py
@@ -74,7 +74,7 @@ def main(random_selection=False, headless=False, short_exec=False, quickstart=Fa
         scene_model = choose_from_options(options=SCENES, name="scene", random_selection=random_selection)
 
     # Choose robot to create
-    robot_name = "Fetch"
+    robot_name = "fetch"
     if not quickstart:
         robot_name = choose_from_options(
             options=list(sorted(REGISTERED_ROBOTS)), name="robot", random_selection=random_selection


### PR DESCRIPTION
Seeing a crash on `isaac5.1` branch when running, `python -m omnigibson.examples.robots.robot_control_example --quickstart` with error message `AssertionError: Fetch is not a registered robot.`

Because the YAML files are lowercase, the quickstart robot identifier needs to also be lowercase in this case.

Verified that this change fixes the crash when rerunning the quickstart example.