### PR TITLE
Fix kinematic mixin regression from object state refactor

### DIFF
--- a/OmniGibson/omnigibson/object_states/kinematics_mixin.py
+++ b/OmniGibson/omnigibson/object_states/kinematics_mixin.py
@@ -19,29 +19,37 @@ class KinematicsMixin(BaseObjectState):
         return deps
 
     def cache_info(self, get_value_args):
+        # Import here to avoid circular imports
+        from omnigibson.objects.object_base import BaseObject
+
         # Run super first
         info = super().cache_info(get_value_args=get_value_args)
 
         # Store this object as well as any other objects from @get_value_args
         info[self.obj] = {"q": self.obj.states[Joint].get_value(), "p": self.obj.states[Pose].get_value()}
         for arg in get_value_args:
-            info[arg] = {"q": arg.states[Joint].get_value(), "p": arg.states[Pose].get_value()}
+            if isinstance(arg, BaseObject):
+                info[arg] = {"q": arg.states[Joint].get_value(), "p": arg.states[Pose].get_value()}
 
         return info
 
     def _cache_is_valid(self, get_value_args):
+        # Import here to avoid circular imports
+        from omnigibson.objects.object_base import BaseObject
+
         # Cache is valid if and only if all of our cached objects have not changed
         t = self._cache[get_value_args]["t"]
         for obj, info in self._cache[get_value_args]["info"].items():
             # If the object is asleep, assume this object hasn't changed, so continue
             if obj.is_asleep:
                 continue
-            # If pose has changed, return False
-            if obj.states[Pose].has_changed(get_value_args=(), value=info["p"], info={}, t=t):
-                return False
-            # If obj's joints have changed, return False
-            if obj.states[Joint].has_changed(get_value_args=(), value=info["q"], info={}, t=t):
-                return False
+            if isinstance(obj, BaseObject):
+                # If pose has changed, return False
+                if obj.states[Pose].has_changed(get_value_args=(), value=info["p"], info={}, t=t):
+                    return False
+                # If obj's joints have changed, return False
+                if obj.states[Joint].has_changed(get_value_args=(), value=info["q"], info={}, t=t):
+                    return False
         return True
 
     @classproperty


### PR DESCRIPTION
Some misleading comments I left on Stef's PR #1996 caused this regression. Here the argument can actually be a particle system, which will cause breakages.