### PR TITLE
Fix joylo launch errors

### DIFF
--- a/OmniGibson/omnigibson/envs/hdf5_data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/hdf5_data_wrapper.py
@@ -457,9 +457,11 @@ class HDF5CollectionWrapper(HDF5DataWrapper):
                 lazy.carb.settings.get_settings().set_bool("/app/asyncRenderingLowLatency", True)
 
             # Disable mouse grabbing since we're only using the UI passively
-            lazy.carb.settings.get_settings().set_bool("/physics/mouseInteractionEnabled", False)
-            lazy.carb.settings.get_settings().set_bool("/physics/mouseGrab", False)
-            lazy.carb.settings.get_settings().set_bool("/physics/forceGrab", False)
+            # These settings trigger PhysX UI callbacks that write to the USD root layer
+            with og.sim.editing_usd():
+                lazy.carb.settings.get_settings().set_bool("/physics/mouseInteractionEnabled", False)
+                lazy.carb.settings.get_settings().set_bool("/physics/mouseGrab", False)
+                lazy.carb.settings.get_settings().set_bool("/physics/forceGrab", False)
 
         # Set the dump filter for better performance
         # TODO: Possibly remove this feature once we have fully tensorized state saving, which may be more efficient

--- a/OmniGibson/omnigibson/maps/segmentation_map.py
+++ b/OmniGibson/omnigibson/maps/segmentation_map.py
@@ -99,6 +99,7 @@ class SegmentationMap(BaseMap):
         self.room_ins_name_to_ins_id = room_ins_name_to_ins_id
         self.room_ins_id_to_ins_name = {value: key for key, value in room_ins_name_to_ins_id.items()}
         self.room_sem_name_to_ins_name = room_sem_name_to_ins_name
+        self.room_ins_name_to_sem_name = {ins: sem for sem, ins_list in room_sem_name_to_ins_name.items() for ins in ins_list}
         self.room_ins_map = img_ins
         self.room_sem_map = img_sem
 

--- a/OmniGibson/omnigibson/maps/segmentation_map.py
+++ b/OmniGibson/omnigibson/maps/segmentation_map.py
@@ -99,7 +99,9 @@ class SegmentationMap(BaseMap):
         self.room_ins_name_to_ins_id = room_ins_name_to_ins_id
         self.room_ins_id_to_ins_name = {value: key for key, value in room_ins_name_to_ins_id.items()}
         self.room_sem_name_to_ins_name = room_sem_name_to_ins_name
-        self.room_ins_name_to_sem_name = {ins: sem for sem, ins_list in room_sem_name_to_ins_name.items() for ins in ins_list}
+        self.room_ins_name_to_sem_name = {
+            ins: sem for sem, ins_list in room_sem_name_to_ins_name.items() for ins in ins_list
+        }
         self.room_ins_map = img_ins
         self.room_sem_map = img_sem
 

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -186,9 +186,10 @@ class VisionSensor(BaseSensor):
     def _load(self):
         # Define a new camera prim at the current stage
         # Note that we can't use og.sim.stage here because the vision sensors get loaded first
-        return lazy.pxr.UsdGeom.Camera.Define(
-            lazy.isaacsim.core.utils.stage.get_current_stage(), self.prim_path
-        ).GetPrim()
+        with og.sim.editing_usd():
+            return lazy.pxr.UsdGeom.Camera.Define(
+                lazy.isaacsim.core.utils.stage.get_current_stage(), self.prim_path
+            ).GetPrim()
 
     def _post_load(self):
         # run super first

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -545,8 +545,12 @@ class BehaviorTask(BaseTask):
                     entity = env.scene.get_system(name) if is_system else env.scene.object_registry("name", name)
             self.object_scope[obj_inst] = entity
 
-        # Write back to task metadata
-        self.update_bddl_scope_metadata(env)
+        # Only write back to task metadata in strict mode (full assignment).
+        # In non-strict mode (partial assignment before wildcard compilation),
+        # writing back would overwrite the cached inst_to_name with only the
+        # base-scope entries, losing wildcard instance mappings.
+        if strict:
+            self.update_bddl_scope_metadata(env)
 
     def update_bddl_scope_metadata(self, env):
         """

--- a/joylo/gello/utils/og_teleop_utils.py
+++ b/joylo/gello/utils/og_teleop_utils.py
@@ -30,15 +30,8 @@ parser.add_argument("--activity", type=str, required=True)
 
 def get_task_relevant_room_types(activity_name):
     task_obj = get_knowledge_base().get_task(f"{activity_name}-0")
-    task_obj._ensure_compiled()
-    init_conds = task_obj.conditions.parsed_initial_conditions
-    room_types = set()
-    for init_cond in init_conds:
-        if len(init_cond) == 3:
-            if "inroom" == init_cond[0]:
-                room_types.add(init_cond[2])
-
-    return list(room_types)
+    _, _, inroom_assignments = task_obj.parse_base_scope()
+    return list(set(inroom_assignments.values()))
 
 
 def augment_rooms(relevant_rooms, scene_model, task_name):

--- a/joylo/gello/utils/og_teleop_utils.py
+++ b/joylo/gello/utils/og_teleop_utils.py
@@ -185,7 +185,8 @@ def create_and_dock_viewport(parent_window, position, ratio, camera_path):
     Returns:
         The created viewport window
     """
-    viewport = lazy.omni.kit.viewport.utility.create_viewport_window()
+    with og.sim.editing_usd():
+        viewport = lazy.omni.kit.viewport.utility.create_viewport_window()
     og.sim.render()
 
     dock_window(
@@ -196,7 +197,8 @@ def create_and_dock_viewport(parent_window, position, ratio, camera_path):
     )
     og.sim.render()
 
-    viewport.viewport_api.set_active_camera(camera_path)
+    with og.sim.editing_usd():
+        viewport.viewport_api.set_active_camera(camera_path)
     og.sim.render()
 
     return viewport
@@ -285,32 +287,34 @@ def setup_cameras(robot, external_sensors, resolution, config):
             "right", f"{robot.arm_names[1]}_eef_link"
         )
 
-        for wrist_link in (left_wrist_link, right_wrist_link):
-            camera_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(
-                prim_path=f"{robot.links[wrist_link].prim_path}/Camera"
-            )
-            if config.wrist_camera_pos is not None:
-                camera_prim.GetAttribute("xformOp:translate").Set(
-                    lazy.pxr.Gf.Vec3d(*config.wrist_camera_pos.tolist())
+        with og.sim.editing_usd():
+            for wrist_link in (left_wrist_link, right_wrist_link):
+                camera_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(
+                    prim_path=f"{robot.links[wrist_link].prim_path}/Camera"
                 )
-            if config.wrist_camera_ori is not None:
-                camera_prim.GetAttribute("xformOp:orient").Set(
-                    lazy.pxr.Gf.Quatd(*config.wrist_camera_ori[[3, 0, 1, 2]].tolist())
-                )
+                if config.wrist_camera_pos is not None:
+                    camera_prim.GetAttribute("xformOp:translate").Set(
+                        lazy.pxr.Gf.Vec3d(*config.wrist_camera_pos.tolist())
+                    )
+                if config.wrist_camera_ori is not None:
+                    camera_prim.GetAttribute("xformOp:orient").Set(
+                        lazy.pxr.Gf.Quatd(*config.wrist_camera_ori[[3, 0, 1, 2]].tolist())
+                    )
 
     # Adjust head camera offset if configured
     if config.head_camera_pos is not None or config.head_camera_ori is not None:
         head_camera_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(
             prim_path=eyes_cam_prim_path
         )
-        if config.head_camera_pos is not None:
-            head_camera_prim.GetAttribute("xformOp:translate").Set(
-                lazy.pxr.Gf.Vec3d(*config.head_camera_pos.tolist())
-            )
-        if config.head_camera_ori is not None:
-            head_camera_prim.GetAttribute("xformOp:orient").Set(
-                lazy.pxr.Gf.Quatd(*config.head_camera_ori[[3, 0, 1, 2]].tolist())
-            )
+        with og.sim.editing_usd():
+            if config.head_camera_pos is not None:
+                head_camera_prim.GetAttribute("xformOp:translate").Set(
+                    lazy.pxr.Gf.Vec3d(*config.head_camera_pos.tolist())
+                )
+            if config.head_camera_ori is not None:
+                head_camera_prim.GetAttribute("xformOp:orient").Set(
+                    lazy.pxr.Gf.Quatd(*config.head_camera_ori[[3, 0, 1, 2]].tolist())
+                )
 
     camera_paths = [
         eyes_cam_prim_path,
@@ -319,22 +323,24 @@ def setup_cameras(robot, external_sensors, resolution, config):
 
     # Lock camera attributes
     LOCK_CAMERA_ATTR = "omni:kit:cameraLock"
-    for cam_path in camera_paths:
-        cam_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(cam_path)
-        cam_prim.GetAttribute("horizontalAperture").Set(40.0)
+    with og.sim.editing_usd():
+        for cam_path in camera_paths:
+            cam_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(cam_path)
+            cam_prim.GetAttribute("horizontalAperture").Set(40.0)
 
-        # Lock attributes afterwards as well to avoid external modification
-        if cam_prim.HasAttribute(LOCK_CAMERA_ATTR):
-            attr = cam_prim.GetAttribute(LOCK_CAMERA_ATTR)
-        else:
-            attr = cam_prim.CreateAttribute(
-                LOCK_CAMERA_ATTR, lazy.pxr.Sdf.ValueTypeNames.Bool
-            )
-        attr.Set(True)
+            # Lock attributes afterwards as well to avoid external modification
+            if cam_prim.HasAttribute(LOCK_CAMERA_ATTR):
+                attr = cam_prim.GetAttribute(LOCK_CAMERA_ATTR)
+            else:
+                attr = cam_prim.CreateAttribute(
+                    LOCK_CAMERA_ATTR, lazy.pxr.Sdf.ValueTypeNames.Bool
+                )
+            attr.Set(True)
 
     # Disable all render products to save on speed
-    for sensor in VisionSensor.SENSORS.values():
-        sensor.render_product.hydra_texture.set_updates_enabled(False)
+    with og.sim.editing_usd():
+        for sensor in VisionSensor.SENSORS.values():
+            sensor.render_product.hydra_texture.set_updates_enabled(False)
 
     return camera_paths, viewports
 
@@ -656,23 +662,24 @@ def setup_flashlights(robot):
     """
     flashlights = {}
 
-    for arm in robot.arm_names:
-        light_prim = getattr(lazy.pxr.UsdLux, "SphereLight").Define(
-            og.sim.stage, f"{robot.links[f'{arm}_eef_link'].prim_path}/flashlight"
-        )
-        light_prim.GetRadiusAttr().Set(0.01)
-        light_prim.GetIntensityAttr().Set(FLASHLIGHT_INTENSITY)
-        light_prim.LightAPI().GetNormalizeAttr().Set(True)
+    with og.sim.editing_usd():
+        for arm in robot.arm_names:
+            light_prim = getattr(lazy.pxr.UsdLux, "SphereLight").Define(
+                og.sim.stage, f"{robot.links[f'{arm}_eef_link'].prim_path}/flashlight"
+            )
+            light_prim.GetRadiusAttr().Set(0.01)
+            light_prim.GetIntensityAttr().Set(FLASHLIGHT_INTENSITY)
+            light_prim.LightAPI().GetNormalizeAttr().Set(True)
 
-        light_prim.ClearXformOpOrder()
-        translate_op = light_prim.AddTranslateOp()
-        translate_op.Set(lazy.pxr.Gf.Vec3d(-0.01, 0, -0.05))
-        light_prim.SetXformOpOrder([translate_op])
+            light_prim.ClearXformOpOrder()
+            translate_op = light_prim.AddTranslateOp()
+            translate_op.Set(lazy.pxr.Gf.Vec3d(-0.01, 0, -0.05))
+            light_prim.SetXformOpOrder([translate_op])
 
-        # Start with flashlight off
-        light_prim.GetVisibilityAttr().Set("invisible")
+            # Start with flashlight off
+            light_prim.GetVisibilityAttr().Set("invisible")
 
-        flashlights[arm] = light_prim
+            flashlights[arm] = light_prim
 
     return flashlights
 

--- a/joylo/gello/utils/og_teleop_utils.py
+++ b/joylo/gello/utils/og_teleop_utils.py
@@ -18,7 +18,8 @@ from omnigibson.utils.ui_utils import dock_window
 from omnigibson.utils import transform_utils as T
 from omnigibson.sensors import VisionSensor
 from omnigibson.objects.usd_object import USDObject
-from gello.robots.sim_robot.og_teleop_cfg import *
+from gello.utils.og_teleop_cfg import *
+from gello import REPO_DIR
 
 from omnigibson.utils.bddl_utils import get_knowledge_base
 import argparse


### PR DESCRIPTION
- Fix stale imports in `og_teleop_utils`
- Update `get_task_relevant_room_types` to use current `Task.parse_base_scope()` API
- Add `room_ins_name_to_sem_name` reverse mapping to `SegmentationMap` (needed by `BehaviorTask._determine_room_instances`)
- Fix wildcard task `inst_to_name` cache being overwritten during partial scope assignment in `assign_object_scope_with_cache`                                                         - Wrap USD-editing calls in `editing_usd()` context across joylo teleop utils, `VisionSensor`,   
  and `HDF5CollectionWrapper`