### PR TITLE
Add documentation links to claude/agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ under the `isaacsim` package. Everything from isaacsim needs to be imported usin
 (e.g. through simulator.py's launch_app). You can follow most of these imports to the source code by finding the appropriate extension inside the isaacsim directory. Especially
 relevant extensions' names start with isaacsim.core.
 
+OmniGibson currently uses [Isaac Sim 5.1](https://docs.isaacsim.omniverse.nvidia.com/5.1.0/) and [Omniverse Kit 107.3.1](https://docs.omniverse.nvidia.com/kit/docs/kit-manual/107.3.1/). This [documentation for USDRT](https://docs.omniverse.nvidia.com/kit/docs/usdrt.scenegraph/7.6.1/index.html#usdrt-scenegraph-module) may also be especially useful for understanding Fabric and USD syncing. When following the links, make sure not to add an extra "docs/" to the href.
+
 ### BDDL3 (`bddl3/bddl/`)
 - **`activity_definitions/`** — One file per activity with symbolic pre/post conditions.
 - **`object_taxonomy.py`** — Hierarchical object ontology.


### PR DESCRIPTION
FYI in general while testing Claude often still has to be prompted explicitly to use the documentation, otherwise it does not always default to looking it up even if it's quite relevant. But now you can e.g. ask it to follow links to the documentation or look at Omniverse or IsaacSim docs. I initially ran into an issue where it would add an extra `docs/` part to the URL which is why I added the extra sentence at the end, seems like it could be a bit finnicky still. 