### PR TITLE
Remove fixed_base from LightObject

### DIFF
--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -730,7 +730,6 @@ def _launch_simulator(*args, **kwargs):
                 category="background",
                 light_type="Dome",
                 intensity=2500,
-                fixed_base=True,
             )
             self._skybox.load(None)
             self._skybox.color = (1.07, 0.85, 0.61)


### PR DESCRIPTION
Seeing,
```
>       super().__init__(                                                                                                                                                                                                                                                                 
            usd_path=usd_path,                                                                                                                                                                                                                                                            
            relative_prim_path=relative_prim_path,                                                                                                                                                                                                                                        
            name=name,                                                                                                                                                                                                                                                                    
            category=category,                                                                                                                                                                                                                                                            
            scale=scale,                                                                                                                                                                                                                                                                  
            visible=True,                                                                                                                                                                                                                                                                 
            fixed_base=True,                                                                                                                                                                                                                                                              
            visual_only=True,                                                                                                                                                                                                                                                             
            kinematic_only=True,                                                                                                                                                                                                                                                          
            self_collisions=False,                                                                                                                                                                                                                                                        
            prim_type=PrimType.RIGID,                                                                                                                                                                                                                                                     
            include_default_states=include_default_states,                                                                                                                                                                                                                                
            link_physics_materials=link_physics_materials,                                                                                                                                                                                                                                
            load_config=load_config,                                                                                                                                                                                                                                                      
            abilities=abilities,                                                                                                                                                                                                                                                          
            **kwargs,                                                                                                                                                                                                                                                                     
        )                                                                                                                                                                                                                                                                                 
E       TypeError: omnigibson.objects.usd_object.USDObject.__init__() got multiple values for keyword argument 'fixed_base'
```
when creating the skybox since we pass in the kwargs from the `LightObject` class to `USDObject` now.                                                                                                                                                             
                                                                                                         