### PR TITLE
[Deprecated] Object State Tensorize 2/2

### DIFF
--- a/OmniGibson/omnigibson/object_states/heat_source_or_sink.py
+++ b/OmniGibson/omnigibson/object_states/heat_source_or_sink.py
@@ -1,16 +1,13 @@
 import torch as th
 
-import omnigibson as og
 from omnigibson.macros import create_module_macros
 from omnigibson.object_states.aabb import AABB
 from omnigibson.object_states.inside import Inside
 from omnigibson.object_states.link_based_state_mixin import LinkBasedStateMixin
-from omnigibson.object_states.object_state_base import AbsoluteObjectState
 from omnigibson.object_states.open_state import Open
+from omnigibson.object_states.tensorized_value_state import TensorizedValueState
 from omnigibson.object_states.toggle import ToggledOn
-from omnigibson.object_states.update_state_mixin import UpdateStateMixin
-from omnigibson.utils.constants import PrimType
-from omnigibson.utils.python_utils import classproperty
+from omnigibson.utils.python_utils import classproperty, torch_delete
 
 # Create settings for this module
 m = create_module_macros(module_path=__file__)
@@ -24,16 +21,142 @@ m.DEFAULT_HEATING_RATE = 0.04
 m.DEFAULT_DISTANCE_THRESHOLD = 0.2
 
 
-class HeatSourceOrSink(AbsoluteObjectState, LinkBasedStateMixin, UpdateStateMixin):
+class HeatSourceOrSink(LinkBasedStateMixin, TensorizedValueState):
     """
     This state indicates the heat source or heat sink state of the object.
 
-    Currently, if the object is not an active heat source/sink, this returns (False, None).
-    Otherwise, it returns True and the position of the heat source element, or (True, None) if the heat source has no
-    heating element / only checks for Inside.
-    E.g. on a stove object, True and the coordinates of the heating element will be returned.
-    on a microwave object, True and None will be returned.
+    Tensorized storage
+    ------------------
+    VALUES[:] — (N,) bool — active gate per heat source. True when the source is
+    currently emitting heat (toggled on if required, not open if required).
+
+    All geometry and config tensors are public (no leading underscore) so that
+    Temperature._apply_heat_source_influence() can read them directly without
+    violating encapsulation, following the MaxTemperature.TEMPERATURE_IDXS pattern.
     """
+
+    # ── Construction-time constants (resized at _add_obj / _remove_obj) ──────
+    TEMPERATURES = None  # (N,) float32 — target temperature of each heat source
+    HEATING_RATES = None  # (N,) float32 — rate of temperature change per second
+    DISTANCE_THRESHOLDS = None  # (N,) float32 — spatial range (near mode); unused for inside mode
+    REQUIRES_INSIDE = None  # (N,) bool
+    REQUIRES_TOGGLED_ON = None  # (N,) bool
+    REQUIRES_CLOSED = None  # (N,) bool
+    TOGGLED_ON_IDXS = None  # (N,) int64 — index into ToggledOn.VALUES; -1 if not applicable
+
+    # ── Per-step geometry (refreshed in global_update, read by Temperature) ──
+    POSITIONS = None  # (N, 3) float32 — emitter position (near) or AABB center (inside)
+    AABB_LO = None  # (N, 3) float32
+    AABB_HI = None  # (N, 3) float32
+
+    @classproperty
+    def value_shape(cls):
+        return ()
+
+    @classproperty
+    def value_type(cls):
+        return th.bool
+
+    @classproperty
+    def value_name(cls):
+        return "active"
+
+    @classmethod
+    def global_initialize(cls):
+        super().global_initialize()
+        cls.TEMPERATURES = th.empty(0, dtype=th.float32)
+        cls.HEATING_RATES = th.empty(0, dtype=th.float32)
+        cls.DISTANCE_THRESHOLDS = th.empty(0, dtype=th.float32)
+        cls.REQUIRES_INSIDE = th.empty(0, dtype=th.bool)
+        cls.REQUIRES_TOGGLED_ON = th.empty(0, dtype=th.bool)
+        cls.REQUIRES_CLOSED = th.empty(0, dtype=th.bool)
+        cls.TOGGLED_ON_IDXS = th.empty(0, dtype=th.int64)
+        cls.POSITIONS = th.empty((0, 3), dtype=th.float32)
+        cls.AABB_LO = th.empty((0, 3), dtype=th.float32)
+        cls.AABB_HI = th.empty((0, 3), dtype=th.float32)
+
+        # Register callback to keep TOGGLED_ON_IDXS consistent when a ToggledOn is removed.
+        # Pattern mirrors MaxTemperature's TEMPERATURE_IDXS update on Temperature removal.
+        def _update_toggled_on_idxs(obj):
+            if obj not in ToggledOn.OBJ_IDXS:
+                return
+            deleted_idx = ToggledOn.OBJ_IDXS[obj]
+            # Only decrement valid indices (>= 0) that point past the deleted slot.
+            valid = cls.TOGGLED_ON_IDXS >= 0
+            cls.TOGGLED_ON_IDXS = th.where(
+                valid & (cls.TOGGLED_ON_IDXS >= deleted_idx),
+                cls.TOGGLED_ON_IDXS - 1,
+                cls.TOGGLED_ON_IDXS,
+            )
+
+        ToggledOn.add_callback_on_remove(
+            name="HeatSourceOrSink_toggled_on_idx_update", callback=_update_toggled_on_idxs
+        )
+
+    @classmethod
+    def _add_obj(cls, obj):
+        super()._add_obj(obj=obj)
+        # Append placeholder rows; actual values are written in __init__ after super() returns.
+        cls.TEMPERATURES = th.cat([cls.TEMPERATURES, th.zeros(1, dtype=th.float32)])
+        cls.HEATING_RATES = th.cat([cls.HEATING_RATES, th.zeros(1, dtype=th.float32)])
+        cls.DISTANCE_THRESHOLDS = th.cat([cls.DISTANCE_THRESHOLDS, th.zeros(1, dtype=th.float32)])
+        cls.REQUIRES_INSIDE = th.cat([cls.REQUIRES_INSIDE, th.zeros(1, dtype=th.bool)])
+        cls.REQUIRES_TOGGLED_ON = th.cat([cls.REQUIRES_TOGGLED_ON, th.zeros(1, dtype=th.bool)])
+        cls.REQUIRES_CLOSED = th.cat([cls.REQUIRES_CLOSED, th.zeros(1, dtype=th.bool)])
+        cls.TOGGLED_ON_IDXS = th.cat([cls.TOGGLED_ON_IDXS, th.full((1,), -1, dtype=th.int64)])
+        cls.POSITIONS = th.cat([cls.POSITIONS, th.zeros((1, 3), dtype=th.float32)], dim=0)
+        cls.AABB_LO = th.cat([cls.AABB_LO, th.zeros((1, 3), dtype=th.float32)], dim=0)
+        cls.AABB_HI = th.cat([cls.AABB_HI, th.zeros((1, 3), dtype=th.float32)], dim=0)
+
+    @classmethod
+    def _remove_obj(cls, obj):
+        deleted_idx = cls.OBJ_IDXS[obj]
+        cls.TEMPERATURES = torch_delete(cls.TEMPERATURES, [deleted_idx])
+        cls.HEATING_RATES = torch_delete(cls.HEATING_RATES, [deleted_idx])
+        cls.DISTANCE_THRESHOLDS = torch_delete(cls.DISTANCE_THRESHOLDS, [deleted_idx])
+        cls.REQUIRES_INSIDE = torch_delete(cls.REQUIRES_INSIDE, [deleted_idx])
+        cls.REQUIRES_TOGGLED_ON = torch_delete(cls.REQUIRES_TOGGLED_ON, [deleted_idx])
+        cls.REQUIRES_CLOSED = torch_delete(cls.REQUIRES_CLOSED, [deleted_idx])
+        cls.TOGGLED_ON_IDXS = torch_delete(cls.TOGGLED_ON_IDXS, [deleted_idx])
+        cls.POSITIONS = torch_delete(cls.POSITIONS, [deleted_idx])
+        cls.AABB_LO = torch_delete(cls.AABB_LO, [deleted_idx])
+        cls.AABB_HI = torch_delete(cls.AABB_HI, [deleted_idx])
+        super()._remove_obj(obj=obj)
+
+    @classmethod
+    def _update_values(cls, values):
+        active = th.ones(len(cls.IDX_OBJS), dtype=th.bool)
+        # ToggledOn IS a TensorizedValueState — pure tensor index lookup, no loop
+        if cls.REQUIRES_TOGGLED_ON.any():
+            toggled = ToggledOn.VALUES[cls.TOGGLED_ON_IDXS[cls.REQUIRES_TOGGLED_ON], 0] > 0.5
+            active[cls.REQUIRES_TOGGLED_ON] &= toggled
+        # Open is NOT a TensorizedValueState — per-object call is unavoidable
+        for i in th.where(cls.REQUIRES_CLOSED)[0].tolist():
+            if cls.IDX_OBJS[i].states[Open].get_value():
+                active[i] = False
+        return active
+
+    @classmethod
+    def global_update(cls):
+        if not cls.IDX_OBJS:
+            return
+
+        # Refresh per-step geometry (loop over N_hs, typically < 10).
+        # Will become a pure tensor op once AABB is tensorized.
+        for i, obj in enumerate(cls.IDX_OBJS):
+            lo, hi = obj.states[AABB].get_value()
+            cls.AABB_LO[i] = lo
+            cls.AABB_HI[i] = hi
+            if cls.REQUIRES_INSIDE[i]:
+                cls.POSITIONS[i] = (lo + hi) / 2.0
+            else:
+                hs_state = obj.states[cls]
+                link = hs_state.link
+                cls.POSITIONS[i] = (
+                    link.aabb_center if link == hs_state._default_link else link.get_position_orientation()[0]
+                )
+
+        super().global_update()  # calls _update_values → refreshes VALUES (active flags)
 
     def __init__(
         self,
@@ -63,29 +186,35 @@ class HeatSourceOrSink(AbsoluteObjectState, LinkBasedStateMixin, UpdateStateMixi
                 will mean that the "heating element" link for the object will be
                 ignored.
         """
+        # super().__init__ calls _add_obj, which appends placeholder rows to class tensors.
         super(HeatSourceOrSink, self).__init__(obj)
+
+        # Set per-instance config (same semantics as original).
         self._temperature = temperature if temperature is not None else m.DEFAULT_TEMPERATURE
         self._heating_rate = heating_rate if heating_rate is not None else m.DEFAULT_HEATING_RATE
         self.distance_threshold = distance_threshold if distance_threshold is not None else m.DEFAULT_DISTANCE_THRESHOLD
 
-        # If the heat source needs to be toggled on, we assert the presence
-        # of that ability.
         if requires_toggled_on:
             assert ToggledOn in self.obj.states
         self.requires_toggled_on = requires_toggled_on
 
-        # If the heat source needs to be closed, we assert the presence
-        # of that ability.
         if requires_closed:
             assert Open in self.obj.states
         self.requires_closed = requires_closed
 
-        # If the heat source needs to contain an object inside to heat it,
-        # we record that for use in the heat transfer process.
         self.requires_inside = requires_inside
 
-        # Internal state that gets cached
-        self._affected_objects = None
+        # Write actual config into class-level tensors at our index.
+        idx = type(self).OBJ_IDXS[obj]
+        type(self).TEMPERATURES[idx] = self._temperature
+        type(self).HEATING_RATES[idx] = self._heating_rate
+        type(self).DISTANCE_THRESHOLDS[idx] = self.distance_threshold
+        type(self).REQUIRES_INSIDE[idx] = requires_inside
+        type(self).REQUIRES_TOGGLED_ON[idx] = requires_toggled_on
+        type(self).REQUIRES_CLOSED[idx] = requires_closed
+        if requires_toggled_on and ToggledOn in obj.states:
+            type(self).TOGGLED_ON_IDXS[idx] = ToggledOn.OBJ_IDXS[obj]
+        # else: stays -1 as set by _add_obj
 
     @classmethod
     def is_compatible(cls, obj, **kwargs):
@@ -162,134 +291,5 @@ class HeatSourceOrSink(AbsoluteObjectState, LinkBasedStateMixin, UpdateStateMixi
         super()._initialize()
         self.initialize_link_mixin()
 
-    def _get_value(self):
-        # Check the toggle state.
-        if self.requires_toggled_on and not self.obj.states[ToggledOn].get_value():
-            return False
-
-        # Check the open state.
-        if self.requires_closed and self.obj.states[Open].get_value():
-            return False
-
-        return True
-
-    def affects_obj(self, obj):
-        """
-        Computes whether this heat source or sink object is affecting object @obj
-        Computes the temperature delta that may be applied to object @obj. NOTE: This value is agnostic to simulation
-        stepping speed, and should be scaled accordingly
-
-        Args:
-            obj (StatefulObject): Object whose temperature delta should be computed
-
-        Returns:
-            bool: Whether this heat source or sink is currently affecting @obj's temperature
-        """
-        # No change if we're not on
-        if not self.get_value():
-            return False
-
-        # If the object is not affected, we return False
-        if obj not in self._affected_objects:
-            return False
-
-        # If all checks pass, we're actively influencing the object!
-        return True
-
-    def _update(self):
-        # Avoid circular imports
-        from omnigibson.object_states.temperature import Temperature
-
-        # Update the internally tracked nearby objects to accelerate filtering for affects_obj
-        affected_objects = set()
-
-        # Only update if we're valid
-        if self.get_value():
-
-            def overlap_callback(hit):
-                nonlocal affected_objects
-                # global affected_objects
-                obj = self.obj.scene.object_registry("prim_path", "/".join(hit.rigid_body.split("/")[:-1]))
-                if obj is not None and obj != self.obj and obj in Temperature.OBJ_IDXS:
-                    affected_objects.add(obj)
-                # Always continue traversal
-                return True
-
-            if self.requires_inside:
-                # Use overlap_box check to check for objects inside the box!
-                aabb_lower, aabb_upper = self.obj.states[AABB].get_value()
-                half_extent = (aabb_upper - aabb_lower) / 2.0
-                aabb_center = (aabb_upper + aabb_lower) / 2.0
-
-                og.sim.psqi.overlap_box(
-                    halfExtent=half_extent.tolist(),
-                    pos=aabb_center.tolist(),
-                    rot=[0, 0, 0, 1.0],
-                    reportFn=overlap_callback,
-                )
-
-                # Cloth isn't subject to overlap checks, so we also have to manually check their poses as well
-                cloth_objs = tuple(self.obj.scene.object_registry("prim_type", PrimType.CLOTH, []))
-                n_cloth_objs = len(cloth_objs)
-                if n_cloth_objs > 0:
-                    cloth_positions = th.zeros((n_cloth_objs, 3))
-                    for i, obj in enumerate(cloth_objs):
-                        cloth_positions[i] = obj.get_position_orientation()[0]
-                    for idx in th.where(
-                        th.all(
-                            (aabb_lower.reshape(1, 3) < cloth_positions) & (cloth_positions < aabb_upper.reshape(1, 3)),
-                            dim=-1,
-                        )
-                    )[0]:
-                        # Only add if object has temperature
-                        if cloth_objs[idx] in Temperature.OBJ_IDXS:
-                            affected_objects.add(cloth_objs[idx])
-
-                # Additionally prune objects based on Temperature / Inside requirement -- cast to avoid in-place operations
-                for obj in tuple(affected_objects):
-                    if not obj.states[Inside].get_value(self.obj):
-                        affected_objects.remove(obj)
-
-            else:
-                # Position is either the AABB center of the default link or the meta link position itself
-                heat_source_pos = (
-                    self.link.aabb_center
-                    if self.link == self._default_link
-                    else self.link.get_position_orientation()[0]
-                )
-
-                # Use overlap_sphere check!
-                og.sim.psqi.overlap_sphere(
-                    radius=self.distance_threshold,
-                    pos=heat_source_pos.tolist(),
-                    reportFn=overlap_callback,
-                )
-
-                # Cloth isn't subject to overlap checks, so we also have to manually check their poses as well
-                cloth_objs = tuple(self.obj.scene.object_registry("prim_type", PrimType.CLOTH, []))
-                n_cloth_objs = len(cloth_objs)
-                if n_cloth_objs > 0:
-                    cloth_positions = th.zeros((n_cloth_objs, 3))
-                    for i, obj in enumerate(cloth_objs):
-                        cloth_positions[i] = obj.get_position_orientation()[0]
-                    for idx in th.where(
-                        th.norm(heat_source_pos.reshape(1, 3) - cloth_positions, dim=-1) <= self.distance_threshold
-                    )[0]:
-                        # Only add if object has temperature
-                        if cloth_objs[idx] in Temperature.OBJ_IDXS:
-                            affected_objects.add(cloth_objs[idx])
-
-        # Remove self (we cannot affect ourselves) and update the internal set of objects, and remove self
-        if self.obj in affected_objects:
-            affected_objects.remove(self.obj)
-        self._affected_objects = affected_objects
-
-        # Propagate the affected objects' temperatures
-        if len(self._affected_objects) > 0:
-            Temperature.update_temperature_from_heatsource_or_sink(
-                objs=self._affected_objects,
-                temperature=self.temperature,
-                rate=self.heating_rate,
-            )
-
-    # Nothing needs to be done to save/load HeatSource
+    # Nothing needs to be done to save/load HeatSource beyond the inherited
+    # TensorizedValueState._dump_state / _load_state (which handle VALUES["active"]).

--- a/OmniGibson/omnigibson/object_states/on_fire.py
+++ b/OmniGibson/omnigibson/object_states/on_fire.py
@@ -1,6 +1,9 @@
+import torch as th
+
 from omnigibson.macros import create_module_macros
 from omnigibson.object_states.heat_source_or_sink import HeatSourceOrSink
 from omnigibson.object_states.temperature import Temperature
+from omnigibson.utils.python_utils import torch_delete
 
 # Create settings for this module
 m = create_module_macros(module_path=__file__)
@@ -21,6 +24,56 @@ class OnFire(HeatSourceOrSink):
     It may include a heatsource_link annotation (e.g. candle wick), in which case the fire visualization will be placed
     under that meta link. Otherwise (e.g. charcoal), the fire visualization will be placed under the root link.
     """
+
+    TEMPERATURE_IDXS = None  # (N,) int64   — index into Temperature.VALUES for each OnFire object
+    IGNITION_TEMPERATURES = None  # (N,) float32  — ignition threshold per object
+
+    @classmethod
+    def global_initialize(cls):
+        super().global_initialize()
+        cls.TEMPERATURE_IDXS = th.empty(0, dtype=th.int64)
+        cls.IGNITION_TEMPERATURES = th.empty(0, dtype=th.float32)
+
+        # TEMPERATURE_IDXS[i] is an integer slot index into Temperature.VALUES.
+        # When a Temperature object is removed, TensorizedValueState._remove_obj deletes its
+        # row from Temperature.VALUES and all subsequent rows shift down by one.  Any stored
+        # index that pointed past the deleted slot now refers to the wrong object.
+        # This callback fires before the deletion and decrements every stored index that is
+        # >= the deleted slot, keeping TEMPERATURE_IDXS in sync with Temperature.VALUES.
+        # The same pattern is used for HeatSourceOrSink.TOGGLED_ON_IDXS (registered on
+        # ToggledOn removal) and MaxTemperature.TEMPERATURE_IDXS (registered on Temperature removal).
+        def _update_temperature_idxs(obj):
+            if obj not in Temperature.OBJ_IDXS:
+                return
+            deleted_idx = Temperature.OBJ_IDXS[obj]
+            valid = cls.TEMPERATURE_IDXS >= 0
+            cls.TEMPERATURE_IDXS = th.where(
+                valid & (cls.TEMPERATURE_IDXS >= deleted_idx),
+                cls.TEMPERATURE_IDXS - 1,
+                cls.TEMPERATURE_IDXS,
+            )
+
+        Temperature.add_callback_on_remove(name="OnFire_temperature_idx_update", callback=_update_temperature_idxs)
+
+    @classmethod
+    def _add_obj(cls, obj):
+        super()._add_obj(obj)
+        cls.TEMPERATURE_IDXS = th.cat([cls.TEMPERATURE_IDXS, th.full((1,), -1, dtype=th.int64)])
+        cls.IGNITION_TEMPERATURES = th.cat([cls.IGNITION_TEMPERATURES, th.zeros(1, dtype=th.float32)])
+
+    @classmethod
+    def _remove_obj(cls, obj):
+        deleted_idx = cls.OBJ_IDXS[obj]
+        cls.TEMPERATURE_IDXS = torch_delete(cls.TEMPERATURE_IDXS, [deleted_idx])
+        cls.IGNITION_TEMPERATURES = torch_delete(cls.IGNITION_TEMPERATURES, [deleted_idx])
+        super()._remove_obj(obj)
+
+    @classmethod
+    def _update_values(cls, values):
+        # OnFire is active when the object's current temperature >= its ignition threshold.
+        # Pure tensor op: no loop needed.
+        temps = Temperature.VALUES[cls.TEMPERATURE_IDXS]  # (N,) current temp of each fire object
+        return temps >= cls.IGNITION_TEMPERATURES  # (N,) bool
 
     def __init__(
         self,
@@ -59,6 +112,11 @@ class OnFire(HeatSourceOrSink):
         )
         self.ignition_temperature = ignition_temperature
 
+        # Write OnFire-specific config into class tensors at our index.
+        idx = type(self).OBJ_IDXS[obj]
+        type(self).TEMPERATURE_IDXS[idx] = Temperature.OBJ_IDXS[obj]
+        type(self).IGNITION_TEMPERATURES[idx] = ignition_temperature
+
     @classmethod
     def requires_meta_link(cls, **kwargs):
         # Does not require meta link to be specified
@@ -74,14 +132,6 @@ class OnFire(HeatSourceOrSink):
         deps = super().get_dependencies()
         deps.add(Temperature)
         return deps
-
-    def _update(self):
-        # Call super first
-        super()._update()
-
-        # If it's on fire, maintain the fire temperature
-        if self.get_value():
-            self.obj.states[Temperature].set_value(self.temperature)
 
     def _get_value(self):
         return self.obj.states[Temperature].get_value() >= self.ignition_temperature

--- a/OmniGibson/omnigibson/object_states/on_top.py
+++ b/OmniGibson/omnigibson/object_states/on_top.py
@@ -29,10 +29,14 @@ class OnTop(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
             self.obj.reset()
 
         for _ in range(os_m.DEFAULT_HIGH_LEVEL_SAMPLING_ATTEMPTS):
-            if sample_kinematics("onTop", self.obj, other, use_trav_map=use_trav_map) and self.get_value(other):
-                return True
-            else:
-                og.sim.load_state(state, serialized=False)
+            if sample_kinematics("onTop", self.obj, other, use_trav_map=use_trav_map):
+                # sample_kinematics uses step_physics() internally, which keeps the raw contact
+                # cache fresh but does not run Touching.global_update(). Refresh the Touching
+                # matrix here so get_value() reads current contact state.
+                Touching.global_update()
+                if self.get_value(other):
+                    return True
+            og.sim.load_state(state, serialized=False)
 
         return False
 

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -1,7 +1,10 @@
+import torch as th
+
 import omnigibson as og
 from omnigibson.macros import create_module_macros
 from omnigibson.object_states.aabb import AABB
 from omnigibson.object_states.heat_source_or_sink import HeatSourceOrSink
+from omnigibson.object_states.inside import Inside
 from omnigibson.object_states.tensorized_value_state import TensorizedValueState
 from omnigibson.utils.python_utils import classproperty
 
@@ -25,20 +28,6 @@ class Temperature(TensorizedValueState):
         self._set_value(m.DEFAULT_TEMPERATURE)
 
     @classmethod
-    def update_temperature_from_heatsource_or_sink(cls, objs, temperature, rate):
-        """
-        Updates @objs' internal temperatures based on @temperature and @rate
-
-        Args:
-            objs (Iterable of StatefulObject): Objects whose temperatures should be updated
-            temperature (float): Heat source / sink temperature
-            rate (float): Heating rate of the source / sink
-        """
-        # Get idxs for objs
-        idxs = [cls.OBJ_IDXS[obj] for obj in objs]
-        cls.VALUES[idxs] += (temperature - cls.VALUES[idxs]) * rate * og.sim.get_sim_step_dt()
-
-    @classmethod
     def get_dependencies(cls):
         deps = super().get_dependencies()
         deps.add(AABB)
@@ -52,8 +41,161 @@ class Temperature(TensorizedValueState):
 
     @classmethod
     def _update_values(cls, values):
-        # Apply temperature decay
+        # Apply temperature decay toward ambient
         return values + (m.DEFAULT_TEMPERATURE - values) * m.TEMPERATURE_DECAY_SPEED * og.sim.get_sim_step_dt()
+
+    @classmethod
+    def global_update(cls):
+        # Lazy import to avoid circular dependency: on_fire → temperature → on_fire
+        from omnigibson.object_states.on_fire import OnFire
+
+        super().global_update()  # applies ambient decay via _update_values()
+
+        # Pin active OnFire objects to fire_temperature so decay cannot extinguish them.
+        if OnFire.IDX_OBJS and OnFire.VALUES.any():
+            active_fire = th.where(OnFire.VALUES)[0]
+            temp_idxs = OnFire.TEMPERATURE_IDXS[active_fire]
+            cls.VALUES[temp_idxs] = OnFire.TEMPERATURES[active_fire]
+
+        cls._apply_heat_source_influence(HeatSourceOrSink)
+        cls._apply_heat_source_influence(OnFire)
+
+    @classmethod
+    def _get_obj_positions(cls):
+        """
+        Compute AABB centers for all tracked temperature objects.
+
+        Returns:
+            th.Tensor: (T, 3) float32 — AABB center of each object in cls.IDX_OBJS order.
+        """
+        return th.stack([sum(obj.states[AABB].get_value()) / 2.0 for obj in cls.IDX_OBJS])
+
+    @classmethod
+    def _get_affected_matrix(cls, obj_positions, heatsource_cls):
+        """
+        Compute which active heat sources affect which temperature objects.
+
+        Near mode uses batched cdist; inside mode uses vectorized AABB containment
+        followed by a semantic Inside check for spatially plausible candidates.
+
+        Args:
+            obj_positions (th.Tensor): (T, 3) float32 — AABB centers of all temperature
+                objects in cls.IDX_OBJS order.
+            heatsource_cls: HeatSourceOrSink or OnFire class whose tensors to read.
+
+        Returns:
+            th.Tensor: (H, T) bool — affected[h, t] is True if heat source h affects
+                temperature object t. H = len(heatsource_cls.IDX_OBJS),
+                T = len(cls.IDX_OBJS). Inactive heat sources have all-False rows.
+        """
+        H = len(heatsource_cls.IDX_OBJS)
+        T = len(cls.IDX_OBJS)
+        affected = th.zeros((H, T), dtype=th.bool)
+
+        active_mask = heatsource_cls.VALUES  # (H,) bool
+
+        # ── Near mode: batched cdist ──────────────────────────────────────────
+        near_mask = active_mask & ~heatsource_cls.REQUIRES_INSIDE
+        if near_mask.any():
+            near_idxs = th.where(near_mask)[0]
+            positions = heatsource_cls.POSITIONS[near_idxs]  # (H_near, 3)
+            thresholds = heatsource_cls.DISTANCE_THRESHOLDS[near_idxs]  # (H_near,)
+
+            dists = th.cdist(positions, obj_positions)  # (H_near, T)
+            affected[near_idxs] = dists < thresholds.unsqueeze(1)  # (H_near, T)
+
+        # ── Inside mode: AABB containment + semantic Inside filter ────────────
+        inside_mask = active_mask & heatsource_cls.REQUIRES_INSIDE
+        if inside_mask.any():
+            inside_idxs = th.where(inside_mask)[0]
+            aabb_lo = heatsource_cls.AABB_LO[inside_idxs]  # (H_inside, 3)
+            aabb_hi = heatsource_cls.AABB_HI[inside_idxs]  # (H_inside, 3)
+
+            # Vectorized AABB containment: (H_inside, T)
+            in_aabb = (
+                (obj_positions.unsqueeze(0) >= aabb_lo.unsqueeze(1))
+                & (obj_positions.unsqueeze(0) <= aabb_hi.unsqueeze(1))
+            ).all(dim=-1)
+
+            # use state Inside as filter again.
+            # TODO: (andi) tensorized after Inside is tensorized.
+            for inside_idx, heatsource_idx in enumerate(inside_idxs.tolist()):
+                heatsource_obj = heatsource_cls.IDX_OBJS[heatsource_idx]
+                for temperature_idx in th.where(in_aabb[inside_idx])[0].tolist():
+                    temperature_obj = cls.IDX_OBJS[temperature_idx]
+                    if not temperature_obj.states[Inside].get_value(heatsource_obj):
+                        in_aabb[inside_idx, temperature_idx] = False
+
+            affected[inside_idxs] = in_aabb
+
+        return affected
+
+    @classmethod
+    def _apply_heat_source_influence(cls, heatsource_cls):
+        if not heatsource_cls.IDX_OBJS or not cls.IDX_OBJS:
+            return
+        if not heatsource_cls.VALUES.any():
+            return
+
+        dt = og.sim.get_sim_step_dt()
+        temperature_obj_positions = cls._get_obj_positions()  # (T, 3)
+        affected = cls._get_affected_matrix(temperature_obj_positions, heatsource_cls)  # (H, T)
+
+        # (H, T) temperature delta, zeroed for unaffected pairs
+        temp_diff = heatsource_cls.TEMPERATURES.unsqueeze(1) - cls.VALUES.unsqueeze(0)  # (H, T)
+        deltas = temp_diff * heatsource_cls.HEATING_RATES.unsqueeze(1) * dt  # (H, T)
+        deltas[~affected] = 0.0
+
+        # Multiple heat sources sum (order-independent)
+        cls.VALUES += deltas.sum(dim=0)  # (T,)
+
+    @classmethod
+    def get_objs_affected_by_heatsource(cls, heatsources, objs):
+        """
+        Returns the subset of @heatsources that are actively heating at least one object in @objs.
+
+        Args:
+            heatsources (list of StatefulObject): Candidate heat source objects to test.
+                May contain HeatSourceOrSink and/or OnFire objects.
+            objs (list of StatefulObject): Target objects to check whether they are being heated.
+
+        Returns:
+            list of StatefulObject: Heat sources from @heatsources that affect at least one
+                object in @objs.
+        """
+        # Lazy import to avoid circular dependency: on_fire → temperature → on_fire
+        from omnigibson.object_states.on_fire import OnFire
+
+        if not cls.IDX_OBJS:
+            return []
+        # Only track those with Temperature state
+        objs_tracked = [obj for obj in objs if obj in cls.OBJ_IDXS]
+        if not objs_tracked:
+            return []
+
+        result = []
+        temperature_obj_positions = cls._get_obj_positions()
+
+        # Partition heatsources into HeatSourceOrSink vs OnFire
+        heatsource_only = []
+        on_fires = []
+        for heatsource in heatsources:
+            if heatsource in HeatSourceOrSink.OBJ_IDXS:
+                heatsource_only.append(heatsource)
+            else:
+                on_fires.append(heatsource)
+
+        for heatsource_cls, heatsource_tracked in ((HeatSourceOrSink, heatsource_only), (OnFire, on_fires)):
+            if not heatsource_tracked or not heatsource_cls.IDX_OBJS or not heatsource_cls.VALUES.any():
+                continue
+            affected = cls._get_affected_matrix(temperature_obj_positions, heatsource_cls)
+            result.extend(
+                hs
+                for hs in heatsource_tracked
+                if any(affected[heatsource_cls.OBJ_IDXS[hs], cls.OBJ_IDXS[obj]] for obj in objs_tracked)
+            )
+
+        return result
 
     @classproperty
     def value_name(cls):

--- a/OmniGibson/omnigibson/object_states/tensorized_value_state.py
+++ b/OmniGibson/omnigibson/object_states/tensorized_value_state.py
@@ -3,11 +3,10 @@ import math
 import torch as th
 
 from omnigibson.object_states.object_state_base import AbsoluteObjectState
-from omnigibson.object_states.update_state_mixin import GlobalUpdateStateMixin
 from omnigibson.utils.python_utils import classproperty, torch_delete
 
 
-class TensorizedValueState(AbsoluteObjectState, GlobalUpdateStateMixin):
+class TensorizedValueState(AbsoluteObjectState):
     """
     A state-mixin that implements optimized global value updates across all object state instances
     of this type, i.e.: all values across all object state instances are updated at once, rather than per
@@ -30,9 +29,6 @@ class TensorizedValueState(AbsoluteObjectState, GlobalUpdateStateMixin):
 
     @classmethod
     def global_initialize(cls):
-        # Call super first
-        super().global_initialize()
-
         # Initialize the global variables
         cls.VALUES = th.empty(0, dtype=cls.value_type).reshape(0, *cls.value_shape)
         cls.OBJ_IDXS = dict()
@@ -45,9 +41,6 @@ class TensorizedValueState(AbsoluteObjectState, GlobalUpdateStateMixin):
 
     @classmethod
     def global_update(cls):
-        # Call super first
-        super().global_update()
-
         # This should be globally update all values. If there are no values, we skip by default since there is nothing
         # being tracked currently
         n_values = len(cls.VALUES)

--- a/OmniGibson/omnigibson/object_states/toggle.py
+++ b/OmniGibson/omnigibson/object_states/toggle.py
@@ -4,13 +4,13 @@ import omnigibson as og
 import omnigibson.lazy as lazy
 from omnigibson.macros import create_module_macros
 from omnigibson.object_states.link_based_state_mixin import LinkBasedStateMixin
-from omnigibson.object_states.object_state_base import AbsoluteObjectState, BooleanStateMixin
+from omnigibson.object_states.object_state_base import BooleanStateMixin
 from omnigibson.object_states.open_state import Open
-from omnigibson.object_states.update_state_mixin import GlobalUpdateStateMixin, UpdateStateMixin
+from omnigibson.object_states.tensorized_value_state import TensorizedValueState
 from omnigibson.prims.geom_prim import GeomPrim
 from omnigibson.utils.constants import PrimType
 from omnigibson.utils.numpy_utils import vtarray_to_torch
-from omnigibson.utils.python_utils import classproperty
+from omnigibson.utils.python_utils import classproperty, torch_delete
 from omnigibson.utils.usd_utils import RigidContactAPI, absolute_prim_path_to_scene_relative, create_primitive_mesh
 
 # Create settings for this module
@@ -21,27 +21,145 @@ m.DEFAULT_SCALE = 0.1
 m.CAN_TOGGLE_STEPS = 5
 
 
-class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, UpdateStateMixin, GlobalUpdateStateMixin):
-    # List of set of prim paths defining robot finger links belonging to any manipulation robots per scene
+class ToggledOn(TensorizedValueState, BooleanStateMixin, LinkBasedStateMixin):
+    """
+    Boolean state representing whether a button-like object has been toggled on.
+
+    Tensorized storage
+    ------------------
+    Inherits TensorizedValueState. All per-object mutable values are stored in class-level
+    tensors and lists (same index as VALUES):
+
+        VALUES[:, 0]     — toggle on/off (float32, 0.0 = off / 1.0 = on)
+        VALUES[:, 1]     — robot_can_toggle_steps counter (float32, used as int)
+        _requires_closed — bool tensor (N,); construction-time constant
+        visual_markers   — list of GeomPrim; toggle-button visual indicator per object
+        scales           — list of float or Tensor; marker scale per object
+
+    Per-step scratch buffer
+    -----------------------
+    _scratch_masks is a pre-allocated (N, 6) bool tensor reused every step to avoid
+    per-call mask allocations. See column layout in the class body.
+
+    Per-instance state (not in class-level arrays):
+        self.scale      — temporary storage of constructor arg; used only during _initialize()
+                          to populate cls.scales[idx], not accessed at runtime
+    """
+
+    # list[set[str]]: robot finger prim paths per scene; refreshed every step in global_update
     _robot_finger_paths = None
 
-    # Set of objects that are contacting any manipulation robots
+    # set[StatefulObject]: objects in contact with any robot finger; refreshed every step
     _finger_contact_objs = None
 
+    # th.Tensor shape (N,) bool: whether each tracked object requires closed state to toggle on.
+    # Construction-time constant; same indexing as VALUES.
+    # Named with underscore to avoid collision with the @property requires_closed below.
+    _requires_closed = None
+
+    # list[GeomPrim]: visual toggle-button markers, one per tracked object (same idx as VALUES).
+    # Populated during _initialize(); used in _check_overlap and color updates.
+    visual_markers = None
+
+    # list[float | th.Tensor]: per-object marker scale (same idx as VALUES).
+    # Populated during _initialize(); used in _check_overlap for sphere radius.
+    scales = None
+
+    # th.Tensor shape (N, 6) bool: pre-allocated scratch buffer for _update_values.
+    # Resized when objects are added / removed; never reallocated mid-step.
+    # Column layout (fixed):
+    #   0  COL_OPEN        open_values (reused as active & ~can_toggle in step 4)
+    #   1  COL_FORCE_OFF   _requires_closed & open
+    #   2  COL_ACTIVE      ~force_off
+    #   3  COL_IN_CONTACT  in contact with finger & active
+    #   4  COL_CAN_TOGGLE  sphere overlap confirmed & in_contact
+    #   5  COL_FLIP        counter == CAN_TOGGLE_STEPS & active
+    _scratch_masks = None
+
+    # Class-level color constants: defined once, reused every flip and _set_value call.
+    # Avoids allocating new th.tensor([...]) on every color update.
+    COLOR_ON = th.tensor([0, 1.0, 0])  # green  — toggle is on
+    COLOR_OFF = th.tensor([1.0, 0, 0])  # red    — toggle is off
+
+    @classproperty
+    def value_shape(cls):
+        # Two floats per object: [toggle_state, robot_can_toggle_steps]
+        return (2,)
+
+    @classproperty
+    def value_type(cls):
+        # float32 for both fields; toggle_state is 0.0/1.0 (bool semantics),
+        # robot_can_toggle_steps is an integer stored as float.
+        return th.float32
+
+    @classproperty
+    def value_name(cls):
+        # Used by the parent's _dump_state / _load_state for the raw tensor column.
+        # Individual fields are accessed by column index, not by this key directly.
+        return "toggle_state"
+
+    @classmethod
+    def global_initialize(cls):
+        """
+        Initialize all class-level state for ToggledOn. Called once at simulator start
+        and on each clear/reset. Allocates VALUES (via super) and all auxiliary structures.
+        """
+        # Allocate VALUES, OBJ_IDXS, IDX_OBJS, CALLBACKS_ON_REMOVE, STATE_SIZE
+        super().global_initialize()
+
+        cls._robot_finger_paths = []
+        cls._finger_contact_objs = set()
+        cls._requires_closed = th.empty(0, dtype=th.bool)
+        cls.visual_markers = []
+        cls.scales = []
+        # Start with zero rows; resized in _add_obj / _remove_obj as objects arrive.
+        cls._scratch_masks = th.zeros((0, 6), dtype=th.bool)
+
+    @classmethod
+    def _add_obj(cls, obj):
+        # Append a row to VALUES and update OBJ_IDXS / IDX_OBJS via parent.
+        super()._add_obj(obj=obj)
+        # _requires_closed placeholder (False); overwritten in __init__ immediately after.
+        cls._requires_closed = th.cat([cls._requires_closed, th.tensor([False])])
+        # visual_markers and scales are populated in _initialize(); use None as placeholder.
+        cls.visual_markers.append(None)
+        cls.scales.append(None)
+        # Grow scratch buffer by one zero row to match new N.
+        cls._scratch_masks = th.cat([cls._scratch_masks, th.zeros((1, 6), dtype=th.bool)], dim=0)
+
+    @classmethod
+    def _remove_obj(cls, obj):
+        """Remove all class-level entries for obj before delegating to the parent."""
+        # Always read deleted_idx first, before any list/tensor deletions and before super().
+        deleted_idx = cls.OBJ_IDXS[obj]
+        cls._requires_closed = torch_delete(cls._requires_closed, [deleted_idx])
+        del cls.visual_markers[deleted_idx]
+        del cls.scales[deleted_idx]
+        cls._scratch_masks = torch_delete(cls._scratch_masks, [deleted_idx])
+        # Parent handles VALUES, OBJ_IDXS, IDX_OBJS cleanup.
+        super()._remove_obj(obj=obj)
+
     def __init__(self, obj, scale=None, requires_closed=False):
+        # self.scale is a temporary instance variable used only during _initialize() to
+        # resolve the final marker scale and store it in cls.scales[idx].
+        # It is not accessed after initialization.
         self.scale = scale
-        self.value = False
-        self.robot_can_toggle_steps = 0
-        self.visual_marker = None
 
         if requires_closed:
-            assert Open in obj.states
-        self.requires_closed = requires_closed
+            assert Open in obj.states, f"ToggledOn requires_closed=True but {obj.name} has no Open state."
 
-        # We also generate the function for checking overlaps at runtime
-        self._check_overlap = None
-
+        # super().__init__ calls _add_obj, which appends rows to VALUES, _requires_closed,
+        # visual_markers, scales, and _scratch_masks.
         super().__init__(obj)
+
+        # Write the constructor flag into the class-level bool tensor at this object's index.
+        # Done after super().__init__ so that OBJ_IDXS[obj] is already populated.
+        type(self)._requires_closed[self.OBJ_IDXS[obj]] = requires_closed
+
+    @property
+    def requires_closed(self):
+        """Read-only bool view into the class-level _requires_closed tensor for this object."""
+        return bool(type(self)._requires_closed[self.OBJ_IDXS[self.obj]].item())
 
     @classmethod
     def is_compatible(cls, obj, **kwargs):
@@ -77,10 +195,18 @@ class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, Upd
 
     @classmethod
     def global_update(cls):
-        # Clear finger contact objects since it will be refreshed now
+        """
+        Step 1 — Contact collection:
+            Refresh _robot_finger_paths and _finger_contact_objs from RigidContactAPI once per step.
+            This mirrors the original global_update() behavior.
+
+        Step 2 — Tensorized value update:
+            Delegate to TensorizedValueState.global_update(), which calls _update_values() and
+            fires state_updated() for any object whose VALUES row changed.
+        """
+        # Step 1 - refresh finger contact data
         cls._finger_contact_objs = set()
 
-        # detect marker and hand interaction
         cls._robot_finger_paths = [
             {
                 link.prim_path
@@ -92,38 +218,163 @@ class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, Upd
             for scene in og.sim.scenes
         ]
 
-        # If there aren't any valid robot link paths, immediately return
-        if not any(len(robot_finger_paths) > 0 for robot_finger_paths in cls._robot_finger_paths):
-            return
+        # Only query contacts if at least one manipulation robot is present.
+        if any(len(paths) > 0 for paths in cls._robot_finger_paths):
+            for scene_idx, (scene, scene_finger_paths) in enumerate(zip(og.sim.scenes, cls._robot_finger_paths)):
+                if len(scene_finger_paths) == 0:
+                    continue
 
-        for scene_idx, (scene, scene_robot_finger_paths) in enumerate(zip(og.sim.scenes, cls._robot_finger_paths)):
-            if len(scene_robot_finger_paths) == 0:
-                continue
+                # Get the robot finger prim paths' contacts
+                contact_pairs = RigidContactAPI.get_contact_pairs(scene_idx, scene_finger_paths)
+                for contact_pair in contact_pairs:
+                    obj = scene.object_registry("prim_path", "/".join(contact_pair[1].split("/")[:-1]))
+                    if obj is not None:
+                        cls._finger_contact_objs.add(obj)
 
-            # Get the robot finger prim paths' contacts
-            contact_pairs = RigidContactAPI.get_contact_pairs(scene_idx, scene_robot_finger_paths)
-            for contact_pair in contact_pairs:
-                obj = scene.object_registry("prim_path", "/".join(contact_pair[1].split("/")[:-1]))
-                if obj is not None:
-                    cls._finger_contact_objs.add(obj)
+        # Step 2 - batch value update (calls _update_values, then fires state_updated)
+        super().global_update()
 
     @classproperty
     def meta_link_types(cls):
         return [m.TOGGLE_META_LINK_TYPE]
 
+    @classmethod
+    def _check_overlap(cls, idx):
+        """
+        Check whether any robot finger overlaps the toggle-button marker sphere for the object
+        at class-level index idx.
+
+        Args:
+            idx (int): Index into cls.IDX_OBJS / cls.visual_markers / cls.scales.
+
+        Returns:
+            bool: True if a robot finger overlaps the marker sphere.
+        """
+        valid_hit = False
+        all_finger_paths = {path for path_set in cls._robot_finger_paths for path in path_set}
+
+        def overlap_callback(hit):
+            nonlocal valid_hit
+            valid_hit = hit.rigid_body in all_finger_paths
+            # Continue traversal only if we don't have a valid hit yet
+            return not valid_hit
+
+        marker = cls.visual_markers[idx]
+        scale = cls.scales[idx]
+        # TODO: This is a temporary fix for flatcache before we properly implement trigger volumes
+        og.sim.psqi.overlap_sphere(
+            radius=th.min(marker.extent * scale).item(),
+            pos=marker.get_position_orientation()[0].tolist(),
+            reportFn=overlap_callback,
+        )
+        # if marker.prim.GetTypeName() == "Mesh":
+        #     og.sim.psqi.overlap_mesh(*projection_mesh_ids, reportFn=overlap_callback)
+        # else:
+        #     og.sim.psqi.overlap_shape(*projection_mesh_ids, reportFn=overlap_callback)
+        return valid_hit
+
+    @classmethod
+    def _update_values(cls, values):
+        """
+        Vectorized per-step update for all tracked ToggledOn instances. Mimics the original
+        per-object _update() logic using tensor operations and a pre-allocated scratch buffer.
+
+        Scratch buffer column layout (see class variables):
+            COL_OPEN=0  COL_FORCE_OFF=1  COL_ACTIVE=2
+            COL_IN_CONTACT=3  COL_CAN_TOGGLE=4  COL_FLIP=5
+        Column 0 (COL_OPEN) is reused in step 4 as "active & ~can_toggle" temp once step 1 is done.
+
+        Logic:
+          1. requires_closed guard  — force off objects that must be closed but are open.
+          2. Contact mask           — which active objects have a finger nearby.
+          3. Overlap check          — of those, which truly overlap the marker sphere.
+          4. Counter update         — increment for can_toggle, reset for active & ~can_toggle.
+          5. Toggle flip            — flip state for objects whose counter hit CAN_TOGGLE_STEPS.
+          6. Color sync             — update visual marker color for flipped objects.
+
+        Args:
+            values (th.Tensor): Shape (N, 2). col 0 = toggle state, col 1 = step counter.
+
+        Returns:
+            th.Tensor: Updated values tensor (clone of input with modifications applied).
+        """
+        # Single clone — required so the base class can detect changes via new_values != cls.VALUES.
+        new_values = values.clone()
+
+        # Column index constants (defined locally for readability; no object creation overhead).
+        COL_OPEN, COL_FORCE_OFF, COL_ACTIVE, COL_IN_CONTACT, COL_CAN_TOGGLE, COL_FLIP = range(6)
+
+        # Reset all scratch columns for this step (in-place fill, no allocation).
+        cls._scratch_masks.fill_(False)
+
+        # Step 1: requires_closed guard.
+        # Open is not tensorized; loop only over the _requires_closed subset.
+        for i in th.where(cls._requires_closed)[0].tolist():
+            cls._scratch_masks[i, COL_OPEN] = cls.IDX_OBJS[i].states[Open].get_value()
+
+        th.logical_and(cls._requires_closed, cls._scratch_masks[:, COL_OPEN], out=cls._scratch_masks[:, COL_FORCE_OFF])
+        th.logical_not(cls._scratch_masks[:, COL_FORCE_OFF], out=cls._scratch_masks[:, COL_ACTIVE])
+        # Zero out both toggle state and step counter for force-off objects (in-place).
+        new_values[cls._scratch_masks[:, COL_FORCE_OFF]] = 0.0
+
+        # Step 2: contact mask.
+        for i, obj in enumerate(cls.IDX_OBJS):
+            cls._scratch_masks[i, COL_IN_CONTACT] = obj in cls._finger_contact_objs
+        # Only active objects proceed to overlap check.
+        cls._scratch_masks[:, COL_IN_CONTACT] &= cls._scratch_masks[:, COL_ACTIVE]
+
+        # Step 3: overlap check (unavoidable per-object; only for in-contact subset).
+        for i in th.where(cls._scratch_masks[:, COL_IN_CONTACT])[0].tolist():
+            cls._scratch_masks[i, COL_CAN_TOGGLE] = cls._check_overlap(i)
+
+        # Step 4: step counter update.
+        # Increment counter for can_toggle objects (can_toggle ⊆ in_contact ⊆ active).
+        new_values[cls._scratch_masks[:, COL_CAN_TOGGLE], 1] += 1
+        # Reset counter for active objects that cannot toggle.
+        # Reuse COL_OPEN (step 1 data no longer needed) to avoid allocating a new mask tensor.
+        th.logical_and(
+            cls._scratch_masks[:, COL_ACTIVE],
+            ~cls._scratch_masks[:, COL_CAN_TOGGLE],
+            out=cls._scratch_masks[:, COL_OPEN],
+        )
+        new_values[cls._scratch_masks[:, COL_OPEN], 1] = 0.0
+
+        # Step 5: toggle flip.
+        th.eq(new_values[:, 1], m.CAN_TOGGLE_STEPS, out=cls._scratch_masks[:, COL_FLIP])
+        cls._scratch_masks[:, COL_FLIP] &= cls._scratch_masks[:, COL_ACTIVE]
+        new_values[cls._scratch_masks[:, COL_FLIP], 0] = 1.0 - values[cls._scratch_masks[:, COL_FLIP], 0]
+
+        # Step 6: sync visual marker colors for flipped objects.
+        # Per-object USD color write; unavoidable loop, runs only for the flipped subset.
+        # Uses class-level COLOR_ON / COLOR_OFF constants — no per-flip tensor allocation.
+        for i in th.where(cls._scratch_masks[:, COL_FLIP])[0].tolist():
+            cls.visual_markers[i].color = cls.COLOR_ON if bool(new_values[i, 0].item()) else cls.COLOR_OFF
+
+        return new_values
+
     def _get_value(self):
-        return self.value
+        # Return toggle boolean from column 0 of the shared VALUES tensor.
+        return bool(self.VALUES[self.OBJ_IDXS[self.obj], 0].item())
 
     def _set_value(self, new_value):
+        """
+        Set the toggle state directly (e.g. from BDDL task initialization or external scripts).
+        Also syncs the visual marker color using the class-level COLOR_ON / COLOR_OFF constants.
+
+        Args:
+            new_value (bool): Desired toggle on/off state.
+
+        Returns:
+            bool: True if set successfully; False if blocked by requires_closed + Open state.
+        """
         if new_value and self.requires_closed and self.obj.states[Open].get_value():
             # If the object is open, we cannot toggle it on
             return False
 
-        self.value = new_value
-
-        # Choose which color to apply to the toggle marker
-        self.visual_marker.color = th.tensor([0, 1.0, 0]) if self.value else th.tensor([1.0, 0, 0])
-
+        idx = self.OBJ_IDXS[self.obj]
+        self.VALUES[idx, 0] = 1.0 if new_value else 0.0
+        # Green = on, red = off. Use class-level constants to avoid per-call tensor allocation.
+        type(self).visual_markers[idx].color = type(self).COLOR_ON if new_value else type(self).COLOR_OFF
         return True
 
     def _initialize(self):
@@ -143,17 +394,13 @@ class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, Upd
             mesh_prim_path = f"{self.link.prim_path}/mesh_0"
             pre_existing_mesh = lazy.isaacsim.core.utils.prims.get_prim_at_path(mesh_prim_path)
 
-        # Create a primitive mesh neither option exists
+        # Create a primitive mesh if neither option exists
         if not pre_existing_mesh:
             mesh_prim_path = f"{self.link.prim_path}/visuals/mesh_0"
             self.scale = m.DEFAULT_SCALE if self.scale is None else self.scale
-            # Note: We have to create a mesh (instead of a sphere shape) because physx complains about non-uniform
-            # scaling for non-meshes
-            create_primitive_mesh(
-                prim_path=mesh_prim_path,
-                primitive_type="Sphere",
-                extents=1.0,
-            )
+            # Note: We have to create a mesh (instead of a sphere shape) because physx complains
+            # about non-uniform scaling for non-meshes
+            create_primitive_mesh(prim_path=mesh_prim_path, primitive_type="Sphere", extents=1.0)
         else:
             # Infer radius from mesh if not specified as an input
             lazy.isaacsim.core.utils.bounds.recompute_extents(prim=pre_existing_mesh)
@@ -161,71 +408,24 @@ class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, Upd
 
         # Create the visual geom instance referencing the generated mesh prim
         relative_prim_path = absolute_prim_path_to_scene_relative(self.obj.scene, mesh_prim_path)
-        self.visual_marker = GeomPrim(relative_prim_path=relative_prim_path, name=f"{self.obj.name}_visual_marker")
-        self.visual_marker.load(self.obj.scene)
-        self.visual_marker.scale = self.scale
-        self.visual_marker.initialize()
-        self.visual_marker.visible = True
+        marker = GeomPrim(relative_prim_path=relative_prim_path, name=f"{self.obj.name}_visual_marker")
+        marker.load(self.obj.scene)
+        marker.scale = self.scale
+        marker.initialize()
+        marker.visible = True
 
         # Store the projection mesh's IDs
-        # projection_mesh_ids = lazy.pxr.PhysicsSchemaTools.encodeSdfPath(self.visual_marker.prim_path)
+        # projection_mesh_ids = lazy.pxr.PhysicsSchemaTools.encodeSdfPath(marker.prim_path)
 
-        # Define function for checking overlap
-        valid_hit = False
+        # Store marker and resolved scale in the class-level lists at this object's index.
+        # Both are accessed by _check_overlap() and _update_values() at the class level.
+        idx = self.OBJ_IDXS[self.obj]
+        type(self).visual_markers[idx] = marker
+        type(self).scales[idx] = self.scale
 
-        def overlap_callback(hit):
-            nonlocal valid_hit
-            all_finger_paths = {path for path_set in self._robot_finger_paths for path in path_set}
-            valid_hit = hit.rigid_body in all_finger_paths
-            # Continue traversal only if we don't have a valid hit yet
-            return not valid_hit
-
-        # Set this value to be False by default
-        self._set_value(False)
-
-        def check_overlap():
-            nonlocal valid_hit
-            valid_hit = False
-            # TODO: This is a temporary fix for flatcache before we properly implement trigger volumes
-            og.sim.psqi.overlap_sphere(
-                radius=th.min(self.visual_marker.extent * self.scale).item(),
-                pos=self.visual_marker.get_position_orientation()[0].tolist(),
-                reportFn=overlap_callback,
-            )
-            # if self.visual_marker.prim.GetTypeName() == "Mesh":
-            #     og.sim.psqi.overlap_mesh(*projection_mesh_ids, reportFn=overlap_callback)
-            # else:
-            #     og.sim.psqi.overlap_shape(*projection_mesh_ids, reportFn=overlap_callback)
-            return valid_hit
-
-        self._check_overlap = check_overlap
-
-    def _update(self):
-        # If the object is required to be closed to toggle on, and it is not, we turn it off and stop.
-        if self.requires_closed and self.obj.states[Open].get_value():
-            self.set_value(False)
-            self.robot_can_toggle_steps = 0
-            return
-
-        # If we're not nearby any fingers, we automatically can't toggle
-        if self.obj not in self._finger_contact_objs:
-            robot_can_toggle = False
-        else:
-            # Check to make sure fingers are actually overlapping the toggle button mesh
-            robot_can_toggle = self._check_overlap()
-
-        previous_step = self.robot_can_toggle_steps
-        if robot_can_toggle:
-            self.robot_can_toggle_steps += 1
-        else:
-            self.robot_can_toggle_steps = 0
-
-        # If step size is different, add this object to the current state update set in its scene
-        if previous_step != self.robot_can_toggle_steps:
-            self.obj.state_updated()
-
-        if self.robot_can_toggle_steps == m.CAN_TOGGLE_STEPS:
-            self.set_value(not self.value)
+        # VALUES[idx, 0] was initialized to 0.0 (off) by _add_obj(). Sync the marker color.
+        # This replaces the former self._set_value(False) call.
+        marker.color = type(self).COLOR_OFF
 
     @staticmethod
     def get_texture_change_params():
@@ -236,19 +436,26 @@ class ToggledOn(AbsoluteObjectState, BooleanStateMixin, LinkBasedStateMixin, Upd
 
     @property
     def state_size(self):
+        # Two floats: toggle_state + robot_can_toggle_steps. Same as the pre-tensorized value.
         return 2
 
     # For this state, we simply store its value and the robot_can_toggle steps.
     def _dump_state(self):
-        return dict(value=self.value, hand_in_marker_steps=self.robot_can_toggle_steps)
+        idx = self.OBJ_IDXS[self.obj]
+        return dict(
+            value=bool(self.VALUES[idx, 0].item()),
+            hand_in_marker_steps=int(self.VALUES[idx, 1].item()),
+        )
 
     def _load_state(self, state):
-        # Nothing special to do here when initialized vs. uninitialized
+        # Restore toggle via _set_value so the visual marker color is also updated.
         self._set_value(state["value"])
-        self.robot_can_toggle_steps = state["hand_in_marker_steps"]
+        # Restore step counter directly into the tensor.
+        self.VALUES[self.OBJ_IDXS[self.obj], 1] = float(state["hand_in_marker_steps"])
 
     def serialize(self, state):
+        # [toggle_state, can_toggle_steps] as float32
         return th.tensor([state["value"], state["hand_in_marker_steps"]], dtype=th.float32)
 
     def deserialize(self, state):
-        return dict(value=bool(state[0]), hand_in_marker_steps=int(state[1])), 2
+        return dict(value=bool(state[0].item()), hand_in_marker_steps=int(state[1].item())), 2

--- a/OmniGibson/omnigibson/object_states/touching.py
+++ b/OmniGibson/omnigibson/object_states/touching.py
@@ -54,6 +54,31 @@ class Touching(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
 
     @classmethod
     def _rebuild_block_state(cls):
+        """
+        (Re)build all pre-allocated tensors that map objects to their rows/cols in the
+        physics contact matrix.  Must be called whenever the set of tracked objects changes
+        (object added or removed).
+
+        Layout
+        ------
+        RigidContactAPI exposes a per-scene contact matrix of shape (R, C).  Each rigid body
+        occupies a contiguous slice of rows (as reporter) and a contiguous slice of columns
+        (as reportee).  We pre-build two block-diagonal projection matrices:
+
+          _BLOCK_OBJ_TO_CONTACT_ROWS  (N_total, R_total) float32
+          _BLOCK_OBJ_TO_CONTACT_COLS  (N_total, C_total) float32
+
+        Row i of each matrix is a 0/1 mask that selects the contact-matrix rows/cols that
+        belong to object i.  Scenes are stacked block-diagonally so multi-scene environments
+        are handled with a single pair of matmuls.
+
+        _BLOCK_CONTACT_MATRIX  (R_total, C_total) float32
+          Pre-allocated buffer filled in-place every step from the live physics data.
+
+        _INTER_OBJECT_TOUCHING_MATRIX  (N_total, N_total) bool
+          Final output: entry [i, j] is True when objects i and j are in contact.
+          Updated by global_update() each step.
+        """
         if not cls._IDX_OBJS:
             cls._BLOCK_OBJ_TO_CONTACT_ROWS = None
             cls._BLOCK_OBJ_TO_CONTACT_COLS = None
@@ -106,10 +131,20 @@ class Touching(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
 
     @classmethod
     def global_update(cls):
+        """
+        Refresh _INTER_OBJECT_TOUCHING_MATRIX from the current physics contact cache.
+
+        Called automatically every sim step via the normal global_update machinery.
+        May also be called manually after og.sim.step_physics()-only sequences (e.g.
+        sample_kinematics) when the raw contact cache is fresh but the touching matrix
+        would otherwise be stale.
+        """
         if cls._BLOCK_CONTACT_MATRIX is None:
             return
 
-        # Fill pre-allocated block contact matrix in-place (no allocation)
+        # Pull the latest contact data from physics into the pre-allocated buffer.
+        # step_physics() already keeps RigidContactAPI's raw cache current, so this
+        # is just a copy into our block layout — no physics query overhead.
         RigidContactAPI.update_block_contact_matrix(
             cls._ACTIVE_SCENE_IDXS,
             cls._BLOCK_CONTACT_MATRIX,
@@ -117,14 +152,16 @@ class Touching(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
             cls._SCENE_COL_OFFSETS,
         )
 
-        # Two matmuls → (N_total, N_total) one-way contact
+        # Two matmuls produce (N_total, N_total) one-way contact:
+        #   one_way[i, j] = 1  iff object i reports contact with object j
         one_way = RigidContactAPI.compute_pairwise_contacts(
             cls._BLOCK_CONTACT_MATRIX,
             cls._BLOCK_OBJ_TO_CONTACT_ROWS,
             cls._BLOCK_OBJ_TO_CONTACT_COLS,
         )
 
-        # Symmetrize — kinematic objects have no rows, so OR both directions
+        # Symmetrize via OR: kinematic objects have no contact rows of their own,
+        # so contact is only reported in one direction; OR catches both cases.
         cls._INTER_OBJECT_TOUCHING_MATRIX[:] = one_way | one_way.T
         cls._INTER_OBJECT_TOUCHING_MATRIX.fill_diagonal_(False)
 

--- a/OmniGibson/omnigibson/object_states/touching.py
+++ b/OmniGibson/omnigibson/object_states/touching.py
@@ -67,10 +67,10 @@ class Touching(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
         r_off = c_off = 0
 
         for scene_idx in cls._ACTIVE_SCENE_IDXS:
-            cm = RigidContactAPI.get_contact_matrix(scene_idx)
-            if cm is None:
+            contact_matrix = RigidContactAPI.get_contact_matrix(scene_idx)
+            if contact_matrix is None:
                 continue
-            R, C = cm.shape
+            R, C = contact_matrix.shape
             scene_objs = [obj for obj in cls._IDX_OBJS if obj.scene.idx == scene_idx]
             N = len(scene_objs)
             row_masks = th.zeros((N, R), dtype=th.float32)

--- a/OmniGibson/omnigibson/object_states/touching.py
+++ b/OmniGibson/omnigibson/object_states/touching.py
@@ -1,3 +1,5 @@
+import torch as th
+
 from omnigibson.utils.usd_utils import RigidContactAPI
 from omnigibson.object_states.kinematics_mixin import KinematicsMixin
 from omnigibson.object_states.object_state_base import BooleanStateMixin, RelativeObjectState
@@ -5,17 +7,126 @@ from omnigibson.utils.constants import PrimType
 
 
 class Touching(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
-    @staticmethod
-    def _check_rigid_contact(obj_a, obj_b):
-        # If both objects are kinematic, we can't check for contact.
-        if obj_a.kinematic_only and obj_b.kinematic_only:
-            return False
-        # Find a kinematic object and check for contact with the other object.
-        kinematic_obj = obj_a if obj_a.kinematic_only else obj_b
-        non_kinematic_obj = obj_b if obj_a.kinematic_only else obj_a
-        return RigidContactAPI.is_in_contact(
-            scene_idx=kinematic_obj.scene.idx, query_set=[non_kinematic_obj], with_set=[kinematic_obj]
+    # ── Core output ─────────────────────────────────────────────────────────
+    _INTER_OBJECT_TOUCHING_MATRIX = None  # (N_total, N_total) bool — single tensor, updated in-place
+
+    # ── Global object tracking ──────────────────────────────────────────────
+    _OBJ_IDXS = None  # dict[obj → int] — global index across all scenes
+    _IDX_OBJS = None  # list[obj]        — global list
+
+    # ── Rigid path — pre-built at init/add/remove, never rebuilt mid-step ───
+    _BLOCK_OBJ_TO_CONTACT_ROWS = None  # (N_total, R_total) float — pre-built block-diagonal
+    _BLOCK_OBJ_TO_CONTACT_COLS = None  # (N_total, C_total) float — pre-built block-diagonal
+    _BLOCK_CONTACT_MATRIX = None  # (R_total, C_total) float — pre-allocated, filled in-place each step
+    _ACTIVE_SCENE_IDXS = None  # list[int]  — ordered scene list
+    _SCENE_ROW_OFFSETS = None  # list[int]  — row start per scene in block layout
+    _SCENE_COL_OFFSETS = None  # list[int]  — col start per scene in block layout
+
+    @classmethod
+    def global_initialize(cls):
+        cls._INTER_OBJECT_TOUCHING_MATRIX = None
+        cls._OBJ_IDXS = {}
+        cls._IDX_OBJS = []
+        cls._BLOCK_OBJ_TO_CONTACT_ROWS = None
+        cls._BLOCK_OBJ_TO_CONTACT_COLS = None
+        cls._BLOCK_CONTACT_MATRIX = None
+        cls._ACTIVE_SCENE_IDXS = None
+        cls._SCENE_ROW_OFFSETS = None
+        cls._SCENE_COL_OFFSETS = None
+
+    def _initialize(self):
+        super()._initialize()
+        if Touching._OBJ_IDXS is None:
+            Touching.global_initialize()
+        idx = len(Touching._IDX_OBJS)
+        Touching._IDX_OBJS.append(self.obj)
+        Touching._OBJ_IDXS[self.obj] = idx
+        Touching._rebuild_block_state()
+
+    def remove(self):
+        if self.obj in Touching._OBJ_IDXS:
+            old_idx = Touching._OBJ_IDXS.pop(self.obj)
+            Touching._IDX_OBJS.pop(old_idx)
+            # Rebuild the index map from the (now shortened) list
+            Touching._OBJ_IDXS = {obj: i for i, obj in enumerate(Touching._IDX_OBJS)}
+            Touching._rebuild_block_state()
+        super().remove()
+
+    @classmethod
+    def _rebuild_block_state(cls):
+        if not cls._IDX_OBJS:
+            cls._BLOCK_OBJ_TO_CONTACT_ROWS = None
+            cls._BLOCK_OBJ_TO_CONTACT_COLS = None
+            cls._BLOCK_CONTACT_MATRIX = None
+            cls._INTER_OBJECT_TOUCHING_MATRIX = None
+            return
+
+        cls._ACTIVE_SCENE_IDXS = sorted({obj.scene.idx for obj in cls._IDX_OBJS})
+        per_scene_row_masks, per_scene_col_masks = [], []
+        cls._SCENE_ROW_OFFSETS, cls._SCENE_COL_OFFSETS = [], []
+        r_off = c_off = 0
+
+        for scene_idx in cls._ACTIVE_SCENE_IDXS:
+            cm = RigidContactAPI.get_contact_matrix(scene_idx)
+            if cm is None:
+                continue
+            R, C = cm.shape
+            scene_objs = [obj for obj in cls._IDX_OBJS if obj.scene.idx == scene_idx]
+            N = len(scene_objs)
+            row_masks = th.zeros((N, R), dtype=th.float32)
+            col_masks = th.zeros((N, C), dtype=th.float32)
+            for local_i, obj in enumerate(scene_objs):
+                if obj.prim_type != PrimType.CLOTH:
+                    row_idxs = RigidContactAPI.get_contact_row_indices(scene_idx, [obj])
+                    col_idxs = RigidContactAPI.get_contact_col_indices(scene_idx, [obj])
+                    if len(row_idxs):
+                        row_masks[local_i, row_idxs] = 1.0
+                    if len(col_idxs):
+                        col_masks[local_i, col_idxs] = 1.0
+            per_scene_row_masks.append(row_masks)
+            per_scene_col_masks.append(col_masks)
+            cls._SCENE_ROW_OFFSETS.append(r_off)
+            cls._SCENE_COL_OFFSETS.append(c_off)
+            r_off += R
+            c_off += C
+
+        if not per_scene_row_masks:
+            return
+
+        cls._BLOCK_OBJ_TO_CONTACT_ROWS = th.block_diag(*per_scene_row_masks)  # (N_total, R_total)
+        cls._BLOCK_OBJ_TO_CONTACT_COLS = th.block_diag(*per_scene_col_masks)  # (N_total, C_total)
+        # Pre-allocate block contact matrix — filled in-place each step, never reallocated
+        cls._BLOCK_CONTACT_MATRIX = th.zeros(
+            cls._BLOCK_OBJ_TO_CONTACT_ROWS.shape[1],  # R_total
+            cls._BLOCK_OBJ_TO_CONTACT_COLS.shape[1],  # C_total
+            dtype=th.float32,
         )
+        N_total = len(cls._IDX_OBJS)
+        cls._INTER_OBJECT_TOUCHING_MATRIX = th.zeros((N_total, N_total), dtype=th.bool)
+
+    @classmethod
+    def global_update(cls):
+        if cls._BLOCK_CONTACT_MATRIX is None:
+            return
+
+        # Fill pre-allocated block contact matrix in-place (no allocation)
+        RigidContactAPI.update_block_contact_matrix(
+            cls._ACTIVE_SCENE_IDXS,
+            cls._BLOCK_CONTACT_MATRIX,
+            cls._SCENE_ROW_OFFSETS,
+            cls._SCENE_COL_OFFSETS,
+        )
+
+        # Two matmuls → (N_total, N_total) one-way contact
+        one_way = RigidContactAPI.compute_pairwise_contacts(
+            cls._BLOCK_CONTACT_MATRIX,
+            cls._BLOCK_OBJ_TO_CONTACT_ROWS,
+            cls._BLOCK_OBJ_TO_CONTACT_COLS,
+        )
+
+        # Symmetrize — kinematic objects have no rows, so OR both directions
+        cls._INTER_OBJECT_TOUCHING_MATRIX[:] = one_way | one_way.T
+        cls._INTER_OBJECT_TOUCHING_MATRIX.fill_diagonal_(False)
 
     @staticmethod
     def _check_cloth_contact(cloth_obj, other_obj):
@@ -23,12 +134,17 @@ class Touching(KinematicsMixin, RelativeObjectState, BooleanStateMixin):
         return any(contact_prim_path in other_link_paths for contact_prim_path, _ in cloth_obj.root_link.get_contacts())
 
     def _get_value(self, other):
-        if self.obj.prim_type == PrimType.CLOTH and other.prim_type == PrimType.CLOTH:
-            raise ValueError("Cannot detect contact between two cloth objects.")
-        # If one of the objects is cloth, rely on cloth's get_contacts() method (RigidContactAPI does not include cloth).
-        elif self.obj.prim_type == PrimType.CLOTH:
-            return self._check_cloth_contact(self.obj, other)
-        elif other.prim_type == PrimType.CLOTH:
-            return self._check_cloth_contact(other, self.obj)
-        else:
-            return self._check_rigid_contact(other, self.obj) and self._check_rigid_contact(self.obj, other)
+        # Cloth path: fall back to per-call check
+        if self.obj.prim_type == PrimType.CLOTH or other.prim_type == PrimType.CLOTH:
+            if self.obj.prim_type == PrimType.CLOTH and other.prim_type == PrimType.CLOTH:
+                raise ValueError("Cannot detect contact between two cloth objects.")
+            cloth_obj = self.obj if self.obj.prim_type == PrimType.CLOTH else other
+            rigid_obj = other if self.obj.prim_type == PrimType.CLOTH else self.obj
+            return self._check_cloth_contact(cloth_obj, rigid_obj)
+
+        # Rigid path: O(1) matrix lookup
+        if Touching._INTER_OBJECT_TOUCHING_MATRIX is None:
+            return False
+        i = Touching._OBJ_IDXS[self.obj]
+        j = Touching._OBJ_IDXS[other]
+        return bool(Touching._INTER_OBJECT_TOUCHING_MATRIX[i, j].item())

--- a/OmniGibson/omnigibson/object_states/update_state_mixin.py
+++ b/OmniGibson/omnigibson/object_states/update_state_mixin.py
@@ -27,30 +27,3 @@ class UpdateStateMixin(BaseObjectState):
         classes = super()._do_not_register_classes
         classes.add("UpdateStateMixin")
         return classes
-
-
-class GlobalUpdateStateMixin(BaseObjectState):
-    """
-    A state-mixin that allows for per-sim-step global updates via the global_update() call
-    """
-
-    @classmethod
-    def global_initialize(cls):
-        """
-        Executes a global initialization sequence for this state. Default is no-op
-        """
-        pass
-
-    @classmethod
-    def global_update(cls):
-        """
-        Executes a global update for this object state. Default is no-op
-        """
-        pass
-
-    @classproperty
-    def _do_not_register_classes(cls):
-        # Don't register this class since it's an abstract template
-        classes = super()._do_not_register_classes
-        classes.add("GlobalUpdateStateMixin")
-        return classes

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -22,6 +22,9 @@ from omnigibson.macros import create_module_macros, gm
 from omnigibson.object_states.factory import get_states_by_dependency_order
 from omnigibson.object_states.joint_break_subscribed_state_mixin import JointBreakSubscribedStateMixin
 from omnigibson.object_states.tensorized_value_state import TensorizedValueState
+from omnigibson.object_states.touching import (
+    Touching,
+)  # This is temporary because we haven't implemented RelativeTensorizedStates yet
 from omnigibson.object_states.update_state_mixin import UpdateStateMixin
 from omnigibson.objects.light_object import LightObject
 from omnigibson.objects.object_base import BaseObject
@@ -496,7 +499,7 @@ def _launch_simulator(*args, **kwargs):
             self.object_state_types_requiring_update = [
                 state
                 for state in self.object_state_types
-                if (issubclass(state, UpdateStateMixin) or issubclass(state, TensorizedValueState))
+                if (issubclass(state, UpdateStateMixin) or issubclass(state, TensorizedValueState) or state is Touching)
             ]
             self.object_state_types_on_joint_break = {
                 state for state in self.object_state_types if issubclass(state, JointBreakSubscribedStateMixin)
@@ -510,7 +513,7 @@ def _launch_simulator(*args, **kwargs):
             self.stop()
 
             for state in self.object_state_types_requiring_update:
-                if issubclass(state, TensorizedValueState):
+                if issubclass(state, TensorizedValueState) or state is Touching:
                     state.global_initialize()
 
             # Now start rebuilding everything
@@ -1106,7 +1109,7 @@ def _launch_simulator(*args, **kwargs):
                 if gm.ENABLE_OBJECT_STATES:
                     # Step the object states in global topological order (if the scene exists)
                     for state_type in self.object_state_types_requiring_update:
-                        if issubclass(state_type, TensorizedValueState):
+                        if issubclass(state_type, TensorizedValueState) or state_type is Touching:
                             state_type.global_update()
                         if issubclass(state_type, UpdateStateMixin):
                             for scene in self.scenes:
@@ -1743,7 +1746,7 @@ def _launch_simulator(*args, **kwargs):
 
             # Clear all global update states
             for state in self.object_state_types_requiring_update:
-                if issubclass(state, TensorizedValueState):
+                if issubclass(state, TensorizedValueState) or state is Touching:
                     state.global_initialize()
 
             # Clear all materials

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -14,25 +14,6 @@ from contextlib import nullcontext
 from pathlib import Path
 from cProfile import Profile
 
-
-def with_profiler(name):
-    def decorator(fn):
-        @functools.wraps(fn)
-        def wrapper(self, *args, **kwargs):
-            profiler = getattr(self, name)
-            if profiler is not None:
-                profiler.enable()
-            try:
-                return fn(self, *args, **kwargs)
-            finally:
-                if profiler is not None:
-                    profiler.disable()
-
-        return wrapper
-
-    return decorator
-
-
 import torch as th
 
 import omnigibson as og
@@ -40,7 +21,8 @@ import omnigibson.lazy as lazy
 from omnigibson.macros import create_module_macros, gm
 from omnigibson.object_states.factory import get_states_by_dependency_order
 from omnigibson.object_states.joint_break_subscribed_state_mixin import JointBreakSubscribedStateMixin
-from omnigibson.object_states.update_state_mixin import GlobalUpdateStateMixin, UpdateStateMixin
+from omnigibson.object_states.tensorized_value_state import TensorizedValueState
+from omnigibson.object_states.update_state_mixin import UpdateStateMixin
 from omnigibson.objects.light_object import LightObject
 from omnigibson.objects.object_base import BaseObject
 from omnigibson.prims import XFormPrim
@@ -67,9 +49,28 @@ from omnigibson.utils.usd_utils import (
     ControllableObjectViewAPI,
     PoseAPI,
     RigidContactAPI,
+    clear as clear_usd_utils,
+    triangularize_mesh,
 )
-from omnigibson.utils.usd_utils import clear as clear_usd_utils
-from omnigibson.utils.usd_utils import triangularize_mesh
+
+
+def with_profiler(name):
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            profiler = getattr(self, name)
+            if profiler is not None:
+                profiler.enable()
+            try:
+                return fn(self, *args, **kwargs)
+            finally:
+                if profiler is not None:
+                    profiler.disable()
+
+        return wrapper
+
+    return decorator
+
 
 # Create module logger
 log = create_module_logger(module_name=__name__)
@@ -495,7 +496,7 @@ def _launch_simulator(*args, **kwargs):
             self.object_state_types_requiring_update = [
                 state
                 for state in self.object_state_types
-                if (issubclass(state, UpdateStateMixin) or issubclass(state, GlobalUpdateStateMixin))
+                if (issubclass(state, UpdateStateMixin) or issubclass(state, TensorizedValueState))
             ]
             self.object_state_types_on_joint_break = {
                 state for state in self.object_state_types if issubclass(state, JointBreakSubscribedStateMixin)
@@ -509,7 +510,7 @@ def _launch_simulator(*args, **kwargs):
             self.stop()
 
             for state in self.object_state_types_requiring_update:
-                if issubclass(state, GlobalUpdateStateMixin):
+                if issubclass(state, TensorizedValueState):
                     state.global_initialize()
 
             # Now start rebuilding everything
@@ -1105,7 +1106,7 @@ def _launch_simulator(*args, **kwargs):
                 if gm.ENABLE_OBJECT_STATES:
                     # Step the object states in global topological order (if the scene exists)
                     for state_type in self.object_state_types_requiring_update:
-                        if issubclass(state_type, GlobalUpdateStateMixin):
+                        if issubclass(state_type, TensorizedValueState):
                             state_type.global_update()
                         if issubclass(state_type, UpdateStateMixin):
                             for scene in self.scenes:
@@ -1742,7 +1743,7 @@ def _launch_simulator(*args, **kwargs):
 
             # Clear all global update states
             for state in self.object_state_types_requiring_update:
-                if issubclass(state, GlobalUpdateStateMixin):
+                if issubclass(state, TensorizedValueState):
                     state.global_initialize()
 
             # Clear all materials

--- a/OmniGibson/omnigibson/transition_rules.py
+++ b/OmniGibson/omnigibson/transition_rules.py
@@ -25,6 +25,7 @@ from omnigibson.object_states import (
     Heated,
     HeatSourceOrSink,
     MaxTemperature,
+    Temperature,
     OnTop,
     Open,
     Saturated,
@@ -2303,12 +2304,11 @@ class CookingRule(RecipeRule):
             object_candidates=object_candidates, container=container, global_info=global_info
         )
 
-        # Compute whether each heatsource is affecting the container
-        info["heatsource_categories"] = set(
-            obj.category
-            for obj in object_candidates["heatSource"]
-            if obj.states[HeatSourceOrSink].affects_obj(container)
+        # Collect categories of heat sources from the candidates actively affecting the container.
+        affecting_heatsources = Temperature.get_objs_affected_by_heatsource(
+            heatsources=object_candidates["heatSource"], objs=[container]
         )
+        info["heatsource_categories"] = {obj.category for obj in affecting_heatsources}
 
         return info
 

--- a/OmniGibson/omnigibson/utils/usd_utils.py
+++ b/OmniGibson/omnigibson/utils/usd_utils.py
@@ -634,6 +634,44 @@ class RigidContactAPIImpl:
 
         return query_contacts.any(dim=1)
 
+    def get_contact_matrix(self, scene_idx):
+        """
+        Returns the (R, C) bool contact matrix for @scene_idx, or None if not yet built.
+        """
+        return self._CONTACT_MATRIX.get(scene_idx)
+
+    def update_block_contact_matrix(self, scene_idxs, block_contact_matrix, row_offsets, col_offsets):
+        """
+        Fill a pre-allocated (R_total, C_total) block contact matrix in-place from the
+        current per-scene contact matrices. Call once per step before compute_pairwise_contacts().
+
+        Args:
+            scene_idxs (list[int]): Ordered scene indices matching block layout.
+            block_contact_matrix (th.Tensor): (R_total, C_total) float — pre-allocated, mutated in-place.
+            row_offsets (list[int]): Row start index in block matrix for each scene.
+            col_offsets (list[int]): Col start index in block matrix for each scene.
+        """
+        for s, r_off, c_off in zip(scene_idxs, row_offsets, col_offsets):
+            cm = self._CONTACT_MATRIX.get(s)
+            if cm is not None:
+                block_contact_matrix[r_off : r_off + cm.shape[0], c_off : c_off + cm.shape[1]] = cm.float()
+
+    def compute_pairwise_contacts(self, block_contact_matrix, obj_row_masks, obj_col_masks):
+        """
+        Compute NxN pairwise object contact matrix via two matmuls.
+
+        Args:
+            block_contact_matrix (th.Tensor): (R_total, C_total) float — filled this step.
+            obj_row_masks (th.Tensor): (N, R_total) float — which dynamic prims belong to each object.
+            obj_col_masks (th.Tensor): (N, C_total) float — which rigid prims belong to each object.
+
+        Returns:
+            th.Tensor: (N, N) bool — one_way[i,j] is True if any dynamic prim of obj_i
+                is in contact with any rigid prim of obj_j.
+        """
+        query_contacts = obj_row_masks @ block_contact_matrix  # (N, C_total)
+        return (query_contacts @ obj_col_masks.T) > 0  # (N, N)
+
     def clear(self):
         """
         Clears internal contact views, mappings, and caches.


### PR DESCRIPTION
This is an unfinished pr.
## Changes in this PR: 
### Tensorize `HeatSourceOrSink` and `OnFire`
- Modify `HeatSourceOrSink` as a `TensorizedValueState`. Update `OnFire` accordingly. 
- Move check_affected_obj out of `HeatSourceOrSink` into Temperature. Now logic becomes: Temperature would get all `HeatSource` location, using cdist and Inside state to check whether it should update.
### Tensorize Touching
- Replace per-call `RigidContactAPI.is_in_contact()` with a pre-built block-diagonal matrix pipeline. At init/remove, projection matrices are built mapping each object to its rows/cols in the contact matrix. Cloth objects retain the original per-call fallback. 
