### PR TITLE
Small update to robot definition schema to make controllers optional

### DIFF
--- a/OmniGibson/omnigibson/robots/definition_schema.py
+++ b/OmniGibson/omnigibson/robots/definition_schema.py
@@ -102,8 +102,8 @@ class RobotDefinition:
     Root configuration for a robot, with optional capability sub-configs.
     """
 
-    raw_controller_order: Optional[List[str]]
-    default_controllers: Optional[Dict[str, str]]
+    raw_controller_order: Optional[List[str]] = None
+    default_controllers: Optional[Dict[str, str]] = None
     default_joint_pos: Optional[List[Any]] = None
     disabled_collision_pairs: Optional[List[List[str]]] = None
     disabled_collision_link_names: Optional[List[Any]] = None


### PR DESCRIPTION
Confirmed with @Andorexad that these fields should be optional as they're missing from several of the existing robot YAML definitions.

Otherwise, certain robots cause crashes like, 
```
2026-03-03T23:46:11Z [56,403ms] [Error] [omni.kit.app._impl] [py stderr]: omegaconf.errors.MissingMandatoryValue: Structured config of type 
`RobotDefinition` has missing mandatory value: raw_controller_order
    full_key: raw_controller_order
    object_type=RobotDefinition
```