### PR TITLE
Fix synsets index.html page on knowledgebase website

### DIFF
--- a/knowledgebase/knowledgebase/templates/synset_list.html
+++ b/knowledgebase/knowledgebase/templates/synset_list.html
@@ -153,13 +153,13 @@
           {% endfor %}
         </td>
         <td>
-          {% for task in synset.tasks[:10] %}
+          {% for task in (synset.tasks | list)[:10] %}
             <a href="{{ url_for('task_detail', name=task.name) }}">{{ task.name }}, </a>
           {% endfor %}
           {% if synset.tasks|length > 10 %}...{% endif %}
         </td>
         <td>
-          {% for category in synset.categories[:10] %}
+          {% for category in (synset.categories | list)[:10] %}
             <a href="{{ url_for('category_detail', name=category.name) }}">{{ category.name }}, </a>
           {% endfor %}
           {% if synset.categories|length > 10 %}...{% endif %}


### PR DESCRIPTION
Seeing,
```
Error generating page synset_list: 'set' object is not subscriptable
```
On the [build and deploy](https://github.com/StanfordVL/BEHAVIOR-1K/actions/runs/24662014992/job/72110150460) job.

Verified that running `python build_static_site.py` now completes without error after the change.