### PR TITLE
Apply replay transitions after load_state, not before

### DIFF
--- a/OmniGibson/omnigibson/envs/data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/data_wrapper.py
@@ -675,7 +675,11 @@ class DataPlaybackWrapper(DataWrapper):
         for i, (a, s, ss, r, te, tr) in enumerate(zip(action, state, state_size, reward, terminated, truncated)):
             if i % 1000 == 0:
                 log.info(f"Playing back episode {episode_id}, step {i}/{len(action)}")
-            # Execute any transitions that should occur at this current step
+
+            # Restore the sim state first; the recorded state at step i is the pre-transition snapshot.
+            og.sim.load_state(s[: int(ss)], serialized=True)
+
+            # Then execute any transitions recorded at this step so the scene matches state[i+1].
             if str(i) in transitions:
                 cur_transitions = transitions[str(i)]
                 scene = og.sim.scenes[0]
@@ -692,10 +696,6 @@ class DataPlaybackWrapper(DataWrapper):
                     obj.set_position(th.ones(3) * 100.0 + th.ones(3) * 5 * j)
                 # Step physics to initialize any new objects
                 og.sim.step()
-
-            # Restore the sim state, and take a very small step with the action to make sure physics are
-            # properly propagated after the sim state update
-            og.sim.load_state(s[: int(ss)], serialized=True)
             if not self.include_contacts:
                 # When all objects/systems are visual-only, keep them still on every step
                 for obj in self.scene.objects:

--- a/OmniGibson/omnigibson/envs/data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/data_wrapper.py
@@ -672,14 +672,14 @@ class DataPlaybackWrapper(DataWrapper):
             }, "Expected reset() to have inserted an initial obs-only entry into the trajectory history!"
             self.current_traj_history[-1]["obs"] = self._process_obs(self.current_obs, init_info)
 
-        for i, (a, s, ss, r, te, tr) in enumerate(zip(action, state, state_size, reward, terminated, truncated)):
+        # Iterate through the rest of the episode and playback each step
+        for i, (a, s, ss, r, te, tr) in enumerate(
+            zip(action, state[1:], state_size[1:], reward, terminated, truncated)
+        ):
             if i % 1000 == 0:
                 log.info(f"Playing back episode {episode_id}, step {i}/{len(action)}")
 
-            # Restore the sim state first; the recorded state at step i is the pre-transition snapshot.
-            og.sim.load_state(s[: int(ss)], serialized=True)
-
-            # Then execute any transitions recorded at this step so the scene matches state[i+1].
+            # Execute any transitions that should occur at this current step
             if str(i) in transitions:
                 cur_transitions = transitions[str(i)]
                 scene = og.sim.scenes[0]
@@ -696,6 +696,10 @@ class DataPlaybackWrapper(DataWrapper):
                     obj.set_position(th.ones(3) * 100.0 + th.ones(3) * 5 * j)
                 # Step physics to initialize any new objects
                 og.sim.step()
+
+            # Restore the sim state, and take a very small step with the action to make sure
+            # physics are properly propagated after the sim state update
+            og.sim.load_state(s[: int(ss)], serialized=True)
             if not self.include_contacts:
                 # When all objects/systems are visual-only, keep them still on every step
                 for obj in self.scene.objects:


### PR DESCRIPTION
What's happening in replaying the hdf5 of halve_an_egg: after touching the egg with a knife, the transition rule runs by which the whole egg disappears and two halved eggs appear in its place.

The bug: At step 1020 the replay code first removed the whole egg and added the halves so the scene no longer has the whole egg. Then it tried to load the recorded snapshot for step 1020, which still mentions the whole egg's ID.

Crash: AssertionError: Could not find object while deserializing with hash_key uuid: 27912356 (This UUID 27912356 is the whole egg.)

 The fix is swapping the order. First load the snapshot (scene has the whole egg). Then apply the "remove whole egg, add halves" change. Now the scene matches what the next step expects.