### PR TITLE
Fix JoyLo Home reset after slicing objects

### DIFF
--- a/OmniGibson/omnigibson/utils/usd_utils.py
+++ b/OmniGibson/omnigibson/utils/usd_utils.py
@@ -2469,6 +2469,7 @@ def activate_prim_and_children(prim_path):
     Args:
         prim_path (str): Path to the prim to activate
     """
+
     def _activate(path):
         current_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(path)
         current_prim.SetActive(True)

--- a/OmniGibson/omnigibson/utils/usd_utils.py
+++ b/OmniGibson/omnigibson/utils/usd_utils.py
@@ -2469,11 +2469,14 @@ def activate_prim_and_children(prim_path):
     Args:
         prim_path (str): Path to the prim to activate
     """
-    current_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(prim_path)
-    current_prim.SetActive(True)
-    # Use GetAllChildren to also find those that are inactive
-    for child in current_prim.GetAllChildren():
-        activate_prim_and_children(child.GetPath().pathString)
+    def _activate(path):
+        current_prim = lazy.isaacsim.core.utils.prims.get_prim_at_path(path)
+        current_prim.SetActive(True)
+        for child in current_prim.GetAllChildren():
+            _activate(child.GetPath().pathString)
+
+    with og.sim.editing_usd():
+        _activate(prim_path)
 
 
 def get_sdf_value_type_name(val):

--- a/joylo/gello/robots/og_robot.py
+++ b/joylo/gello/robots/og_robot.py
@@ -271,6 +271,7 @@ class OGRobotServer:
         # Take a single step
         action = self.get_action()
         self.env.step(action)
+        self.robot.keep_still()
 
         # Set up keyboard handlers
         self._setup_keyboard_handlers()
@@ -1098,22 +1099,25 @@ class OGRobotServer:
                         tro_state, serialized=False
                     )
 
-            # Try to ensure that all task-relevant objects are stable
-            # They should already be stable from the sampled instance, but there is some issue where loading the state
-            # causes some jitter (maybe for small mass / thin objects?)
-            for _ in range(25):
-                og.sim.step_physics()
-                for entity in self.env.task.object_scope.values():
-                    if entity is not None and not isinstance(entity, BaseSystem):
-                        entity.keep_still()
-            self.env.scene.update_initial_file()
             print(
                 f"\nLoading task {self.env.task.activity_name} instance id: {self.instance_id}\n"
             )
             utils.update_instance_id_label(self.instance_id_label, self.instance_id)
 
+
+        # Try to ensure that all task-relevant objects are stable
+        # They should already be stable from the sampled instance, but there is some issue where loading the state
+        # causes some jitter (maybe for small mass / thin objects?)
+        for _ in range(25):
+            og.sim.step_physics()
+            for entity in self.env.task.object_scope.values():
+                if entity is not None and not isinstance(entity, BaseSystem):
+                    entity.keep_still()
+        self.env.scene.update_initial_file()
+
         # Reset env
         self.env.reset()
+        self.robot.keep_still()
 
         # If we're recording, record the retroactively record the instance ID from the previous episode
         if (

--- a/joylo/gello/robots/og_robot.py
+++ b/joylo/gello/robots/og_robot.py
@@ -1121,17 +1121,6 @@ class OGRobotServer:
             self.env.scene.update_initial_file()
             self._needs_initial_file_update = False
 
-
-        # Try to ensure that all task-relevant objects are stable
-        # They should already be stable from the sampled instance, but there is some issue where loading the state
-        # causes some jitter (maybe for small mass / thin objects?)
-        for _ in range(25):
-            og.sim.step_physics()
-            for entity in self.env.task.object_scope.values():
-                if entity is not None and not isinstance(entity, BaseSystem):
-                    entity.keep_still()
-        self.env.scene.update_initial_file()
-
         # Reset env
         self.env.reset()
         self.robot.keep_still()

--- a/joylo/gello/robots/og_robot.py
+++ b/joylo/gello/robots/og_robot.py
@@ -1113,9 +1113,11 @@ class OGRobotServer:
             # They should already be stable from the sampled instance, but loading the state can cause jitter.
             for _ in range(25):
                 og.sim.step_physics()
+                self.robot.keep_still()
                 for entity in self.env.task.object_scope.values():
                     if entity is not None and not isinstance(entity, BaseSystem):
                         entity.keep_still()
+            self.robot.keep_still()
             self.env.scene.update_initial_file()
             self._needs_initial_file_update = False
 

--- a/joylo/gello/robots/og_robot.py
+++ b/joylo/gello/robots/og_robot.py
@@ -266,6 +266,7 @@ class OGRobotServer:
         utils.optimize_sim_settings(vr_mode=(VIEWING_MODE == ViewingMode.VR))
 
         # Reset environment to initialize
+        self._needs_initial_file_update = True
         self.reset()
 
         # Take a single step
@@ -1048,10 +1049,12 @@ class OGRobotServer:
         self._joint_cmd["button_home"] = th.zeros(1)
         self._joint_cmd["button_left"] = th.zeros(1)
         self._joint_cmd["button_right"] = th.zeros(1)
+        should_update_initial_file = self._needs_initial_file_update
 
         # Update the instance id / initial state if the instance ID is specified
         # We will manually update the task relevant objects (TRO) state
         if self.instance_id is not None and increment_instance:
+            should_update_initial_file = True
             self.instance_id += 1
             scene_model = self.env.task.scene_name
             tro_filename = self.env.task.get_cached_activity_scene_filename(
@@ -1105,15 +1108,16 @@ class OGRobotServer:
             utils.update_instance_id_label(self.instance_id_label, self.instance_id)
 
 
-        # Try to ensure that all task-relevant objects are stable
-        # They should already be stable from the sampled instance, but there is some issue where loading the state
-        # causes some jitter (maybe for small mass / thin objects?)
-        for _ in range(25):
-            og.sim.step_physics()
-            for entity in self.env.task.object_scope.values():
-                if entity is not None and not isinstance(entity, BaseSystem):
-                    entity.keep_still()
-        self.env.scene.update_initial_file()
+        if should_update_initial_file:
+            # Try to ensure that all task-relevant objects are stable before caching a reset baseline.
+            # They should already be stable from the sampled instance, but loading the state can cause jitter.
+            for _ in range(25):
+                og.sim.step_physics()
+                for entity in self.env.task.object_scope.values():
+                    if entity is not None and not isinstance(entity, BaseSystem):
+                        entity.keep_still()
+            self.env.scene.update_initial_file()
+            self._needs_initial_file_update = False
 
         # Reset env
         self.env.reset()


### PR DESCRIPTION
Home reset in JoyLo was updating the scene initial file on every reset, so after a sliceable object transitioned, the sliced scene could become the new reset baseline. Only refresh the baseline during initial setup or when loading a new sampled task instance.

Also wrap inactive prim reactivation in an editing_usd context so restoring the original object after a transition stays synchronized with Fabric.