### PR TITLE
Enable RT2 and fractional opacity

### DIFF
--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -619,6 +619,11 @@ def _launch_simulator(*args, **kwargs):
 
         def _set_renderer_settings(self):
             settings = lazy.carb.settings.get_settings()
+            settings.set_bool("/rtx/rtx/modes/rt/enabled", True) # real-time 2.0 requires rt to be enabled as well 
+            settings.set_bool("/rtx/rtx/modes/rt2/enabled", True)
+            settings.set("/rtx/rendermode", "RealTimePathTracing")
+            settings.set_bool("/rtx/raytracing/fractionalCutoutOpacity", True)
+
             settings.set_bool("/rtx/reflections/enabled", True)
             settings.set_bool("/rtx/indirectDiffuse/enabled", True)
             settings.set_int(

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -619,7 +619,7 @@ def _launch_simulator(*args, **kwargs):
 
         def _set_renderer_settings(self):
             settings = lazy.carb.settings.get_settings()
-            settings.set_bool("/rtx/rtx/modes/rt/enabled", True) # real-time 2.0 requires rt to be enabled as well 
+            settings.set_bool("/rtx/rtx/modes/rt/enabled", True)  # real-time 2.0 requires rt to be enabled as well
             settings.set_bool("/rtx/rtx/modes/rt2/enabled", True)
             settings.set("/rtx/rendermode", "RealTimePathTracing")
             settings.set_bool("/rtx/raytracing/fractionalCutoutOpacity", True)

--- a/joylo/gello/utils/og_teleop_utils.py
+++ b/joylo/gello/utils/og_teleop_utils.py
@@ -1025,12 +1025,6 @@ def optimize_sim_settings(vr_mode=False):
         # Additional RTX settings
         settings.set_bool("/rtx-transient/dlssg/enabled", True)
 
-        # Disable fractional cutout opacity for speed
-        # Alternatively, turn this on so that we can use semi-translucent visualizers
-        lazy.carb.settings.get_settings().set_bool(
-            "/rtx/raytracing/fractionalCutoutOpacity", False
-        )
-
     # Does this improve things?
     # See https://docs.omniverse.nvidia.com/kit/docs/omni.timeline/latest/TIME_STEPPING.html#synchronizing-wall-clock-time-and-simulation-time
     # Obtain the main timeline object


### PR DESCRIPTION
This PR enables RTX Real-Time 2.0 by default and turns on fractional cutout opacity that makes interaction with objects with OmniGlass material possible.

See [NVIDIA Documentation on RT2](https://docs.omniverse.nvidia.com/materials-and-rendering/latest/rtx-renderer_rt.html) for further information.
