### PR TITLE
Set finite inertia for collisionless / visual-only rigid links

### DIFF
--- a/OmniGibson/omnigibson/prims/entity_prim.py
+++ b/OmniGibson/omnigibson/prims/entity_prim.py
@@ -273,7 +273,7 @@ class EntityPrim(XFormPrim):
         These links are still represented as rigid prims so their transforms remain available, but GPU dynamics is
         less tolerant of articulation bodies that intentionally have no physical collision response.
         """
-        if not gm.USE_GPU_DYNAMICS:
+        if not gm.USE_GPU_DYNAMICS or self._prim_type != PrimType.RIGID:
             return
 
         non_physical_link_paths = {

--- a/OmniGibson/omnigibson/prims/entity_prim.py
+++ b/OmniGibson/omnigibson/prims/entity_prim.py
@@ -125,7 +125,6 @@ class EntityPrim(XFormPrim):
                 lazy.omni.kit.commands.execute("DeletePrims", paths=[old_link_prim.GetPath()], destructive=False)
 
         self.update_links()
-        self._exclude_non_physical_joints_from_gpu_articulations()
         self._compute_articulation_tree()
 
         # Prepare the articulation view.
@@ -265,32 +264,6 @@ class EntityPrim(XFormPrim):
                 load_config=link_load_config,
             )
             self._links[link_name].load(self.scene)
-
-    def _exclude_non_physical_joints_from_gpu_articulations(self):
-        """
-        Keep visual-only / semantic marker links out of GPU articulation constraint solving.
-
-        These links are still represented as rigid prims so their transforms remain available, but GPU dynamics is
-        less tolerant of articulation bodies that intentionally have no physical collision response.
-        """
-        if not gm.USE_GPU_DYNAMICS or self._prim_type != PrimType.RIGID:
-            return
-
-        non_physical_link_paths = {
-            link.prim_path
-            for link in self._links.values()
-            if link.visual_only or (link.is_meta_link and not link.has_collision_meshes)
-        }
-        if not non_physical_link_paths:
-            return
-
-        with og.sim.editing_usd():
-            for joint_prim in find_joint_prims(self._prim):
-                body0_targets = joint_prim.GetRelationship("physics:body0").GetTargets()
-                body1_targets = joint_prim.GetRelationship("physics:body1").GetTargets()
-                joint_body_paths = {target.pathString for target in (*body0_targets, *body1_targets)}
-                if joint_body_paths & non_physical_link_paths:
-                    joint_prim.GetAttribute("physics:excludeFromArticulation").Set(True)
 
     def update_joints(self):
         """

--- a/OmniGibson/omnigibson/prims/entity_prim.py
+++ b/OmniGibson/omnigibson/prims/entity_prim.py
@@ -125,6 +125,7 @@ class EntityPrim(XFormPrim):
                 lazy.omni.kit.commands.execute("DeletePrims", paths=[old_link_prim.GetPath()], destructive=False)
 
         self.update_links()
+        self._exclude_non_physical_joints_from_gpu_articulations()
         self._compute_articulation_tree()
 
         # Prepare the articulation view.
@@ -264,6 +265,32 @@ class EntityPrim(XFormPrim):
                 load_config=link_load_config,
             )
             self._links[link_name].load(self.scene)
+
+    def _exclude_non_physical_joints_from_gpu_articulations(self):
+        """
+        Keep visual-only / semantic marker links out of GPU articulation constraint solving.
+
+        These links are still represented as rigid prims so their transforms remain available, but GPU dynamics is
+        less tolerant of articulation bodies that intentionally have no physical collision response.
+        """
+        if not gm.USE_GPU_DYNAMICS:
+            return
+
+        non_physical_link_paths = {
+            link.prim_path
+            for link in self._links.values()
+            if link.visual_only or (link.is_meta_link and not link.has_collision_meshes)
+        }
+        if not non_physical_link_paths:
+            return
+
+        with og.sim.editing_usd():
+            for joint_prim in find_joint_prims(self._prim):
+                body0_targets = joint_prim.GetRelationship("physics:body0").GetTargets()
+                body1_targets = joint_prim.GetRelationship("physics:body1").GetTargets()
+                joint_body_paths = {target.pathString for target in (*body0_targets, *body1_targets)}
+                if joint_body_paths & non_physical_link_paths:
+                    joint_prim.GetAttribute("physics:excludeFromArticulation").Set(True)
 
     def update_joints(self):
         """

--- a/OmniGibson/omnigibson/prims/rigid_prim.py
+++ b/OmniGibson/omnigibson/prims/rigid_prim.py
@@ -30,6 +30,8 @@ m = create_module_macros(module_path=__file__)
 
 m.DEFAULT_CONTACT_OFFSET = 0.001
 m.DEFAULT_REST_OFFSET = 0.0
+m.DEFAULT_COLLISIONLESS_LINK_MASS = 1e-4
+m.DEFAULT_COLLISIONLESS_LINK_INERTIA = 1e-5
 m.LEGACY_META_LINK_PATTERN = re.compile(r".*:(\w+)_([A-Za-z0-9]+)_(\d+)_link")
 
 
@@ -91,7 +93,7 @@ class RigidPrim(XFormPrim):
         # Apply rigid body and mass APIs
         ensure_usd_api(self._prim, lazy.pxr.UsdPhysics.RigidBodyAPI)
         ensure_usd_api(self._prim, lazy.pxr.PhysxSchema.PhysxRigidBodyAPI)
-        ensure_usd_api(self._prim, lazy.pxr.UsdPhysics.MassAPI)
+        mass_api = ensure_usd_api(self._prim, lazy.pxr.UsdPhysics.MassAPI)
 
         # Check if it's part of an articulation view
         self._belongs_to_articulation = (
@@ -117,9 +119,14 @@ class RigidPrim(XFormPrim):
 
         # Possibly set the mass / density
         if not self.has_collision_meshes:
-            # A meta (virtual) link has no collision meshes; set a negligible mass and a zero density (ignored)
-            self.mass = 1e-6
+            # A collisionless link still needs non-singular mass properties if it participates in an articulation.
+            self.mass = m.DEFAULT_COLLISIONLESS_LINK_MASS
             self.density = 0.0
+            with og.sim.editing_usd():
+                mass_api.GetDiagonalInertiaAttr().Set(
+                    lazy.pxr.Gf.Vec3f(*([m.DEFAULT_COLLISIONLESS_LINK_INERTIA] * 3))
+                )
+                mass_api.GetPrincipalAxesAttr().Set(lazy.pxr.Gf.Quatf(1.0, 0.0, 0.0, 0.0))
         elif "mass" in self._load_config and self._load_config["mass"] is not None:
             self.mass = self._load_config["mass"]
         if "density" in self._load_config and self._load_config["density"] is not None:

--- a/OmniGibson/omnigibson/prims/rigid_prim.py
+++ b/OmniGibson/omnigibson/prims/rigid_prim.py
@@ -123,9 +123,7 @@ class RigidPrim(XFormPrim):
             self.mass = m.DEFAULT_COLLISIONLESS_LINK_MASS
             self.density = 0.0
             with og.sim.editing_usd():
-                mass_api.GetDiagonalInertiaAttr().Set(
-                    lazy.pxr.Gf.Vec3f(*([m.DEFAULT_COLLISIONLESS_LINK_INERTIA] * 3))
-                )
+                mass_api.GetDiagonalInertiaAttr().Set(lazy.pxr.Gf.Vec3f(*([m.DEFAULT_COLLISIONLESS_LINK_INERTIA] * 3)))
                 mass_api.GetPrincipalAxesAttr().Set(lazy.pxr.Gf.Quatf(1.0, 0.0, 0.0, 0.0))
         elif "mass" in self._load_config and self._load_config["mass"] is not None:
             self.mass = self._load_config["mass"]


### PR DESCRIPTION
GPU dynamics crashes caused by collisionless rigid links participating in articulations.

Collisionless links, such as visual-only or semantic/meta links, were assigned a tiny mass but could still end up with degenerate inertia properties. PhysX GPU articulation solving is less tolerant of these singular mass properties and could fail in GPU solver prep / zero-body kernels (e.g resetVelocity kernel etc.).