### PR TITLE
Fix wildcard task compilation in online sampling + a

### DIFF
--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -55,7 +55,7 @@ class BehaviorTask(BaseTask):
             mapping category name (e.g.: "breakfast_table") to a list of invalid models that should not be sampled from
             that category. During sampling, if a given synset is found in this blacklist, all specified
             models will not be used as options
-        unique_models_per_synset (bool): If True, ensures that each instance of the same synset is assigned a distinct
+        use_unique_models_per_synset (bool): If True, ensures that each instance of the same synset is assigned a distinct
             object model (sampling without replacement). Sampling fails if there are fewer valid models than instances
             for a given synset. Only applies when online_object_sampling is True.
         highlight_task_relevant_objects (bool): whether to overlay task-relevant objects in the scene with a colored mask
@@ -80,7 +80,7 @@ class BehaviorTask(BaseTask):
         randomize_presampled_pose=False,
         sampling_whitelist=None,
         sampling_blacklist=None,
-        unique_models_per_synset=False,
+        use_unique_models_per_synset=False,
         highlight_task_relevant_objects=False,
         termination_config=None,
         reward_config=None,
@@ -117,7 +117,7 @@ class BehaviorTask(BaseTask):
         self.randomize_presampled_pose = randomize_presampled_pose
         self.sampling_whitelist = sampling_whitelist  # Maps str to str to list
         self.sampling_blacklist = sampling_blacklist  # Maps str to str to list
-        self.unique_models_per_synset = unique_models_per_synset  # bool
+        self.use_unique_models_per_synset = use_unique_models_per_synset  # bool
         self.highlight_task_relevant_objs = highlight_task_relevant_objects  # bool
         self.object_scope = None  # Maps str to sim object (BaseObject/BaseSystem) or None
         self.object_instance_to_category = None  # Maps str to str
@@ -466,7 +466,7 @@ class BehaviorTask(BaseTask):
             accept_scene, feedback = self.sampler.assign_objects(
                 sampling_whitelist=self.sampling_whitelist,
                 sampling_blacklist=self.sampling_blacklist,
-                unique_models_per_synset=self.unique_models_per_synset,
+                use_unique_models_per_synset=self.use_unique_models_per_synset,
             )
             if not accept_scene:
                 return accept_scene, feedback

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -363,23 +363,26 @@ class BehaviorTask(BaseTask):
             dict: Maps room_type (str) -> room_instance_name (str).
         """
         room_instances = {}
+        # Fall back to the sampler's candidate map: inroom objects aren't in object_scope yet at this point.
+        inroom_scope = getattr(getattr(self, "sampler", None), "_inroom_object_scope", None) or {}
         for obj_inst, room_type in self._base_inroom_assignments.items():
             entity = self.object_scope.get(obj_inst)
-            if entity is None:
-                continue
-            # Find which room instance this object is in
-            if hasattr(entity, "in_rooms") and entity.in_rooms:
-                for room_inst in entity.in_rooms:
-                    inst_room_type = room_inst.rsplit("_", 1)[0]  # Get room type by removing instance number suffix
-                    if inst_room_type == room_type:
-                        if room_type in room_instances and room_instances[room_type] != room_inst:
-                            log.warning(
-                                f"Multiple room instances for room type '{room_type}': "
-                                f"{room_instances[room_type]} vs {room_inst}. Using {room_instances[room_type]}."
-                            )
-                        else:
-                            room_instances[room_type] = room_inst
-                        break
+            candidate_room_insts = []
+            if entity is not None and getattr(entity, "in_rooms", None):
+                candidate_room_insts = list(entity.in_rooms)
+            else:
+                candidate_room_insts = sorted(inroom_scope.get(room_type, {}).get(obj_inst, {}).keys())
+            for room_inst in candidate_room_insts:
+                inst_room_type = room_inst.rsplit("_", 1)[0]  # Get room type by removing instance number suffix
+                if inst_room_type == room_type:
+                    if room_type in room_instances and room_instances[room_type] != room_inst:
+                        log.warning(
+                            f"Multiple room instances for room type '{room_type}': "
+                            f"{room_instances[room_type]} vs {room_inst}. Using {room_instances[room_type]}."
+                        )
+                    else:
+                        room_instances[room_type] = room_inst
+                    break
         return room_instances
 
     def _compile_with_rooms(self, env):
@@ -400,6 +403,22 @@ class BehaviorTask(BaseTask):
 
         # Compile with the correct scene layout
         self.compiled_task = self._task_def.compile(scene_layout=scene_layout)
+
+        # Sampler was init'd from base (wildcard-stripped) conditions; backfill the wildcard-expanded instances.
+        if self.sampler is not None and self.sampler._inroom_object_instances is not None:
+            new_inroom = False
+            for synset_name, instances in self.compiled_task.parsed_objects.items():
+                for inst in instances:
+                    self.sampler._object_instance_to_synset.setdefault(inst, synset_name)
+            for cond in self.compiled_task.conditions.parsed_initial_conditions:
+                if cond[0] == "inroom":
+                    inst, rt = cond[1], cond[2]
+                    if inst not in self.sampler._inroom_object_instances:
+                        self.sampler._inroom_object_instances.add(inst)
+                        self.sampler._room_type_to_object_instance.setdefault(rt, []).append(inst)
+                        new_inroom = True
+            if new_inroom:
+                self.sampler._build_inroom_object_scope()
 
         # Preserve existing object assignments in the new scope
         old_scope = self.object_scope

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -55,6 +55,9 @@ class BehaviorTask(BaseTask):
             mapping category name (e.g.: "breakfast_table") to a list of invalid models that should not be sampled from
             that category. During sampling, if a given synset is found in this blacklist, all specified
             models will not be used as options
+        unique_models_per_synset (bool): If True, ensures that each instance of the same synset is assigned a distinct
+            object model (sampling without replacement). Sampling fails if there are fewer valid models than instances
+            for a given synset. Only applies when online_object_sampling is True.
         highlight_task_relevant_objects (bool): whether to overlay task-relevant objects in the scene with a colored mask
         termination_config (None or dict): Keyword-mapped configuration to use to generate termination conditions. This
             should be specific to the task class. Default is None, which corresponds to a default config being usd.
@@ -77,6 +80,7 @@ class BehaviorTask(BaseTask):
         randomize_presampled_pose=False,
         sampling_whitelist=None,
         sampling_blacklist=None,
+        unique_models_per_synset=False,
         highlight_task_relevant_objects=False,
         termination_config=None,
         reward_config=None,
@@ -113,6 +117,7 @@ class BehaviorTask(BaseTask):
         self.randomize_presampled_pose = randomize_presampled_pose
         self.sampling_whitelist = sampling_whitelist  # Maps str to str to list
         self.sampling_blacklist = sampling_blacklist  # Maps str to str to list
+        self.unique_models_per_synset = unique_models_per_synset  # bool
         self.highlight_task_relevant_objs = highlight_task_relevant_objects  # bool
         self.object_scope = None  # Maps str to sim object (BaseObject/BaseSystem) or None
         self.object_instance_to_category = None  # Maps str to str
@@ -442,6 +447,7 @@ class BehaviorTask(BaseTask):
             accept_scene, feedback = self.sampler.assign_objects(
                 sampling_whitelist=self.sampling_whitelist,
                 sampling_blacklist=self.sampling_blacklist,
+                unique_models_per_synset=self.unique_models_per_synset,
             )
             if not accept_scene:
                 return accept_scene, feedback

--- a/OmniGibson/omnigibson/utils/bddl_utils.py
+++ b/OmniGibson/omnigibson/utils/bddl_utils.py
@@ -489,7 +489,7 @@ class BDDLSampler:
         # Initialize other variables that will be filled in later
         self._sampling_whitelist = None  # Maps str to str to list
         self._sampling_blacklist = None  # Maps str to str to list
-        self._unique_models_per_synset = False  # bool: if True, sample models without replacement per synset
+        self._use_unique_models_per_synset = False  # bool: if True, sample models without replacement per synset
         self._room_type_to_object_instance = None  # dict
         self._inroom_object_instances = None  # set of str
         self._object_sampling_orders = None  # dict mapping str to list of str
@@ -504,7 +504,7 @@ class BDDLSampler:
         resolved = [self._object_scope.get(a, a) if isinstance(a, str) else a for a in args]
         return sample_bddl_predicate(predicate_cls, *resolved, **kwargs)
 
-    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None, unique_models_per_synset=False):
+    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None, use_unique_models_per_synset=False):
         """Assign inroom objects and import sampleable objects into the scene.
 
         This is phase 1 of sampling: it finds/imports all objects needed by the
@@ -516,7 +516,7 @@ class BDDLSampler:
                 category -> list of valid models.
             sampling_blacklist (None or dict): Maps synset name to dict of
                 category -> list of invalid models.
-            unique_models_per_synset (bool): If True, ensures that each instance
+            use_unique_models_per_synset (bool): If True, ensures that each instance
                 of the same synset is assigned a distinct object model (sampling
                 without replacement). Sampling fails if there are fewer valid
                 models than instances for a given synset.
@@ -529,7 +529,7 @@ class BDDLSampler:
         log.info("Assigning objects for task...")
         self._sampling_whitelist = sampling_whitelist
         self._sampling_blacklist = sampling_blacklist
-        self._unique_models_per_synset = unique_models_per_synset
+        self._use_unique_models_per_synset = use_unique_models_per_synset
 
         # Derive future object instances from parsed initial conditions
         self._future_obj_instances = {
@@ -1156,7 +1156,7 @@ class BDDLSampler:
         self._sampled_objects = set()
         num_new_obj = 0
         # Tracks which models have already been used per synset, to enforce
-        # without-replacement sampling when self._unique_models_per_synset is True
+        # without-replacement sampling when self._use_unique_models_per_synset is True
         sampled_models_per_synset = defaultdict(set)
         # Only populate self.object_scope for sampleable objects
         available_categories = set(get_all_object_categories())
@@ -1250,7 +1250,7 @@ class BDDLSampler:
                         )
 
                     # Exclude models already assigned to other instances of this synset
-                    if self._unique_models_per_synset:
+                    if self._use_unique_models_per_synset:
                         model_choices = model_choices - sampled_models_per_synset[obj_synset]
 
                     # Filter by category
@@ -1259,7 +1259,7 @@ class BDDLSampler:
 
                 if len(model_choices) == 0:
                     # We failed to find ANY valid model across ALL valid categories
-                    if self._unique_models_per_synset:
+                    if self._use_unique_models_per_synset:
                         return (
                             f"Ran out of unique models for synset {obj_synset} "
                             f"(already used: {sorted(sampled_models_per_synset[obj_synset])})"
@@ -1268,7 +1268,7 @@ class BDDLSampler:
 
                 # Randomly select an object model
                 model = random.choice(list(model_choices))
-                if self._unique_models_per_synset:
+                if self._use_unique_models_per_synset:
                     sampled_models_per_synset[obj_synset].add(model)
 
                 # Potentially add additional kwargs

--- a/OmniGibson/omnigibson/utils/bddl_utils.py
+++ b/OmniGibson/omnigibson/utils/bddl_utils.py
@@ -489,6 +489,7 @@ class BDDLSampler:
         # Initialize other variables that will be filled in later
         self._sampling_whitelist = None  # Maps str to str to list
         self._sampling_blacklist = None  # Maps str to str to list
+        self._unique_models_per_synset = False  # bool: if True, sample models without replacement per synset
         self._room_type_to_object_instance = None  # dict
         self._inroom_object_instances = None  # set of str
         self._object_sampling_orders = None  # dict mapping str to list of str
@@ -503,7 +504,7 @@ class BDDLSampler:
         resolved = [self._object_scope.get(a, a) if isinstance(a, str) else a for a in args]
         return sample_bddl_predicate(predicate_cls, *resolved, **kwargs)
 
-    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None):
+    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None, unique_models_per_synset=False):
         """Assign inroom objects and import sampleable objects into the scene.
 
         This is phase 1 of sampling: it finds/imports all objects needed by the
@@ -515,6 +516,10 @@ class BDDLSampler:
                 category -> list of valid models.
             sampling_blacklist (None or dict): Maps synset name to dict of
                 category -> list of invalid models.
+            unique_models_per_synset (bool): If True, ensures that each instance
+                of the same synset is assigned a distinct object model (sampling
+                without replacement). Sampling fails if there are fewer valid
+                models than instances for a given synset.
 
         Returns:
             2-tuple:
@@ -524,6 +529,7 @@ class BDDLSampler:
         log.info("Assigning objects for task...")
         self._sampling_whitelist = sampling_whitelist
         self._sampling_blacklist = sampling_blacklist
+        self._unique_models_per_synset = unique_models_per_synset
 
         # Derive future object instances from parsed initial conditions
         self._future_obj_instances = {
@@ -1149,6 +1155,9 @@ class BDDLSampler:
 
         self._sampled_objects = set()
         num_new_obj = 0
+        # Tracks which models have already been used per synset, to enforce
+        # without-replacement sampling when self._unique_models_per_synset is True
+        sampled_models_per_synset = defaultdict(set)
         # Only populate self.object_scope for sampleable objects
         available_categories = set(get_all_object_categories())
 
@@ -1240,16 +1249,27 @@ class BDDLSampler:
                             else model_choices
                         )
 
+                    # Exclude models already assigned to other instances of this synset
+                    if self._unique_models_per_synset:
+                        model_choices = model_choices - sampled_models_per_synset[obj_synset]
+
                     # Filter by category
                     if len(model_choices) > 0:
                         break
 
                 if len(model_choices) == 0:
                     # We failed to find ANY valid model across ALL valid categories
+                    if self._unique_models_per_synset:
+                        return (
+                            f"Ran out of unique models for synset {obj_synset} "
+                            f"(already used: {sorted(sampled_models_per_synset[obj_synset])})"
+                        )
                     return f"Missing valid object models for all categories: {categories}"
 
                 # Randomly select an object model
                 model = random.choice(list(model_choices))
+                if self._unique_models_per_synset:
+                    sampled_models_per_synset[obj_synset].add(model)
 
                 # Potentially add additional kwargs
                 obj_kwargs = dict()

--- a/OmniGibson/scripts/sampling/autogenerate_task_custom_list_template.py
+++ b/OmniGibson/scripts/sampling/autogenerate_task_custom_list_template.py
@@ -41,7 +41,11 @@ def prompt_choice(prompt, options, multi=False):
     for i, opt in enumerate(options):
         print(f"  [{i}] {opt}")
     while True:
-        raw = input("Enter index or name" + (" (comma-separated for multiple)" if multi else "") + ": ").strip()
+        raw = input(
+            "Enter index or name" + (" (comma-separated for multiple, empty to skip)" if multi else "") + ": "
+        ).strip()
+        if multi and not raw:
+            return []
         chosen = []
         for part in raw.split(","):
             part = part.strip()
@@ -122,6 +126,8 @@ def autogenerate_task_custom_list(activity_name):
                 available_models,
                 multi=True,
             )
+            if not models:
+                continue
             whitelist[synset][cat_name] = {m: None for m in models}
 
     task_entry = {

--- a/OmniGibson/scripts/sampling/sample_b1k_tasks.py
+++ b/OmniGibson/scripts/sampling/sample_b1k_tasks.py
@@ -191,10 +191,10 @@ def main(random_selection=False, headless=False, short_exec=False):
         whitelist, blacklist = None, None
     env.task_config["sampling_whitelist"] = whitelist
     env.task_config["sampling_blacklist"] = blacklist
-    env.task_config["unique_models_per_synset"] = args.unique_models
+    env.task_config["use_unique_models_per_synset"] = args.unique_models
     log.info(f"white_list: {whitelist}")
     log.info(f"black_list: {blacklist}")
-    log.info(f"unique_models_per_synset: {args.unique_models}")
+    log.info(f"use_unique_models_per_synset: {args.unique_models}")
     assert whitelist is not None, "whitelist should not be None for manual sampling"
     BehaviorTask.get_cached_activity_scene_filename(
         scene_model=scene_model,

--- a/OmniGibson/scripts/sampling/sample_b1k_tasks.py
+++ b/OmniGibson/scripts/sampling/sample_b1k_tasks.py
@@ -63,6 +63,14 @@ parser.add_argument(
     default=None,
     help="Output directory for sampled tasks (default: gm.DATA_PATH/2026-challenge-task-instances)",
 )
+parser.add_argument(
+    "-u",
+    "--unique_models",
+    action="store_true",
+    help="If set, each instance of the same synset (e.g. book.n.02_1..6) will be assigned a distinct "
+    "object model from the whitelist (sampling without replacement). Fails if the whitelist for a "
+    "synset has fewer entries than instances.",
+)
 
 # gm.HEADLESS = False
 gm.USE_GPU_DYNAMICS = False
@@ -183,8 +191,10 @@ def main(random_selection=False, headless=False, short_exec=False):
         whitelist, blacklist = None, None
     env.task_config["sampling_whitelist"] = whitelist
     env.task_config["sampling_blacklist"] = blacklist
+    env.task_config["unique_models_per_synset"] = args.unique_models
     log.info(f"white_list: {whitelist}")
     log.info(f"black_list: {blacklist}")
+    log.info(f"unique_models_per_synset: {args.unique_models}")
     assert whitelist is not None, "whitelist should not be None for manual sampling"
     BehaviorTask.get_cached_activity_scene_filename(
         scene_model=scene_model,

--- a/OmniGibson/tests/test_behavior_task.py
+++ b/OmniGibson/tests/test_behavior_task.py
@@ -38,5 +38,47 @@ def test_behavior_task():
         sys.exit(1)
 
 
+def test_behavior_task_wildcard():
+    gm.ENABLE_OBJECT_STATES = True
+    gm.HEADLESS = True
+    config = {
+        "scene": {
+            "type": "InteractiveTraversableScene",
+            "scene_model": "house_double_floor_upper",
+            "load_room_types": ["bathroom"],
+        },
+        "task": {
+            "type": "BehaviorTask",
+            "activity_name": "setting_mousetraps",
+            "activity_definition_id": 0,
+            "online_object_sampling": True,
+            "use_presampled_robot_pose": False,
+        },
+        "robots": [
+            {
+                "type": "Fetch",
+                "obs_modalities": ["rgb"],
+            }
+        ],
+    }
+    try:
+        env = og.Environment(configs=config)
+        scope = env.task.compiled_task.object_scope
+        assert "sink.n.01_*" not in scope, f"wildcard left unexpanded in {sorted(scope)}"
+        assert "floor.n.01_*" not in scope, f"wildcard left unexpanded in {sorted(scope)}"
+        assert "sink.n.01_1" in scope, f"sink.n.01_1 missing from {sorted(scope)}"
+        assert "floor.n.01_1" in scope, f"floor.n.01_1 missing from {sorted(scope)}"
+        print(
+            "Wildcard BehaviorTask instantiated successfully! Ground goal state options:",
+            len(env.task.ground_goal_state_options),
+        )
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     test_behavior_task()
+    test_behavior_task_wildcard()

--- a/bddl3/bddl/wildcard.py
+++ b/bddl3/bddl/wildcard.py
@@ -143,8 +143,9 @@ def expand_wildcards(raw_bddl_str, scene_layout, kb):
                 if cat in info["categories"]
             )
 
-            assert n_valid >= n_min, (
-                f"BDDL requires at least {n_min} instances of synset {synset}, "
+            required = max(1, n_min)
+            assert n_valid >= required, (
+                f"BDDL requires at least {required} instance(s) of synset {synset}, "
                 f"but only found {n_valid} in rooms of type {room_type}!"
             )
 

--- a/bddl3/tests/test_knowledgebase.py
+++ b/bddl3/tests/test_knowledgebase.py
@@ -611,3 +611,19 @@ class TestWildcardExpansion:
         ok, results = ct.check_goal(lambda cls, *e: False)
         assert isinstance(ok, bool)
         assert "satisfied" in results and "unsatisfied" in results
+
+    def test_wildcard_fails_with_zero_matched_instances(self, kb):
+        """A wildcard-only declaration should still require at least one matching scene object."""        
+        from bddl.wildcard import expand_wildcards
+        task = kb.get_task("carrying_in_groceries-0")
+        raw = (
+            task.definition
+            .replace(
+                "electric_refrigerator.n.01_1 electric_refrigerator.n.01_*",
+                "electric_refrigerator.n.01_*",
+            )
+            .replace("(inroom electric_refrigerator.n.01_1 kitchen)\n", "")
+        )
+        layout = {"kitchen": {}}
+        with pytest.raises(AssertionError, match="instance"):
+            expand_wildcards(raw, layout, kb)


### PR DESCRIPTION
## Main Fix 

- Fix `_determine_room_instances` returning `{}` during online sampling, which broke `synset_*` wildcards
- Refresh `BDDLSampler` state after wildcard expansion so phase 2 sampling sees the expanded instances
- Add a sanity check in `expand_wildcards` so a wildcard with zero scene matches fails loudly (.n.01_1 instance no longer required!)

For more context, see #2153.

## Minor changes 

1. When synset has multiple object categories, autogenerate_task_custom_list_template.py currently prompts for at least 1 object model per category -> allow empty input so that when appropriate we don't need to select |# categories| per synset
2. Some tasks (e.g. re_shelving_library_books, putting_away_toys) requires multiple object instances of same synset - thought it would be nice if we can sample unique object models for each instance(sample without replacement)