### PR TITLE
[codex] beep when environment loads

### DIFF
--- a/OmniGibson/omnigibson/envs/env_base.py
+++ b/OmniGibson/omnigibson/envs/env_base.py
@@ -1,5 +1,6 @@
 import random
 import string
+import sys
 from collections import OrderedDict
 from collections.abc import Iterable
 from copy import deepcopy
@@ -445,6 +446,8 @@ class Environment(gym.Env, GymObservable, Recreatable):
 
         # Denote that the scene is loaded
         self._loaded = True
+        sys.stdout.write("\a")
+        sys.stdout.flush()
 
     def update_task(self, task_config):
         """


### PR DESCRIPTION
## Summary

This adds a dependency-free terminal bell when `og.Environment` finishes loading. The beep is emitted in `Environment.post_play_load()` immediately after the environment is marked loaded, which covers normal `og.Environment(...)` construction and vectorized environments that complete loading through the same hook.

## Validation

- `~/miniconda3/condabin/conda run -n behavior python -m py_compile OmniGibson/omnigibson/envs/env_base.py`
- Commit hook: `ruff`
- Commit hook: `ruff-format`

## Notes

A direct `~/miniconda3/condabin/conda run -n behavior ruff check OmniGibson/omnigibson/envs/env_base.py` could not run before commit because `ruff` was not available as a shell command inside the `behavior` environment, but the repository commit hook ran both Ruff checks successfully during commit.