### PR TITLE
Skip viewport creation when RENDER_VIEWER_CAMERA is set to False

### DIFF
--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -217,6 +217,7 @@ class VisionSensor(BaseSensor):
         # Create a new viewport to link to this camera or link to a pre-existing one
         viewport_name = self._load_config["viewport_name"]
         should_create_viewport = viewport_name is not None or gm.RENDER_VIEWER_CAMERA
+        viewport = None
         if should_create_viewport and viewport_name is not None:
             vp_names_to_handles = {vp.name: vp for vp in lazy.omni.kit.viewport.window.get_viewport_window_instances()}
             assert_valid_key(key=viewport_name, valid_keys=vp_names_to_handles, name="viewport name")
@@ -250,7 +251,7 @@ class VisionSensor(BaseSensor):
                         ratio=(1 + n_auxiliary_sensors - i) / (2 + n_auxiliary_sensors - i),
                     )
 
-        self._viewport = viewport if should_create_viewport else None
+        self._viewport = viewport
 
         if self._viewport is not None:
             # Link the camera and viewport together
@@ -723,7 +724,6 @@ class VisionSensor(BaseSensor):
         if self._viewport is not None:
             width, _ = self._viewport.viewport_api.get_texture_resolution()
             self._viewport.viewport_api.set_texture_resolution((width, height))
-            self._image_width = width
 
         # Also update render product and update all annotators
         for annotator in self._annotators.values():
@@ -762,7 +762,6 @@ class VisionSensor(BaseSensor):
         if self._viewport is not None:
             _, height = self._viewport.viewport_api.get_texture_resolution()
             self._viewport.viewport_api.set_texture_resolution((width, height))
-            self._image_height = height
 
         # Also update render product and update all annotators
         for annotator in self._annotators.values():
@@ -881,7 +880,7 @@ class VisionSensor(BaseSensor):
         Returns:
             str: prim path of the active camera attached to this vision sensor
         """
-        return self.prim_path if self._viewport is None else self._viewport.viewport_api.get_active_camera().pathString
+        return None if self._viewport is None else self._viewport.viewport_api.get_active_camera().pathString
 
     @active_camera_path.setter
     def active_camera_path(self, path):

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -216,7 +216,7 @@ class VisionSensor(BaseSensor):
 
         # Create a new viewport to link to this camera or link to a pre-existing one
         viewport_name = self._load_config["viewport_name"]
-        should_create_viewport = viewport_name is not None or gm.RENDER_VIEWER_CAMERA
+        should_create_viewport = viewport_name is not None or not gm.HEADLESS
         viewport = None
         if should_create_viewport and viewport_name is not None:
             vp_names_to_handles = {vp.name: vp for vp in lazy.omni.kit.viewport.window.get_viewport_window_instances()}
@@ -893,7 +893,7 @@ class VisionSensor(BaseSensor):
         if self._viewport is None:
             raise RuntimeError(
                 "Cannot set active_camera_path because this sensor has no viewport. "
-                "Set gm.RENDER_VIEWER_CAMERA=True to enable viewport textures."
+                "Set gm.HEADLESS=False to enable viewport textures."
             )
         self._viewport.viewport_api.set_active_camera(path)
         # Requires 6 updates to propagate changes

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -4,6 +4,7 @@ import torch as th
 
 import omnigibson as og
 import omnigibson.lazy as lazy
+from omnigibson.macros import gm
 from omnigibson.sensors.sensor_base import BaseSensor
 from omnigibson.systems.system_base import get_all_system_names
 from omnigibson.utils.constants import (
@@ -147,6 +148,8 @@ class VisionSensor(BaseSensor):
         self._viewport = None  # Viewport from which to grab data
         self._annotators = None
         self._render_product = None
+        self._image_height = image_height # used when viewport is not created
+        self._image_width = image_width # used when viewport is not created
 
         self._RAW_SENSOR_TYPES = dict(
             rgb="rgb",
@@ -208,15 +211,17 @@ class VisionSensor(BaseSensor):
         self.SENSORS[self.prim_path] = self
 
         resolution = (self._load_config["image_width"], self._load_config["image_height"])
+        self._image_width, self._image_height = resolution
         self._render_product = lazy.omni.replicator.core.create.render_product(self.prim_path, resolution)
 
         # Create a new viewport to link to this camera or link to a pre-existing one
         viewport_name = self._load_config["viewport_name"]
-        if viewport_name is not None:
+        should_create_viewport = viewport_name is not None or not gm.HEADLESS
+        if should_create_viewport and viewport_name is not None:
             vp_names_to_handles = {vp.name: vp for vp in lazy.omni.kit.viewport.window.get_viewport_window_instances()}
             assert_valid_key(key=viewport_name, valid_keys=vp_names_to_handles, name="viewport name")
             viewport = vp_names_to_handles[viewport_name]
-        else:
+        elif should_create_viewport:
             viewport = lazy.omni.kit.viewport.utility.create_viewport_window()
             # Take a render step to make sure the viewport is generated before docking it
             render()
@@ -245,17 +250,19 @@ class VisionSensor(BaseSensor):
                         ratio=(1 + n_auxiliary_sensors - i) / (2 + n_auxiliary_sensors - i),
                     )
 
-        self._viewport = viewport
+            self._viewport = viewport
 
-        # Link the camera and viewport together
-        self._viewport.viewport_api.set_active_camera(self.prim_path)
+            # Link the camera and viewport together
+            self._viewport.viewport_api.set_active_camera(self.prim_path)
 
-        # Requires 4 render updates to propagate changes
-        for i in range(4):
-            render()
+            # Requires 4 render updates to propagate changes
+            for i in range(4):
+                render()
 
-        # Set the viewer size (requires taking one render step afterwards)
-        self._viewport.viewport_api.set_texture_resolution(resolution)
+            # Set the viewer size (requires taking one render step afterwards)
+            self._viewport.viewport_api.set_texture_resolution(resolution)
+        else:
+            self._viewport = None
 
         # Also update relevant camera params from load config
         self.focal_length = self._load_config["focal_length"]
@@ -617,12 +624,14 @@ class VisionSensor(BaseSensor):
         # Destroy the render product
         self._render_product.destroy()
 
-        # Remove the viewport if it's not the main viewport
-        if self._viewport.name != "Viewport":
-            self._viewport.destroy()
-        else:
-            # We're deleting our camera, so set the normal viewport camera to the default /Perspective camera
-            self.active_camera_path = "/OmniverseKit_Persp"
+        # Remove the viewport if it exists.
+        if self._viewport is not None:
+            # Remove the viewport if it's not the main viewport
+            if self._viewport.name != "Viewport":
+                self._viewport.destroy()
+            else:
+                # We're deleting our camera, so set the normal viewport camera to the default /Perspective camera
+                self.active_camera_path = "/OmniverseKit_Persp"
 
         # Run super
         super().remove()
@@ -678,7 +687,7 @@ class VisionSensor(BaseSensor):
         Returns:
             bool: Whether the viewer is visible or not
         """
-        return self._viewport.visible
+        return False if self._viewport is None else self._viewport.visible
 
     @viewer_visibility.setter
     def viewer_visibility(self, visible):
@@ -688,6 +697,8 @@ class VisionSensor(BaseSensor):
         Args:
             visible (bool): Whether the viewer should be visible or not
         """
+        if self._viewport is None:
+            return
         self._viewport.visible = visible
         # Requires 1 render update to propagate changes
         render()
@@ -698,7 +709,7 @@ class VisionSensor(BaseSensor):
         Returns:
             int: Image height of this sensor, in pixels
         """
-        return self._viewport.viewport_api.get_texture_resolution()[1]
+        return self._image_height if self._viewport is None else self._viewport.viewport_api.get_texture_resolution()[1]
 
     @image_height.setter
     def image_height(self, height):
@@ -708,8 +719,12 @@ class VisionSensor(BaseSensor):
         Args:
             height (int): Image height of this sensor, in pixels
         """
-        width, _ = self._viewport.viewport_api.get_texture_resolution()
-        self._viewport.viewport_api.set_texture_resolution((width, height))
+        self._image_height = height
+        width = self._image_width
+        if self._viewport is not None:
+            width, _ = self._viewport.viewport_api.get_texture_resolution()
+            self._viewport.viewport_api.set_texture_resolution((width, height))
+            self._image_width = width
 
         # Also update render product and update all annotators
         for annotator in self._annotators.values():
@@ -733,7 +748,7 @@ class VisionSensor(BaseSensor):
         Returns:
             int: Image width of this sensor, in pixels
         """
-        return self._viewport.viewport_api.get_texture_resolution()[0]
+        return self._image_width if self._viewport is None else self._viewport.viewport_api.get_texture_resolution()[0]
 
     @image_width.setter
     def image_width(self, width):
@@ -743,8 +758,12 @@ class VisionSensor(BaseSensor):
         Args:
             width (int): Image width of this sensor, in pixels
         """
-        _, height = self._viewport.viewport_api.get_texture_resolution()
-        self._viewport.viewport_api.set_texture_resolution((width, height))
+        self._image_width = width
+        height = self._image_height
+        if self._viewport is not None:
+            _, height = self._viewport.viewport_api.get_texture_resolution()
+            self._viewport.viewport_api.set_texture_resolution((width, height))
+            self._image_height = height
 
         # Also update render product and update all annotators
         for annotator in self._annotators.values():
@@ -863,7 +882,7 @@ class VisionSensor(BaseSensor):
         Returns:
             str: prim path of the active camera attached to this vision sensor
         """
-        return self._viewport.viewport_api.get_active_camera().pathString
+        return self.prim_path if self._viewport is None else self._viewport.viewport_api.get_active_camera().pathString
 
     @active_camera_path.setter
     def active_camera_path(self, path):
@@ -873,6 +892,11 @@ class VisionSensor(BaseSensor):
         Args:
             path (str): Prim path to the camera that will be attached to this vision sensor
         """
+        if self._viewport is None:
+            raise RuntimeError(
+                "Cannot set active_camera_path because this sensor has no viewport. "
+                "Set OMNIGIBSON_DISABLE_SENSOR_VIEWPORT_TEXTURES=False to enable viewport textures."
+            )
         self._viewport.viewport_api.set_active_camera(path)
         # Requires 6 updates to propagate changes
         for i in range(6):

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -216,7 +216,7 @@ class VisionSensor(BaseSensor):
 
         # Create a new viewport to link to this camera or link to a pre-existing one
         viewport_name = self._load_config["viewport_name"]
-        should_create_viewport = viewport_name is not None or not gm.HEADLESS
+        should_create_viewport = viewport_name is not None or gm.RENDER_VIEWER_CAMERA
         if should_create_viewport and viewport_name is not None:
             vp_names_to_handles = {vp.name: vp for vp in lazy.omni.kit.viewport.window.get_viewport_window_instances()}
             assert_valid_key(key=viewport_name, valid_keys=vp_names_to_handles, name="viewport name")

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -250,8 +250,9 @@ class VisionSensor(BaseSensor):
                         ratio=(1 + n_auxiliary_sensors - i) / (2 + n_auxiliary_sensors - i),
                     )
 
-            self._viewport = viewport
+        self._viewport = viewport if should_create_viewport else None
 
+        if self._viewport is not None:
             # Link the camera and viewport together
             self._viewport.viewport_api.set_active_camera(self.prim_path)
 
@@ -261,8 +262,6 @@ class VisionSensor(BaseSensor):
 
             # Set the viewer size (requires taking one render step afterwards)
             self._viewport.viewport_api.set_texture_resolution(resolution)
-        else:
-            self._viewport = None
 
         # Also update relevant camera params from load config
         self.focal_length = self._load_config["focal_length"]

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -895,7 +895,7 @@ class VisionSensor(BaseSensor):
         if self._viewport is None:
             raise RuntimeError(
                 "Cannot set active_camera_path because this sensor has no viewport. "
-                "Set OMNIGIBSON_DISABLE_SENSOR_VIEWPORT_TEXTURES=False to enable viewport textures."
+                "Set gm.RENDER_VIEWER_CAMERA=True to enable viewport textures."
             )
         self._viewport.viewport_api.set_active_camera(path)
         # Requires 6 updates to propagate changes


### PR DESCRIPTION
Greetings from RLinf, a reinforcement learning Infrastructure for agentic AI!

When using BEHAVIOR-1K for embodied agent training in RLinf, each OmniGibson environment step is taking a long time to complete (~80 ms on 4090 with R1Pro and the simple "turn on radio" scene). 

Profiling reveals that even when gm.HEADLESS is True and gm.RENDER_VIEWER_CAMERA is False, each vision sensor still has two render targets (Replicator and Viewport Texture) while only the Replicator target is used to retrieve the observations. Since viewport textures are for live viewing in NVIDIA Omniverse and are not useful in a headless setup, this PR disables viewport creation (and henceforth subsequent rendering) when gm.RENDER_VIEWER_CAMERA is set to False. 

According to our measurements, disabling viewport textures accelerate rendering by 100% (since only half of the images need to be rendered), and increases total step speed by 60% (~50ms with R1Pro and "turn on radio").