### PR TITLE
Add lenient timeout per-step for each test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
           ${{ matrix.example && format('-k "{0}"', matrix.example) || '' }}
           --junitxml=${{ matrix.test_file }}${{ matrix.example && format('_{0}', matrix.example) || '' }}.xml
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 30
 
       - name: Deploy artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Maybe not common issue, but I ran into this test seemingly hanging today while i was trying to test the PR test reports:
https://github.com/StanfordVL/BEHAVIOR-1K/actions/runs/22962047723/job/66655123556?pr=1997

The default timeout of 6 hours is probably way too long for us; we could probably set it to either 30 or 60 minutes also to prevent it from clogging up machines. 
Also let me know if there's an obvious bug causing that hanging behavior that can be fixed separately.