### PR TITLE
Small fix for draw_bounding_box test

### DIFF
--- a/OmniGibson/omnigibson/utils/deprecated_utils.py
+++ b/OmniGibson/omnigibson/utils/deprecated_utils.py
@@ -1042,7 +1042,7 @@ def colorize_bboxes(bboxes_2d_data, bboxes_2d_rgb, num_channels=3):
         semantic_id_list.append(bbox_2d[0])
         bbox_2d_list.append(bbox_2d)
     semantic_id_list_np = np.unique(np.array(semantic_id_list))
-    color_list = random_colours(len(semantic_id_list_np.tolist()), True, num_channels)
+    color_list = random_colours(len(semantic_id_list_np.tolist()), False, num_channels)
     for bbox_2d in bbox_2d_list:
         index = np.where(semantic_id_list_np == bbox_2d[0])[0][0]
         bbox_color = color_list[index]


### PR DESCRIPTION
Avoids a bug in the isaacsim code causing `test_examples, object_states.draw_bounding_box` to fail.
```
if enable_random:
            random.seed(10)
            start = random.random()
        hues = [(start + i / N) % 1.0 for i in range(N)]
>       colours = [random_colours_id(i, num_channels) for i in range(start, start + N)]
                                                               ^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: 'float' object cannot be interpreted as an integer
```
I don't think we need all the colours to be in a random order anyway.