### PR TITLE
disable test_primitives for tiago for 50 series GPU

### DIFF
--- a/OmniGibson/tests/test_primitives.py
+++ b/OmniGibson/tests/test_primitives.py
@@ -88,7 +88,14 @@ def primitive_tester(env, objects, primitives, primitives_args):
         og.clear()
 
 
-@pytest.mark.parametrize("robot", ["Tiago", "R1"])
+ROBOTS_UNDER_TEST = ["Tiago", "R1"]
+if th.cuda.is_available() and th.cuda.get_device_capability(0) == (12, 0):
+    # TODO: Currently for 50 series, only Default embodiment works for Tiago, and for R1Pro, all embodiment except Default work.
+    # Here, we remove Tiago for testing.
+    ROBOTS_UNDER_TEST = ["R1"]
+
+
+@pytest.mark.parametrize("robot", ROBOTS_UNDER_TEST)
 class TestPrimitives:
     def test_navigate(self, robot):
         categories = ["floors", "ceilings", "walls"]


### PR DESCRIPTION
These tests are failing due to the embodiment issues on 5090 machines