### PR TITLE
Add attachment visual guides for teleop

### DIFF
--- a/OmniGibson/omnigibson/object_states/attached_to.py
+++ b/OmniGibson/omnigibson/object_states/attached_to.py
@@ -37,9 +37,33 @@ m.DEFAULT_JOINT_TYPE = JointType.JOINT_FIXED
 m.DEFAULT_BREAK_FORCE = 5000  # Newton
 m.DEFAULT_BREAK_TORQUE = 10000  # Newton-Meter
 m.ENABLE_ATTACHMENT_JOINT_VISUALS = False
-m.ATTACHMENT_JOINT_VISUAL_WIDTH = 0.008
-m.ATTACHMENT_JOINT_VISUAL_LENGTH = 0.15
-m.ATTACHMENT_JOINT_VISUAL_COLOR = th.tensor([0.0, 0.35, 1.0])
+
+# Frame visualizer cylinder configurations
+ATTACHMENT_FRAME_CONFIG = {
+    "width": 0.006,
+    "lengths": [0.15, 0.15, 0.15],
+    "directions": [
+        th.tensor([1.0, 0.0, 0.0]),  # X-axis
+        th.tensor([0.0, 1.0, 0.0]),  # Y-axis
+        th.tensor([0.0, 0.0, 1.0]),  # Z-axis
+    ],
+    "quat_offsets": [
+        T.euler2quat(th.tensor([0.0, th.pi / 2, 0.0])),  # X-axis
+        T.euler2quat(th.tensor([-th.pi / 2, 0.0, 0.0])),  # Y-axis
+        T.euler2quat(th.tensor([0.0, 0.0, 0.0])),  # Z-axis
+    ],
+    "colors": [
+        th.tensor([1.0, 0.0, 0.0]),  # Red for X-axis
+        th.tensor([0.0, 1.0, 0.0]),  # Green for Y-axis
+        th.tensor([0.0, 0.0, 1.0]),  # Blue for Z-axis
+    ],
+}
+m.ATTACHMENT_JOINT_VISUAL_WIDTH = ATTACHMENT_FRAME_CONFIG["width"]
+m.ATTACHMENT_JOINT_VISUAL_LENGTHS = ATTACHMENT_FRAME_CONFIG["lengths"]
+m.ATTACHMENT_JOINT_VISUAL_LENGTH = ATTACHMENT_FRAME_CONFIG["lengths"][0]
+m.ATTACHMENT_JOINT_VISUAL_DIRECTIONS = ATTACHMENT_FRAME_CONFIG["directions"]
+m.ATTACHMENT_JOINT_VISUAL_COLORS = ATTACHMENT_FRAME_CONFIG["colors"]
+m.ATTACHMENT_JOINT_VISUAL_ROTATIONS = ATTACHMENT_FRAME_CONFIG["quat_offsets"]
 
 
 # TODO: Make AttachedTo into a global state that manages all the attachments in the scene.
@@ -125,48 +149,66 @@ class AttachedTo(
 
     def _create_attachment_joint_visuals(self):
         """
-        Creates a visual-only local +Z cue under each attachment meta link. The marker starts at the attachment point
-        and extends in the link's up direction so matching male and female cues is visually straightforward.
+        Creates three visual-only axis cues (X, Y, Z) for each attachment meta link.
+        The markers start at the attachment point and extend in their respective directions:
+        X-axis (Red), Y-axis (Green), Z-axis (Blue).
         """
         scene = self.obj.scene
-        mat_prim_path = f"{self.obj.prim_path}/Looks/attachment_joint_visual_up_mat"
-        mat = OmniPBRMaterialPrim(
-            relative_prim_path=absolute_prim_path_to_scene_relative(scene, mat_prim_path),
-            name=f"{self.obj.name}:attachment_joint_visual_up_mat",
-        )
-        mat.load(scene)
-        mat.diffuse_color_constant = m.ATTACHMENT_JOINT_VISUAL_COLOR
+
+        # Create materials for each axis
+        axis_names = ("x", "y", "z")
+        axis_materials = []
+        for axis, color in zip(axis_names, m.ATTACHMENT_JOINT_VISUAL_COLORS):
+            mat_prim_path = f"{self.obj.prim_path}/Looks/attachment_joint_visual_{axis}_mat"
+            mat = OmniPBRMaterialPrim(
+                relative_prim_path=absolute_prim_path_to_scene_relative(scene, mat_prim_path),
+                name=f"{self.obj.name}:attachment_joint_visual_{axis}_mat",
+            )
+            mat.load(scene)
+            mat.diffuse_color_constant = color
+            axis_materials.append(mat)
 
         for link_name, link in self.links.items():
             if not link.meta_link_id.endswith(("M", "F")):
                 continue
 
-            vis_prim_path = f"{link.prim_path}/attachment_joint_visual_up"
-            create_primitive_mesh(vis_prim_path, "Cylinder", extents=1.0)
-            visualizer = GeomPrim(
-                relative_prim_path=absolute_prim_path_to_scene_relative(scene, vis_prim_path),
-                name=f"{self.obj.name}:{link_name}:attachment_joint_visual_up",
-            )
-            visualizer.load(scene)
-            visualizer.material = mat
-            visualizer.scale = (
-                th.tensor(
-                    [
-                        m.ATTACHMENT_JOINT_VISUAL_WIDTH,
-                        m.ATTACHMENT_JOINT_VISUAL_WIDTH,
-                        m.ATTACHMENT_JOINT_VISUAL_LENGTH,
-                    ]
-                )
-                / link.scale
-            )
-            visualizer.set_position_orientation(
-                position=th.tensor([0.0, 0.0, m.ATTACHMENT_JOINT_VISUAL_LENGTH / 2.0]) / link.scale,
-                orientation=th.tensor([0.0, 0.0, 0.0, 1.0]),
-                frame="parent",
-            )
-            visualizer.visible = True
+            frame_visualizers = []
 
-            self.attachment_joint_visuals[link_name] = [visualizer]
+            # Create three cylinders (X, Y, Z axes)
+            for axis, mat, direction, quat_offset, length in zip(
+                axis_names,
+                axis_materials,
+                m.ATTACHMENT_JOINT_VISUAL_DIRECTIONS,
+                m.ATTACHMENT_JOINT_VISUAL_ROTATIONS,
+                m.ATTACHMENT_JOINT_VISUAL_LENGTHS,
+            ):
+                vis_prim_path = f"{link.prim_path}/attachment_joint_visual_{axis}"
+                create_primitive_mesh(vis_prim_path, "Cylinder", extents=1.0)
+                visualizer = GeomPrim(
+                    relative_prim_path=absolute_prim_path_to_scene_relative(scene, vis_prim_path),
+                    name=f"{self.obj.name}:{link_name}:attachment_joint_visual_{axis}",
+                )
+                visualizer.load(scene)
+                visualizer.material = mat
+                visualizer.scale = (
+                    th.tensor(
+                        [
+                            m.ATTACHMENT_JOINT_VISUAL_WIDTH,
+                            m.ATTACHMENT_JOINT_VISUAL_WIDTH,
+                            length,
+                        ]
+                    )
+                    / link.scale
+                )
+                visualizer.set_position_orientation(
+                    position=direction * (length / 2.0) / link.scale,
+                    orientation=quat_offset,
+                    frame="parent",
+                )
+                visualizer.visible = True
+                frame_visualizers.append(visualizer)
+
+            self.attachment_joint_visuals[link_name] = frame_visualizers
 
     def on_joint_break(self, joint_prim_path):
         # Note that when this function is invoked when a joint break event happens, @self.obj is the parent of the

--- a/OmniGibson/omnigibson/object_states/attached_to.py
+++ b/OmniGibson/omnigibson/object_states/attached_to.py
@@ -9,10 +9,18 @@ from omnigibson.object_states.joint_break_subscribed_state_mixin import JointBre
 from omnigibson.object_states.link_based_state_mixin import LinkBasedStateMixin
 from omnigibson.object_states.object_state_base import BooleanStateMixin, RelativeObjectState
 from omnigibson.object_states.update_state_mixin import UpdateStateMixin
+from omnigibson.prims.geom_prim import GeomPrim
+from omnigibson.prims.material_prim import OmniPBRMaterialPrim
 from omnigibson.utils.constants import JointType
 from omnigibson.utils.python_utils import classproperty
 from omnigibson.utils.ui_utils import create_module_logger
-from omnigibson.utils.usd_utils import RigidContactAPI, create_joint, delete_or_deactivate_prim
+from omnigibson.utils.usd_utils import (
+    RigidContactAPI,
+    absolute_prim_path_to_scene_relative,
+    create_joint,
+    create_primitive_mesh,
+    delete_or_deactivate_prim,
+)
 
 # Create module logger
 log = create_module_logger(module_name=__name__)
@@ -28,6 +36,10 @@ m.DEFAULT_ORIENTATION_THRESHOLD = th.deg2rad(th.tensor([15.0])).item()  # 15 deg
 m.DEFAULT_JOINT_TYPE = JointType.JOINT_FIXED
 m.DEFAULT_BREAK_FORCE = 5000  # Newton
 m.DEFAULT_BREAK_TORQUE = 10000  # Newton-Meter
+m.ENABLE_ATTACHMENT_JOINT_VISUALS = False
+m.ATTACHMENT_JOINT_VISUAL_WIDTH = 0.008
+m.ATTACHMENT_JOINT_VISUAL_LENGTH = 0.15
+m.ATTACHMENT_JOINT_VISUAL_COLOR = th.tensor([0.0, 0.35, 1.0])
 
 
 # TODO: Make AttachedTo into a global state that manages all the attachments in the scene.
@@ -90,6 +102,10 @@ class AttachedTo(
         super()._initialize()
         self.initialize_link_mixin()
 
+        self.attachment_joint_visuals = defaultdict(list)
+        if m.ENABLE_ATTACHMENT_JOINT_VISUALS:
+            self._create_attachment_joint_visuals()
+
         # Reference to the parent object (DatasetObject)
         self.parent = None
 
@@ -106,6 +122,51 @@ class AttachedTo(
         # Cache of parent link candidates for other objects (Dict[DatasetObject, Dict[str, str]])
         # @other -> (the male meta link names of @self.obj -> the correspounding female meta link names of @other))
         self.parent_link_candidates = dict()
+
+    def _create_attachment_joint_visuals(self):
+        """
+        Creates a visual-only local +Z cue under each attachment meta link. The marker starts at the attachment point
+        and extends in the link's up direction so matching male and female cues is visually straightforward.
+        """
+        scene = self.obj.scene
+        mat_prim_path = f"{self.obj.prim_path}/Looks/attachment_joint_visual_up_mat"
+        mat = OmniPBRMaterialPrim(
+            relative_prim_path=absolute_prim_path_to_scene_relative(scene, mat_prim_path),
+            name=f"{self.obj.name}:attachment_joint_visual_up_mat",
+        )
+        mat.load(scene)
+        mat.diffuse_color_constant = m.ATTACHMENT_JOINT_VISUAL_COLOR
+
+        for link_name, link in self.links.items():
+            if not link.meta_link_id.endswith(("M", "F")):
+                continue
+
+            vis_prim_path = f"{link.prim_path}/attachment_joint_visual_up"
+            create_primitive_mesh(vis_prim_path, "Cylinder", extents=1.0)
+            visualizer = GeomPrim(
+                relative_prim_path=absolute_prim_path_to_scene_relative(scene, vis_prim_path),
+                name=f"{self.obj.name}:{link_name}:attachment_joint_visual_up",
+            )
+            visualizer.load(scene)
+            visualizer.material = mat
+            visualizer.scale = (
+                th.tensor(
+                    [
+                        m.ATTACHMENT_JOINT_VISUAL_WIDTH,
+                        m.ATTACHMENT_JOINT_VISUAL_WIDTH,
+                        m.ATTACHMENT_JOINT_VISUAL_LENGTH,
+                    ]
+                )
+                / link.scale
+            )
+            visualizer.set_position_orientation(
+                position=th.tensor([0.0, 0.0, m.ATTACHMENT_JOINT_VISUAL_LENGTH / 2.0]) / link.scale,
+                orientation=th.tensor([0.0, 0.0, 0.0, 1.0]),
+                frame="parent",
+            )
+            visualizer.visible = True
+
+            self.attachment_joint_visuals[link_name] = [visualizer]
 
     def on_joint_break(self, joint_prim_path):
         # Note that when this function is invoked when a joint break event happens, @self.obj is the parent of the

--- a/joylo/gello/robots/og_robot.py
+++ b/joylo/gello/robots/og_robot.py
@@ -7,6 +7,7 @@ import json
 import omnigibson as og
 import omnigibson.lazy as lazy
 from omnigibson.envs import HDF5CollectionWrapper
+from omnigibson.macros import macros
 from omnigibson.robots import Robot, REGISTERED_ROBOTS
 from omnigibson.tasks import BehaviorTask
 from omnigibson.systems.system_base import BaseSystem
@@ -38,6 +39,7 @@ class OGRobotServer:
         partial_load: bool = True,
         instance_id: Optional[int] = None,
         ghosting: bool = True,
+        attachment_joint_visuals: Optional[bool] = None,
     ):
         if task_name is not None:
             available_tasks = utils.load_available_tasks()
@@ -62,6 +64,14 @@ class OGRobotServer:
             self.task_name = None
             self.task_cfg = None
             self.instance_id = None
+
+        enable_attachment_joint_visuals = (
+            utils.task_requires_attached_state(self.task_name)
+            if attachment_joint_visuals is None
+            else attachment_joint_visuals
+        )
+        with macros.unlocked():
+            macros.object_states.attached_to.ENABLE_ATTACHMENT_JOINT_VISUALS = enable_attachment_joint_visuals
 
         utils.apply_omnigibson_macros()
 
@@ -345,16 +355,15 @@ class OGRobotServer:
                 and obj.category != "agent"
                 and obj.category not in EXTRA_TASK_RELEVANT_CATEGORIES
             ]
-            
+
             # Setup object beacons
             self.object_beacons = utils.setup_object_beacons(
                 self.task_relevant_objects, self.env.scene
             )
 
-            # Setup task-specific visualizers
-            self.task_visualizers = utils.setup_task_visualizers(
-                self.task_relevant_objects, self.env.scene
-            )
+            # Attachment guides are owned by the AttachedTo object state. Keep this as a placeholder for future
+            # JoyLo-specific task visualizers.
+            self.task_visualizers = {}
 
             # Get task-irrelevant objects
             self.task_irrelevant_objects = [
@@ -371,6 +380,7 @@ class OGRobotServer:
             self.task_relevant_objects = []
             self.task_irrelevant_objects = []
             self.object_beacons = {}
+            self.task_visualizers = {}
 
     def _setup_keyboard_handlers(self):
         """Set up keyboard event handlers"""

--- a/joylo/gello/utils/og_teleop_cfg.py
+++ b/joylo/gello/utils/og_teleop_cfg.py
@@ -364,22 +364,6 @@ VIS_CYLINDER_CONFIG = {
     ],
 }
 
-# Frame visualizer cylinder configurations
-ATTACHMENT_FRAME_CONFIG = {
-    "width": 0.008,
-    "lengths": [0.15, 0.15, 0.15],
-    "quat_offsets": [
-        T.euler2quat(th.tensor([0.0, th.pi / 2, 0.0])),  # X-axis (red)
-        T.euler2quat(th.tensor([-th.pi / 2, 0.0, 0.0])),  # Y-axis (green)
-        T.euler2quat(th.tensor([0.0, 0.0, 0.0])),  # Z-axis (blue)
-    ],
-    "colors": [
-        th.tensor([1.0, 0.0, 0.0]),  # Red for X-axis
-        th.tensor([0.0, 1.0, 0.0]),  # Green for Y-axis
-        th.tensor([0.0, 0.0, 1.0]),  # Blue for Z-axis
-    ],
-}
-
 # External camera parameters
 EXTERNAL_CAMERA_CONFIGS = {
     "external_sensor0": {

--- a/joylo/gello/utils/og_teleop_utils.py
+++ b/joylo/gello/utils/og_teleop_utils.py
@@ -27,6 +27,27 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--activity", type=str, required=True)
 
 
+def _contains_predicate(condition, predicate):
+    if isinstance(condition, (list, tuple)):
+        return any(_contains_predicate(entry, predicate) for entry in condition)
+    return condition == predicate
+
+
+def task_requires_attached_state(task_name):
+    if task_name is None:
+        return False
+
+    try:
+        conditions = get_knowledge_base().get_task(f"{task_name}-0").parse_base_scope()[0]
+    except Exception:
+        return False
+
+    return any(
+        _contains_predicate(condition, "attached")
+        for condition in conditions.parsed_initial_conditions + conditions.parsed_goal_conditions
+    )
+
+
 def get_task_relevant_room_types(activity_name):
     task_obj = get_knowledge_base().get_task(f"{activity_name}-0")
     conditions = task_obj.parse_base_scope()[0]
@@ -932,77 +953,6 @@ def setup_object_beacons(task_relevant_objects, scene):
         beacon.visible = False
 
     return object_beacons
-
-
-def setup_task_visualizers(task_relevant_objects, scene):
-    task_visualizers = {}
-
-    # Extract frame visualization settings
-    vis_geom_width = ATTACHMENT_FRAME_CONFIG["width"]
-    vis_geom_lengths = ATTACHMENT_FRAME_CONFIG["lengths"]
-    vis_geom_quat_offsets = ATTACHMENT_FRAME_CONFIG["quat_offsets"]
-    vis_geom_colors = ATTACHMENT_FRAME_CONFIG["colors"]
-
-    for obj in task_relevant_objects:
-        for link in obj.links.values():
-            if link.is_meta_link and link.meta_link_type == "attachment":
-                # Create frame visualizer for the attachment link
-                frame_visualizers = []
-
-                # Create materials for each axis
-                axis_materials = []
-                for axis, color in zip(("x", "y", "z"), vis_geom_colors):
-                    mat = OmniPBRMaterialPrim(
-                        relative_prim_path=absolute_prim_path_to_scene_relative(
-                            scene, f"{link.prim_path}/attachment_frame_mat_{axis}"
-                        ),
-                        name=f"{obj.name}:attachment_frame_mat_{axis}",
-                    )
-                    mat.load(scene)
-                    mat.diffuse_color_constant = color
-                    axis_materials.append(mat)
-
-                # Create cylinder for each axis (X, Y, Z)
-                for axis, length, mat, quat_offset in zip(
-                    ("x", "y", "z"),
-                    vis_geom_lengths,
-                    axis_materials,
-                    vis_geom_quat_offsets,
-                ):
-                    vis_prim_path = f"{link.prim_path}/attachment_frame_{axis}"
-                    vis_prim = create_primitive_mesh(
-                        vis_prim_path, "Cylinder", extents=1.0
-                    )
-                    visualizer = GeomPrim(
-                        relative_prim_path=absolute_prim_path_to_scene_relative(
-                            scene, vis_prim_path
-                        ),
-                        name=f"{obj.name}:attachment_frame_{axis}",
-                    )
-                    visualizer.load(scene)
-
-                    # Attach material
-                    visualizer.material = mat
-
-                    # Scale the cylinder and normalize with link scale
-                    visualizer.scale = (
-                        th.tensor([vis_geom_width, vis_geom_width, length]) / link.scale
-                    )
-
-                    # Set position and orientation relative to the attachment link
-                    visualizer.set_position_orientation(
-                        position=th.tensor([0, 0, 0]),
-                        orientation=quat_offset,
-                        frame="parent",
-                    )
-
-                    visualizer.visible = False  # Initially hidden
-                    frame_visualizers.append(visualizer)
-
-                # Store all three axis visualizers for this attachment
-                task_visualizers[obj] = frame_visualizers
-
-    return task_visualizers
 
 
 def setup_ghost_robot(scene, robot_type, task_cfg=None):

--- a/joylo/scripts/launch_og.py
+++ b/joylo/scripts/launch_og.py
@@ -14,10 +14,10 @@ class Args:
     partial_load: Optional[bool] = True
     instance_id: Optional[int] = None
     ghosting: Optional[bool] = True
+    attachment_joint_visuals: Optional[bool] = None
 
 
 def launch_robot_server(args: Args):
-
     server = OGRobotServer(
         robot=args.robot,
         port=args.robot_port,
@@ -26,7 +26,8 @@ def launch_robot_server(args: Args):
         task_name=args.task_name,
         partial_load=args.partial_load,
         instance_id=args.instance_id,
-        ghosting=args.ghosting
+        ghosting=args.ghosting,
+        attachment_joint_visuals=args.attachment_joint_visuals,
     )
     server.serve()
 


### PR DESCRIPTION
Adds visual-only local +Z guides for attachment meta links so teleop users can align male/female attachment points more easily. Auto enables them in JoyLo for tasks with `attached` BDDL predicates, while removing the old attachment visualization implementation.