### PR TITLE
Fix wildcard task sampling + a

### DIFF
--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -55,7 +55,7 @@ class BehaviorTask(BaseTask):
             mapping category name (e.g.: "breakfast_table") to a list of invalid models that should not be sampled from
             that category. During sampling, if a given synset is found in this blacklist, all specified
             models will not be used as options
-        unique_models_per_synset (bool): If True, ensures that each instance of the same synset is assigned a distinct
+        use_unique_models_per_synset (bool): If True, ensures that each instance of the same synset is assigned a distinct
             object model (sampling without replacement). Sampling fails if there are fewer valid models than instances
             for a given synset. Only applies when online_object_sampling is True.
         highlight_task_relevant_objects (bool): whether to overlay task-relevant objects in the scene with a colored mask
@@ -80,7 +80,7 @@ class BehaviorTask(BaseTask):
         randomize_presampled_pose=False,
         sampling_whitelist=None,
         sampling_blacklist=None,
-        unique_models_per_synset=False,
+        use_unique_models_per_synset=False,
         highlight_task_relevant_objects=False,
         termination_config=None,
         reward_config=None,
@@ -117,7 +117,7 @@ class BehaviorTask(BaseTask):
         self.randomize_presampled_pose = randomize_presampled_pose
         self.sampling_whitelist = sampling_whitelist  # Maps str to str to list
         self.sampling_blacklist = sampling_blacklist  # Maps str to str to list
-        self.unique_models_per_synset = unique_models_per_synset  # bool
+        self.use_unique_models_per_synset = use_unique_models_per_synset  # bool
         self.highlight_task_relevant_objs = highlight_task_relevant_objects  # bool
         self.object_scope = None  # Maps str to sim object (BaseObject/BaseSystem) or None
         self.object_instance_to_category = None  # Maps str to str
@@ -447,7 +447,7 @@ class BehaviorTask(BaseTask):
             accept_scene, feedback = self.sampler.assign_objects(
                 sampling_whitelist=self.sampling_whitelist,
                 sampling_blacklist=self.sampling_blacklist,
-                unique_models_per_synset=self.unique_models_per_synset,
+                use_unique_models_per_synset=self.use_unique_models_per_synset,
             )
             if not accept_scene:
                 return accept_scene, feedback

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -55,6 +55,9 @@ class BehaviorTask(BaseTask):
             mapping category name (e.g.: "breakfast_table") to a list of invalid models that should not be sampled from
             that category. During sampling, if a given synset is found in this blacklist, all specified
             models will not be used as options
+        unique_models_per_synset (bool): If True, ensures that each instance of the same synset is assigned a distinct
+            object model (sampling without replacement). Sampling fails if there are fewer valid models than instances
+            for a given synset. Only applies when online_object_sampling is True.
         highlight_task_relevant_objects (bool): whether to overlay task-relevant objects in the scene with a colored mask
         termination_config (None or dict): Keyword-mapped configuration to use to generate termination conditions. This
             should be specific to the task class. Default is None, which corresponds to a default config being usd.
@@ -77,6 +80,7 @@ class BehaviorTask(BaseTask):
         randomize_presampled_pose=False,
         sampling_whitelist=None,
         sampling_blacklist=None,
+        unique_models_per_synset=False,
         highlight_task_relevant_objects=False,
         termination_config=None,
         reward_config=None,
@@ -113,6 +117,7 @@ class BehaviorTask(BaseTask):
         self.randomize_presampled_pose = randomize_presampled_pose
         self.sampling_whitelist = sampling_whitelist  # Maps str to str to list
         self.sampling_blacklist = sampling_blacklist  # Maps str to str to list
+        self.unique_models_per_synset = unique_models_per_synset  # bool
         self.highlight_task_relevant_objs = highlight_task_relevant_objects  # bool
         self.object_scope = None  # Maps str to sim object (BaseObject/BaseSystem) or None
         self.object_instance_to_category = None  # Maps str to str
@@ -442,6 +447,7 @@ class BehaviorTask(BaseTask):
             accept_scene, feedback = self.sampler.assign_objects(
                 sampling_whitelist=self.sampling_whitelist,
                 sampling_blacklist=self.sampling_blacklist,
+                unique_models_per_synset=self.unique_models_per_synset,
             )
             if not accept_scene:
                 return accept_scene, feedback

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -421,11 +421,21 @@ class BehaviorTask(BaseTask):
         """
         Initializes the desired activity in the current environment @env
 
-        The flow is:
-        1. Select objects for the base (non-wildcard) scope via sampling or cache.
-        2. Determine which room instances those objects are in.
-        3. Compile the task with the correct scene layout (expanding any wildcards).
-        4. Assign any wildcard-expanded instances.
+        Online flow:
+        1. ``assign_objects`` builds inroom candidates and imports sampleable objects.
+        2. Compile a wildcard-stripped base task and run ``sample_states`` — this
+           performs bipartite matching, binding each base inroom obj_inst to a
+           specific scene object in a specific room instance.
+        3. Clear the bindings of every wildcard-synset base instance so the
+           subsequent expansion treats all instances uniformly.
+        4. Recompile with the real scene layout (now derivable from the matched
+           rooms) — ``expand_wildcards`` produces ``synset_1 .. synset_N``.
+        5. Assign each wildcard instance to a free scene object in the matched room.
+
+        Offline (cache) flow:
+        1. Read ``inst_to_name`` from cached scene metadata.
+        2. Compile using the cached instance names.
+        3. Assign every object from the cache in a single pass.
 
         Args:
             env (Environment): Current active environment instance
@@ -452,67 +462,88 @@ class BehaviorTask(BaseTask):
             if not accept_scene:
                 return accept_scene, feedback
 
-            # Compile with the correct rooms now that objects are assigned
-            self._compile_with_rooms(env)
-
+            # Compile a wildcard-stripped base task.
+            self.compiled_task = self._task_def.compile_base()
+            self._finalize_compiled_task()
+            
             # Phase 2: sample states using compiled conditions
             accept_scene, feedback = self.sampler.sample_states(self.compiled_task)
             if not accept_scene:
                 return accept_scene, feedback
 
-            # Assign any wildcard-expanded instances to remaining scene objects
-            self._assign_wildcard_instances(env)
+            # Wildcards expand AFTER matching rooms
+            if self._task_def.has_wildcards:
+                self._unbind_wildcard_synset_bases()
+                self._compile_with_rooms(env)
+                self._assign_wildcard_instances(env)
         else:
-            # Derive future instances from parsed conditions for cache assignment
-            self.future_obj_instances = {
-                cond[1] for cond in self._base_conditions.parsed_initial_conditions if cond[0] == "future"
-            }
-
-            # Assign base scope objects from cache (non-strict: skip instances
-            # not in cache, e.g. wildcard instances that don't exist yet)
-            self.assign_object_scope_with_cache(env)
-
-            # Compile with correct rooms now that we know where objects are
-            self._compile_with_rooms(env)
-
-            # Re-assign all objects from cache (scope now includes wildcard instances)
+            inst_to_name = env.scene.get_task_metadata(key="inst_to_name")
+            self.compiled_task = self._task_def.compile_from_inst_to_name(inst_to_name)
+            self._finalize_compiled_task()
             self.future_obj_instances = {
                 init_cond.body[1] for init_cond in self.activity_initial_conditions if init_cond.body[0] == "future"
             }
-            # Use non-strict so that wildcard-expanded instances absent from cache are handled by
-            # _assign_wildcard_instances below rather than raising an assertion error.
-            # TODO @wensi-ai: Check object scope again to see if any wildcard objects are recorded. 2026+ tasks do this, 2025 ones don't.
             self.assign_object_scope_with_cache(env)
-            # TODO @wensi-ai: Assign objects to remaining wildcard objects. This is a no-op for 2026+ tasks.
-            self._assign_wildcard_instances(env)
-            # assert that everything in the object scope that's not a future object is not None
             for inst, entity in self.object_scope.items():
                 if inst not in self.future_obj_instances and entity is None:
                     raise ValueError(f"Object instance '{inst}' was not assigned an entity during cache assignment!")
 
         return True, None
 
+    def _unbind_wildcard_synset_bases(self):
+        """Release the anchor instances (e.g. ``bookcase.n.01_1``) of wildcard synsets so wildcard expansion can re-pool them with ``synset_1..._N``."""
+        wildcard_synsets = self._task_def.wildcard_synsets
+        if not wildcard_synsets:
+            return
+        for inst in list(self.object_scope.keys()):
+            synset = self.object_instance_to_category.get(inst)
+            if synset in wildcard_synsets:
+                self.object_scope[inst] = None
+
     def _assign_wildcard_instances(self, env):
-        """Assign wildcard-expanded instances to scene objects in the selected rooms.
+        """Assign each unbound wildcard instance to a scene object in its matched room, in numeric-suffix order."""
+        def numeric_suffix(name):
+            try:
+                return int(name.rsplit("_", 1)[1])
+            except (IndexError, ValueError):
+                return -1
 
-        After wildcard compilation, new instances exist in the scope that need
-        to be matched to objects in the scene that weren't part of the base scope.
+        # Collect unbound slots in suffix order and track already-claimed scene objects
+        unbound = sorted(
+            (
+                inst
+                for inst, entity in self.object_scope.items()
+                if entity is None and "agent.n." not in inst
+            ),
+            key=numeric_suffix,
+        )
+        used = {obj for obj in self.object_scope.values() if obj is not None}
 
-        Args:
-            env: The environment with the active scene.
-        """
-        for inst in self.object_scope:
-            if self.object_scope[inst] is not None:
-                continue
-            if "agent.n." in inst:
-                continue
-            # Try to find a matching object in the scene
+        # Resolve each inroom-constrained instance to its matched room instance
+        room_instances = self._determine_room_instances(env)
+        inroom_assignments = {
+            cond[1]: cond[2]
+            for cond in self.compiled_task.conditions.parsed_initial_conditions
+            if cond[0] == "inroom"
+        }
+
+        # Bind each slot to a free, category-matching object in its matched room
+        for inst in unbound:
+            room_type = inroom_assignments.get(inst)
+            room_inst = room_instances.get(room_type) if room_type is not None else None
+            candidates = (
+                env.scene.object_registry("in_rooms", room_inst, default_val=[])
+                if room_inst is not None
+                else env.scene.objects
+            )
             categories = set(og_categories_from_bddl_inst(inst))
-            for obj in env.scene.objects:
-                # Check category match and that obj isn't already assigned
-                if obj.category in categories and obj not in self.object_scope.values():
-                    self.object_scope[inst] = obj
-                    break
+            matching = sorted(
+                (obj for obj in candidates if obj.category in categories and obj not in used),
+                key=lambda o: numeric_suffix(o.name),
+            )
+            if matching:
+                self.object_scope[inst] = matching[0]
+                used.add(matching[0])
 
     def get_agent(self, env):
         """

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -466,7 +466,7 @@ class BehaviorTask(BaseTask):
             # Compile a wildcard-stripped base task.
             self.compiled_task = self._task_def.compile_base()
             self._finalize_compiled_task()
-            
+
             # Phase 2: sample states using compiled conditions
             accept_scene, feedback = self.sampler.sample_states(self.compiled_task)
             if not accept_scene:
@@ -505,6 +505,7 @@ class BehaviorTask(BaseTask):
 
     def _assign_wildcard_instances(self, env, room_instances):
         """Assign each unbound wildcard instance to a scene object in its matched room, in numeric-suffix order."""
+
         def numeric_suffix(name):
             try:
                 return int(name.rsplit("_", 1)[1])
@@ -513,20 +514,14 @@ class BehaviorTask(BaseTask):
 
         # Collect unbound slots in suffix order and track already-claimed scene objects
         unbound = sorted(
-            (
-                inst
-                for inst, entity in self.object_scope.items()
-                if entity is None and "agent.n." not in inst
-            ),
+            (inst for inst, entity in self.object_scope.items() if entity is None and "agent.n." not in inst),
             key=numeric_suffix,
         )
         used = {obj for obj in self.object_scope.values() if obj is not None}
 
         # Resolve each inroom-constrained instance to its matched room instance
         inroom_assignments = {
-            cond[1]: cond[2]
-            for cond in self.compiled_task.conditions.parsed_initial_conditions
-            if cond[0] == "inroom"
+            cond[1]: cond[2] for cond in self.compiled_task.conditions.parsed_initial_conditions if cond[0] == "inroom"
         }
 
         # Bind each slot to a free, category-matching object in its matched room

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -382,19 +382,20 @@ class BehaviorTask(BaseTask):
                         break
         return room_instances
 
-    def _compile_with_rooms(self, env):
+    def _compile_with_rooms(self, env, room_instances):
         """Compile the wildcard task using the specific room instances from assigned objects.
 
         After object scope has been assigned (via cache or sampling), this
-        determines which room instances are being used, counts objects in those
-        rooms, and compiles the task with proper wildcard expansion.
+        counts objects in the matched rooms and compiles the task with proper
+        wildcard expansion.
 
         Args:
             env: The environment with the active scene.
+            room_instances: Dict mapping room_type -> room_instance_name. Must
+                be computed from the base inroom anchors BEFORE wildcard-synset
+                bases are unbound, or rooms anchored only by a wildcard synset
+                will drop out of the scene layout.
         """
-        # Determine which room instances the assigned objects are in
-        room_instances = self._determine_room_instances(env)
-
         # Build scene layout from those specific rooms
         scene_layout = self._build_scene_layout_from_rooms(env.scene, room_instances)
 
@@ -471,11 +472,13 @@ class BehaviorTask(BaseTask):
             if not accept_scene:
                 return accept_scene, feedback
 
-            # Wildcards expand AFTER matching rooms
+            # Snapshot rooms before unbinding — otherwise rooms anchored only
+            # by a wildcard-synset base instance drop from the scene layout.
             if self._task_def.has_wildcards:
+                room_instances = self._determine_room_instances(env)
                 self._unbind_wildcard_synset_bases()
-                self._compile_with_rooms(env)
-                self._assign_wildcard_instances(env)
+                self._compile_with_rooms(env, room_instances)
+                self._assign_wildcard_instances(env, room_instances)
         else:
             inst_to_name = env.scene.get_task_metadata(key="inst_to_name")
             self.compiled_task = self._task_def.compile_from_inst_to_name(inst_to_name)
@@ -500,7 +503,7 @@ class BehaviorTask(BaseTask):
             if synset in wildcard_synsets:
                 self.object_scope[inst] = None
 
-    def _assign_wildcard_instances(self, env):
+    def _assign_wildcard_instances(self, env, room_instances):
         """Assign each unbound wildcard instance to a scene object in its matched room, in numeric-suffix order."""
         def numeric_suffix(name):
             try:
@@ -520,7 +523,6 @@ class BehaviorTask(BaseTask):
         used = {obj for obj in self.object_scope.values() if obj is not None}
 
         # Resolve each inroom-constrained instance to its matched room instance
-        room_instances = self._determine_room_instances(env)
         inroom_assignments = {
             cond[1]: cond[2]
             for cond in self.compiled_task.conditions.parsed_initial_conditions

--- a/OmniGibson/omnigibson/utils/bddl_utils.py
+++ b/OmniGibson/omnigibson/utils/bddl_utils.py
@@ -489,6 +489,7 @@ class BDDLSampler:
         # Initialize other variables that will be filled in later
         self._sampling_whitelist = None  # Maps str to str to list
         self._sampling_blacklist = None  # Maps str to str to list
+        self._unique_models_per_synset = False  # bool: if True, sample models without replacement per synset
         self._room_type_to_object_instance = None  # dict
         self._inroom_object_instances = None  # set of str
         self._object_sampling_orders = None  # dict mapping str to list of str
@@ -503,7 +504,7 @@ class BDDLSampler:
         resolved = [self._object_scope.get(a, a) if isinstance(a, str) else a for a in args]
         return sample_bddl_predicate(predicate_cls, *resolved, **kwargs)
 
-    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None):
+    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None, unique_models_per_synset=False):
         """Assign inroom objects and import sampleable objects into the scene.
 
         This is phase 1 of sampling: it finds/imports all objects needed by the
@@ -515,6 +516,10 @@ class BDDLSampler:
                 category -> list of valid models.
             sampling_blacklist (None or dict): Maps synset name to dict of
                 category -> list of invalid models.
+            unique_models_per_synset (bool): If True, ensures that each instance
+                of the same synset is assigned a distinct object model (sampling
+                without replacement). Sampling fails if there are fewer valid
+                models than instances for a given synset.
 
         Returns:
             2-tuple:
@@ -524,6 +529,7 @@ class BDDLSampler:
         log.info("Assigning objects for task...")
         self._sampling_whitelist = sampling_whitelist
         self._sampling_blacklist = sampling_blacklist
+        self._unique_models_per_synset = unique_models_per_synset
 
         # Derive future object instances from parsed initial conditions
         self._future_obj_instances = {
@@ -1152,6 +1158,9 @@ class BDDLSampler:
 
         self._sampled_objects = set()
         num_new_obj = 0
+        # Tracks which models have already been used per synset, to enforce
+        # without-replacement sampling when self._unique_models_per_synset is True
+        sampled_models_per_synset = defaultdict(set)
         # Only populate self.object_scope for sampleable objects
         available_categories = set(get_all_object_categories())
 
@@ -1243,16 +1252,27 @@ class BDDLSampler:
                             else model_choices
                         )
 
+                    # Exclude models already assigned to other instances of this synset
+                    if self._unique_models_per_synset:
+                        model_choices = model_choices - sampled_models_per_synset[obj_synset]
+
                     # Filter by category
                     if len(model_choices) > 0:
                         break
 
                 if len(model_choices) == 0:
                     # We failed to find ANY valid model across ALL valid categories
+                    if self._unique_models_per_synset:
+                        return (
+                            f"Ran out of unique models for synset {obj_synset} "
+                            f"(already used: {sorted(sampled_models_per_synset[obj_synset])})"
+                        )
                     return f"Missing valid object models for all categories: {categories}"
 
                 # Randomly select an object model
                 model = random.choice(list(model_choices))
+                if self._unique_models_per_synset:
+                    sampled_models_per_synset[obj_synset].add(model)
 
                 # Potentially add additional kwargs
                 obj_kwargs = dict()

--- a/OmniGibson/omnigibson/utils/bddl_utils.py
+++ b/OmniGibson/omnigibson/utils/bddl_utils.py
@@ -489,7 +489,7 @@ class BDDLSampler:
         # Initialize other variables that will be filled in later
         self._sampling_whitelist = None  # Maps str to str to list
         self._sampling_blacklist = None  # Maps str to str to list
-        self._unique_models_per_synset = False  # bool: if True, sample models without replacement per synset
+        self._use_unique_models_per_synset = False  # bool: if True, sample models without replacement per synset
         self._room_type_to_object_instance = None  # dict
         self._inroom_object_instances = None  # set of str
         self._object_sampling_orders = None  # dict mapping str to list of str
@@ -504,7 +504,7 @@ class BDDLSampler:
         resolved = [self._object_scope.get(a, a) if isinstance(a, str) else a for a in args]
         return sample_bddl_predicate(predicate_cls, *resolved, **kwargs)
 
-    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None, unique_models_per_synset=False):
+    def assign_objects(self, sampling_whitelist=None, sampling_blacklist=None, use_unique_models_per_synset=False):
         """Assign inroom objects and import sampleable objects into the scene.
 
         This is phase 1 of sampling: it finds/imports all objects needed by the
@@ -516,7 +516,7 @@ class BDDLSampler:
                 category -> list of valid models.
             sampling_blacklist (None or dict): Maps synset name to dict of
                 category -> list of invalid models.
-            unique_models_per_synset (bool): If True, ensures that each instance
+            use_unique_models_per_synset (bool): If True, ensures that each instance
                 of the same synset is assigned a distinct object model (sampling
                 without replacement). Sampling fails if there are fewer valid
                 models than instances for a given synset.
@@ -529,7 +529,7 @@ class BDDLSampler:
         log.info("Assigning objects for task...")
         self._sampling_whitelist = sampling_whitelist
         self._sampling_blacklist = sampling_blacklist
-        self._unique_models_per_synset = unique_models_per_synset
+        self._use_unique_models_per_synset = use_unique_models_per_synset
 
         # Derive future object instances from parsed initial conditions
         self._future_obj_instances = {
@@ -1159,7 +1159,7 @@ class BDDLSampler:
         self._sampled_objects = set()
         num_new_obj = 0
         # Tracks which models have already been used per synset, to enforce
-        # without-replacement sampling when self._unique_models_per_synset is True
+        # without-replacement sampling when self._use_unique_models_per_synset is True
         sampled_models_per_synset = defaultdict(set)
         # Only populate self.object_scope for sampleable objects
         available_categories = set(get_all_object_categories())
@@ -1253,7 +1253,7 @@ class BDDLSampler:
                         )
 
                     # Exclude models already assigned to other instances of this synset
-                    if self._unique_models_per_synset:
+                    if self._use_unique_models_per_synset:
                         model_choices = model_choices - sampled_models_per_synset[obj_synset]
 
                     # Filter by category
@@ -1262,7 +1262,7 @@ class BDDLSampler:
 
                 if len(model_choices) == 0:
                     # We failed to find ANY valid model across ALL valid categories
-                    if self._unique_models_per_synset:
+                    if self._use_unique_models_per_synset:
                         return (
                             f"Ran out of unique models for synset {obj_synset} "
                             f"(already used: {sorted(sampled_models_per_synset[obj_synset])})"
@@ -1271,7 +1271,7 @@ class BDDLSampler:
 
                 # Randomly select an object model
                 model = random.choice(list(model_choices))
-                if self._unique_models_per_synset:
+                if self._use_unique_models_per_synset:
                     sampled_models_per_synset[obj_synset].add(model)
 
                 # Potentially add additional kwargs

--- a/OmniGibson/scripts/sampling/autogenerate_task_custom_list_template.py
+++ b/OmniGibson/scripts/sampling/autogenerate_task_custom_list_template.py
@@ -49,7 +49,11 @@ def prompt_choice(prompt, options, multi=False):
     for i, opt in enumerate(options):
         print(f"  [{i}] {opt}")
     while True:
-        raw = input("Enter index or name" + (" (comma-separated for multiple)" if multi else "") + ": ").strip()
+        raw = input(
+            "Enter index or name" + (" (comma-separated for multiple, empty to skip)" if multi else "") + ": "
+        ).strip()
+        if multi and not raw:
+            return []
         chosen = []
         for part in raw.split(","):
             part = part.strip()
@@ -488,6 +492,8 @@ def autogenerate_task_custom_list(activity_name, use_room_gui=True, floor=0):
                 available_models,
                 multi=True,
             )
+            if not models:
+                continue
             whitelist[synset][cat_name] = {m: None for m in models}
 
     task_entry = {

--- a/OmniGibson/scripts/sampling/sample_b1k_tasks.py
+++ b/OmniGibson/scripts/sampling/sample_b1k_tasks.py
@@ -192,10 +192,10 @@ def main(random_selection=False, headless=False, short_exec=False):
         whitelist, blacklist = None, None
     env.task_config["sampling_whitelist"] = whitelist
     env.task_config["sampling_blacklist"] = blacklist
-    env.task_config["unique_models_per_synset"] = args.unique_models
+    env.task_config["use_unique_models_per_synset"] = args.unique_models
     log.info(f"white_list: {whitelist}")
     log.info(f"black_list: {blacklist}")
-    log.info(f"unique_models_per_synset: {args.unique_models}")
+    log.info(f"use_unique_models_per_synset: {args.unique_models}")
     assert whitelist is not None, "whitelist should not be None for manual sampling"
     BehaviorTask.get_cached_activity_scene_filename(
         scene_model=scene_model,

--- a/OmniGibson/scripts/sampling/sample_b1k_tasks.py
+++ b/OmniGibson/scripts/sampling/sample_b1k_tasks.py
@@ -63,6 +63,14 @@ parser.add_argument(
     default=None,
     help="Output directory for sampled tasks (default: gm.DATA_PATH/2026-challenge-task-instances)",
 )
+parser.add_argument(
+    "-u",
+    "--unique_models",
+    action="store_true",
+    help="If set, each instance of the same synset (e.g. book.n.02_1..6) will be assigned a distinct "
+    "object model from the whitelist (sampling without replacement). Fails if the whitelist for a "
+    "synset has fewer entries than instances.",
+)
 
 # gm.HEADLESS = False
 gm.USE_GPU_DYNAMICS = False
@@ -184,8 +192,10 @@ def main(random_selection=False, headless=False, short_exec=False):
         whitelist, blacklist = None, None
     env.task_config["sampling_whitelist"] = whitelist
     env.task_config["sampling_blacklist"] = blacklist
+    env.task_config["unique_models_per_synset"] = args.unique_models
     log.info(f"white_list: {whitelist}")
     log.info(f"black_list: {blacklist}")
+    log.info(f"unique_models_per_synset: {args.unique_models}")
     assert whitelist is not None, "whitelist should not be None for manual sampling"
     BehaviorTask.get_cached_activity_scene_filename(
         scene_model=scene_model,

--- a/OmniGibson/tests/test_behavior_task.py
+++ b/OmniGibson/tests/test_behavior_task.py
@@ -1,6 +1,7 @@
+import sys
+
 import omnigibson as og
 from omnigibson.macros import gm
-import sys
 
 
 def test_behavior_task():
@@ -79,6 +80,51 @@ def test_behavior_task_wildcard():
         sys.exit(1)
 
 
+def test_wildcard_room_anchor_preserved():
+    # installing_a_fence anchors garden ONLY via wildcard-synset bases
+    # (rail_fence.n.01_1, floor.n.01_1). Without the fix in
+    # initialize_activity, unbinding before room determination drops garden
+    # from the scene layout and expand_wildcards raises "found 0 in rooms of
+    # type garden". sample_states is just one (ontop ...) so it samples reliably.
+    gm.ENABLE_OBJECT_STATES = True
+    gm.HEADLESS = True
+    config = {
+        "scene": {
+            "type": "InteractiveTraversableScene",
+            "scene_model": "house_double_floor_lower",
+            "load_room_types": ["garden"],
+        },
+        "task": {
+            "type": "BehaviorTask",
+            "activity_name": "installing_a_fence",
+            "activity_definition_id": 0,
+            "online_object_sampling": True,
+            "use_presampled_robot_pose": False,
+        },
+        "robots": [
+            {
+                "type": "Fetch",
+                "obs_modalities": ["rgb"],
+            }
+        ],
+    }
+    try:
+        env = og.Environment(configs=config)
+        scope = env.task.compiled_task.object_scope
+        assert "rail_fence.n.01_*" not in scope, f"wildcard left unexpanded in {sorted(scope)}"
+        assert "rail_fence.n.01_1" in scope, f"rail_fence.n.01_1 missing from {sorted(scope)}"
+        print(
+            "Wildcard BehaviorTask instantiated successfully! Ground goal state options:",
+            len(env.task.ground_goal_state_options),
+        )
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     test_behavior_task()
     test_behavior_task_wildcard()
+    test_wildcard_room_anchor_preserved()

--- a/OmniGibson/tests/test_behavior_task.py
+++ b/OmniGibson/tests/test_behavior_task.py
@@ -38,5 +38,47 @@ def test_behavior_task():
         sys.exit(1)
 
 
+def test_behavior_task_wildcard():
+    gm.ENABLE_OBJECT_STATES = True
+    gm.HEADLESS = True
+    config = {
+        "scene": {
+            "type": "InteractiveTraversableScene",
+            "scene_model": "house_double_floor_upper",
+            "load_room_types": ["bathroom"],
+        },
+        "task": {
+            "type": "BehaviorTask",
+            "activity_name": "setting_mousetraps",
+            "activity_definition_id": 0,
+            "online_object_sampling": True,
+            "use_presampled_robot_pose": False,
+        },
+        "robots": [
+            {
+                "type": "Fetch",
+                "obs_modalities": ["rgb"],
+            }
+        ],
+    }
+    try:
+        env = og.Environment(configs=config)
+        scope = env.task.compiled_task.object_scope
+        assert "sink.n.01_*" not in scope, f"wildcard left unexpanded in {sorted(scope)}"
+        assert "floor.n.01_*" not in scope, f"wildcard left unexpanded in {sorted(scope)}"
+        assert "sink.n.01_1" in scope, f"sink.n.01_1 missing from {sorted(scope)}"
+        assert "floor.n.01_1" in scope, f"floor.n.01_1 missing from {sorted(scope)}"
+        print(
+            "Wildcard BehaviorTask instantiated successfully! Ground goal state options:",
+            len(env.task.ground_goal_state_options),
+        )
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     test_behavior_task()
+    test_behavior_task_wildcard()

--- a/bddl3/bddl/activity_definitions/re_shelving_library_books/problem0.bddl
+++ b/bddl3/bddl/activity_definitions/re_shelving_library_books/problem0.bddl
@@ -4,7 +4,7 @@
     (:objects
      	book.n.02_1 book.n.02_2 book.n.02_3 - book.n.02
     	table.n.02_1 - table.n.02
-    	bookcase.n.01_* - bookcase.n.01
+    	bookcase.n.01_1 bookcase.n.01_* - bookcase.n.01
     	floor.n.01_1 - floor.n.01
     	agent.n.01_1 - agent.n.01
     )
@@ -14,6 +14,7 @@
         (ontop book.n.02_2 table.n.02_1) 
         (ontop book.n.02_3 table.n.02_1) 
         (inroom table.n.02_1 living_room)
+        (inroom bookcase.n.01_1 living_room)
         (inroom bookcase.n.01_* living_room)
         (inroom floor.n.01_1 living_room) 
         (ontop agent.n.01_1 floor.n.01_1)

--- a/bddl3/bddl/knowledge_base/models.py
+++ b/bddl3/bddl/knowledge_base/models.py
@@ -1040,6 +1040,21 @@ class Task:
         """Whether this task's definition contains wildcard instances."""
         return "*" in self.definition
 
+    @cached_property
+    def wildcard_synsets(self):
+        """Set of synsets that have a wildcard instance declared in this task."""
+        if not self.has_wildcards:
+            return set()
+        synsets = set()
+        for line in self.definition.splitlines():
+            stripped = line.strip()
+            if "*" not in stripped or " - " not in stripped:
+                continue
+            instances_part, synset = stripped.split(" - ", 1)
+            if "*" in instances_part:
+                synsets.add(synset.strip())
+        return synsets
+
     def parse_base_scope(self):
         """Parse the base (non-wildcard) object scope from the raw definition.
 
@@ -1128,6 +1143,25 @@ class Task:
         if self.has_wildcards:
             from bddl.wildcard import expand_wildcards
             problem = expand_wildcards(problem, scene_layout, self.knowledgebase)
+        return CompiledTask(self, problem)
+
+    def compile_base(self):
+        """Compile the wildcard-stripped (base) version of this task.
+        """
+        problem = self._strip_wildcards(self.definition) if self.has_wildcards else self.definition
+        return CompiledTask(self, problem)
+
+    def compile_from_inst_to_name(self, inst_to_name):
+        """Compile this task using cached instance names for wildcard expansion.
+
+        Args:
+            inst_to_name: Dict mapping BDDL instance name to scene object
+                name, as written by :meth:`BehaviorTask.update_bddl_scope_metadata`.
+        """
+        problem = self.definition
+        if self.has_wildcards:
+            from bddl.wildcard import expand_wildcards_from_inst_to_name
+            problem = expand_wildcards_from_inst_to_name(problem, inst_to_name, self.knowledgebase)
         return CompiledTask(self, problem)
 
     @cached_property

--- a/bddl3/bddl/wildcard.py
+++ b/bddl3/bddl/wildcard.py
@@ -8,9 +8,142 @@ of the environment, not the task.
 :func:`expand_wildcards` takes a raw BDDL string and a scene layout dict,
 and returns an expanded BDDL string with wildcards replaced by concrete
 numbered instances.
+:func:`expand_wildcards_from_inst_to_name` does the
+same but uses the cached ``inst_to_name`` mapping (written by
+``BehaviorTask.update_bddl_scope_metadata``).
 """
 
 from copy import deepcopy
+
+
+def _parse_wildcards(raw_bddl):
+    """Scan a tokenised BDDL for wildcard declarations.
+
+    Returns a tuple ``(swap_info, start_init_idx, end_init_idx)`` where
+    ``swap_info`` maps each wildcard token (e.g. ``cabinet.n.01_*``) to a
+    dict containing ``object_scope_idx``, ``n_minimum_instances``,
+    ``categories``, ``synset``, ``room``, and ``init_cond_idx``. Shared by
+    both :func:`expand_wildcards` and :func:`expand_wildcards_from_inst_to_name`.
+    """
+    swap_info = {}
+    in_goal = False
+    start_init_idx = None
+    end_init_idx = None
+
+    for idx, line in enumerate(raw_bddl):
+        if "*" in line:
+            assert not in_goal, (
+                "Found wildcard in BDDL goal conditions, "
+                "but only expected in object_scope and init conditions!"
+            )
+
+            if "-" in line:
+                # Object scope line: "inst_1 inst_* - synset"
+                instances, synset = line.strip(" \n\t").split(" - ")
+                instances = instances.split(" ")
+
+                wildcard_instance = instances[-1]
+                assert "*" in wildcard_instance, (
+                    f"Expected wildcard in final instance: {line}"
+                )
+                assert wildcard_instance not in swap_info, (
+                    f"Duplicate wildcard for synset {synset}!"
+                )
+
+                swap_info[wildcard_instance] = {
+                    "object_scope_idx": idx,
+                    "n_minimum_instances": len(instances) - 1,
+                    "explicit_instances": instances[:-1],
+                    "synset": synset,
+                }
+
+            else:
+                # Init condition line: "(inroom inst_* room_type)"
+                tokens = line.strip(" ()\n\t").split(" ")
+                assert len(tokens) == 3, (
+                    f"Expected 3 tokens for wildcard init condition: {line}"
+                )
+                assert tokens[0] == "inroom", (
+                    f"Only inroom supported for wildcard init condition: {tokens[0]}"
+                )
+                _, wildcard_instance, room = tokens
+                assert wildcard_instance in swap_info, (
+                    f"Wildcard instance {wildcard_instance} not declared in object scope!"
+                )
+                swap_info[wildcard_instance]["room"] = room
+                swap_info[wildcard_instance]["init_cond_idx"] = idx
+
+        elif ":init" in line:
+            start_init_idx = idx
+        elif ":goal" in line:
+            end_init_idx = idx
+            in_goal = True
+
+    return swap_info, start_init_idx, end_init_idx
+
+
+def _apply_expansion(raw_bddl, swap_info, start_init_idx, end_init_idx, extra_instances_for):
+    """Apply the expansion described by ``extra_instances_for`` to the BDDL lines.
+
+    ``extra_instances_for`` is a callable mapping a wildcard token (key of
+    ``swap_info``) to the list of concrete instance names that should
+    replace the ``_*`` token in the object scope line and produce one
+    ``(inroom ...)`` line each.
+    """
+    raw_bddl_init_cond_lines = deepcopy(raw_bddl[start_init_idx:end_init_idx])
+    new_init_cond_lines = []
+
+    for line in raw_bddl_init_cond_lines:
+        if "*" in line:
+            # Find which wildcard instance this line references
+            tokens = line.split(" ")
+            wildcard_instance = None
+            for token in tokens:
+                if "*" in token:
+                    wildcard_instance = token.strip("()")
+                    break
+            assert wildcard_instance is not None, (
+                f"Expected wildcard token in line: {line}"
+            )
+
+            info = swap_info[wildcard_instance]
+            extra_instances = extra_instances_for(wildcard_instance, info)
+
+            # Replace wildcard in object scope line
+            obj_scope_idx = info["object_scope_idx"]
+            raw_bddl[obj_scope_idx] = raw_bddl[obj_scope_idx].replace(
+                wildcard_instance, " ".join(extra_instances)
+            )
+
+            # Generate extra init condition lines
+            init_cond_line = raw_bddl[info["init_cond_idx"]]
+            for extra_inst in extra_instances:
+                new_init_cond_lines.append(
+                    init_cond_line.replace(wildcard_instance, extra_inst)
+                )
+        else:
+            new_init_cond_lines.append(line)
+
+    # Reassemble the BDDL
+    raw_bddl = raw_bddl[:start_init_idx] + new_init_cond_lines + raw_bddl[end_init_idx:]
+    return "".join(raw_bddl)
+
+
+def _synset_categories(kb, synset):
+    """Return the set of leaf-level category names under ``synset``."""
+    synset_obj = kb.get_synset(synset)
+    assert synset_obj is not None, f"Synset {synset} not found in knowledge base!"
+    assert "sceneObject" in synset_obj.abilities, (
+        f"Wildcard can only be used on sceneObject synsets, "
+        f"but got synset: {synset}"
+    )
+    # Collect all valid categories from synset subtree
+    categories = set()
+    for s in [synset_obj] + sorted(synset_obj.descendants, key=lambda x: x.name):
+        if s.is_leaf:
+            for c in s.categories:
+                categories.add(c.name)
+    return categories
 
 
 def expand_wildcards(raw_bddl_str, scene_layout, kb):
@@ -38,136 +171,75 @@ def expand_wildcards(raw_bddl_str, scene_layout, kb):
             have enough matching objects.
     """
     raw_bddl = raw_bddl_str.splitlines(keepends=True)
-
-    # First pass: find wildcard declarations and their metadata
-    swap_info = {}
-    in_goal = False
-    start_init_idx = None
-    end_init_idx = None
-
-    for idx, line in enumerate(raw_bddl):
-        if "*" in line:
-            assert not in_goal, (
-                "Found wildcard in BDDL goal conditions, "
-                "but only expected in object_scope and init conditions!"
-            )
-
-            if "-" in line:
-                # Object scope line: "inst_1 inst_* - synset"
-                instances, synset = line.strip(" \n\t").split(" - ")
-                instances = instances.split(" ")
-
-                synset_obj = kb.get_synset(synset)
-                assert synset_obj is not None, f"Synset {synset} not found in knowledge base!"
-                assert "sceneObject" in synset_obj.abilities, (
-                    f"Wildcard can only be used on sceneObject synsets, "
-                    f"but got synset: {synset}"
-                )
-
-                # Collect all valid categories from synset subtree
-                categories = set()
-                for s in [synset_obj] + sorted(
-                    synset_obj.descendants, key=lambda x: x.name
-                ):
-                    if s.is_leaf:
-                        for c in s.categories:
-                            categories.add(c.name)
-
-                wildcard_instance = instances[-1]
-                assert "*" in wildcard_instance, (
-                    f"Expected wildcard in final instance: {line}"
-                )
-                assert wildcard_instance not in swap_info, (
-                    f"Duplicate wildcard for synset {synset}!"
-                )
-
-                swap_info[wildcard_instance] = {
-                    "object_scope_idx": idx,
-                    "n_minimum_instances": len(instances) - 1,
-                    "categories": categories,
-                    "synset": synset,
-                }
-
-            else:
-                # Init condition line: "(inroom inst_* room_type)"
-                tokens = line.strip(" ()\n\t").split(" ")
-                assert len(tokens) == 3, (
-                    f"Expected 3 tokens for wildcard init condition: {line}"
-                )
-                assert tokens[0] == "inroom", (
-                    f"Only inroom supported for wildcard init condition: {tokens[0]}"
-                )
-                _, wildcard_instance, room = tokens
-                assert wildcard_instance in swap_info, (
-                    f"Wildcard instance {wildcard_instance} not declared in object scope!"
-                )
-                swap_info[wildcard_instance]["room"] = room
-                swap_info[wildcard_instance]["init_cond_idx"] = idx
-
-        elif ":init" in line:
-            start_init_idx = idx
-        elif ":goal" in line:
-            end_init_idx = idx
-            in_goal = True
+    swap_info, start_init_idx, end_init_idx = _parse_wildcards(raw_bddl)
 
     # If no wildcards found, return as-is
     if not swap_info:
         return raw_bddl_str
 
-    # Second pass: expand wildcards using scene_layout
-    raw_bddl_init_cond_lines = deepcopy(raw_bddl[start_init_idx:end_init_idx])
-    new_init_cond_lines = []
+    for info in swap_info.values():
+        info["categories"] = _synset_categories(kb, info["synset"])
 
-    for line in raw_bddl_init_cond_lines:
-        if "*" in line:
-            # Find which wildcard instance this line references
-            tokens = line.split(" ")
-            wildcard_instance = None
-            for token in tokens:
-                if "*" in token:
-                    wildcard_instance = token.strip("()")
-                    break
-            assert wildcard_instance is not None, (
-                f"Expected wildcard token in line: {line}"
-            )
+    def extras(wildcard_instance, info):
+        n_min = info["n_minimum_instances"]
+        synset = info["synset"]
+        room_type = info["room"]
+        # Count matching objects in the room from scene_layout
+        room_categories = scene_layout.get(room_type, {})
+        n_valid = sum(
+            count for cat, count in room_categories.items()
+            if cat in info["categories"]
+        )
+        assert n_valid >= n_min, (
+            f"BDDL requires at least {n_min} instances of synset {synset}, "
+            f"but only found {n_valid} in rooms of type {room_type}!"
+        )
+        # Generate extra instance names
+        return [f"{synset}_{i + 1}" for i in range(n_min, n_valid)]
 
-            info = swap_info[wildcard_instance]
-            n_min = info["n_minimum_instances"]
-            synset = info["synset"]
-            room_type = info["room"]
+    return _apply_expansion(raw_bddl, swap_info, start_init_idx, end_init_idx, extras)
 
-            # Count matching objects in the room from scene_layout
-            room_categories = scene_layout.get(room_type, {})
-            n_valid = sum(
-                count for cat, count in room_categories.items()
-                if cat in info["categories"]
-            )
 
-            assert n_valid >= n_min, (
-                f"BDDL requires at least {n_min} instances of synset {synset}, "
-                f"but only found {n_valid} in rooms of type {room_type}!"
-            )
+def expand_wildcards_from_inst_to_name(raw_bddl_str, inst_to_name, kb):
+    """Expand wildcards using a cached ``inst_to_name`` mapping.
 
-            # Generate extra instance names
-            extra_instances = [
-                f"{synset}_{i + 1}" for i in range(n_min, n_valid)
-            ]
+    Used by offline / cache-load sampling. ``inst_to_name`` already lists
+    every concrete instance name written when the task was sampled, so we
+    can substitute wildcards directly without re-counting the scene.
 
-            # Replace wildcard in object scope line
-            obj_scope_idx = info["object_scope_idx"]
-            raw_bddl[obj_scope_idx] = raw_bddl[obj_scope_idx].replace(
-                wildcard_instance, " ".join(extra_instances)
-            )
+    Args:
+        raw_bddl_str: Raw BDDL problem file contents.
+        inst_to_name: Dict mapping BDDL instance name to scene object name
+            (as written by ``BehaviorTask.update_bddl_scope_metadata``).
+        kb: A :class:`~bddl.knowledge_base.KnowledgeBase` instance.
 
-            # Generate extra init condition lines
-            init_cond_line = raw_bddl[info["init_cond_idx"]]
-            for extra_inst in extra_instances:
-                new_init_cond_lines.append(
-                    init_cond_line.replace(wildcard_instance, extra_inst)
-                )
-        else:
-            new_init_cond_lines.append(line)
+    Returns:
+        str: The expanded BDDL string.
+    """
+    raw_bddl = raw_bddl_str.splitlines(keepends=True)
+    swap_info, start_init_idx, end_init_idx = _parse_wildcards(raw_bddl)
 
-    # Reassemble the BDDL
-    raw_bddl = raw_bddl[:start_init_idx] + new_init_cond_lines + raw_bddl[end_init_idx:]
-    return "".join(raw_bddl)
+    # If no wildcards found, return as-is
+    if not swap_info:
+        return raw_bddl_str
+
+    def extras(wildcard_instance, info):
+        synset = info["synset"]
+        explicit = set(info["explicit_instances"])
+        prefix = f"{synset}_"
+        # Pull all `<synset>_<int>` keys present in the cache that weren't
+        # already declared explicitly in the BDDL. Sort numerically.
+        candidates = []
+        for inst in inst_to_name:
+            if not inst.startswith(prefix):
+                continue
+            suffix = inst[len(prefix):]
+            if not suffix.isdigit():
+                continue
+            if inst in explicit:
+                continue
+            candidates.append((int(suffix), inst))
+        candidates.sort()
+        return [inst for _, inst in candidates]
+
+    return _apply_expansion(raw_bddl, swap_info, start_init_idx, end_init_idx, extras)

--- a/bddl3/tests/test_knowledgebase.py
+++ b/bddl3/tests/test_knowledgebase.py
@@ -611,3 +611,35 @@ class TestWildcardExpansion:
         ok, results = ct.check_goal(lambda cls, *e: False)
         assert isinstance(ok, bool)
         assert "satisfied" in results and "unsatisfied" in results
+
+    def test_compile_base_strips_wildcards(self, kb):
+        """compile_base produces a CompiledTask with the wildcard tokens removed."""
+        ct = kb.get_task("carrying_in_groceries-0").compile_base()
+        assert "electric_refrigerator.n.01_*" not in ct.object_scope
+        assert "electric_refrigerator.n.01_1" in ct.object_scope
+        # Wildcard-only extras must not appear before expansion.
+        assert "electric_refrigerator.n.01_2" not in ct.object_scope
+
+    def test_expand_wildcards_from_inst_to_name(self, kb):
+        """compile_from_inst_to_name pulls expanded instances from the cache mapping."""
+        task = kb.get_task("carrying_in_groceries-0")
+        inst_to_name = {
+            "electric_refrigerator.n.01_1": "fridge_0",
+            "electric_refrigerator.n.01_2": "fridge_1",
+            "electric_refrigerator.n.01_3": "fridge_2",
+        }
+        ct = task.compile_from_inst_to_name(inst_to_name)
+        fridge_instances = sorted(n for n in ct.object_scope if "electric_refrigerator" in n)
+        assert fridge_instances == [
+            "electric_refrigerator.n.01_1",
+            "electric_refrigerator.n.01_2",
+            "electric_refrigerator.n.01_3",
+        ]
+        inroom = {cond[1] for cond in ct.conditions.parsed_initial_conditions if cond[0] == "inroom"}
+        assert "electric_refrigerator.n.01_2" in inroom
+        assert "electric_refrigerator.n.01_3" in inroom
+
+    def test_wildcard_synsets(self, kb):
+        """wildcard_synsets enumerates synsets that have a wildcard in the definition."""
+        task = kb.get_task("carrying_in_groceries-0")
+        assert "electric_refrigerator.n.01" in task.wildcard_synsets


### PR DESCRIPTION
### Main Fix

**Online sampling path:**
- The previous code expanded wildcards before `sample_states`, but `sample_states` is what picks the room (via bipartite matching). So wildcard expansion has to happen _after_ the rooms are decided.
- We still need at least one explicit instance of the wildcard synset in the BDDL so `sample_states` considers it — that's the anchor _1.
- Once the rooms are matched, we expand the wildcards and assign the new instances to free scene objects in the matched room.

**Offline sample path:**
- The previous code counted scene objects and re-expanded wildcards from scratch, which is unnecessary — the wildcards were already expanded when the cache was saved.
- Instead, we now read directly from inst_to_name and expand wildcards using those names.
- This collapses the previous "non-strict assign → recompile → reassign" sequence into a single pass, since every wildcard instance is pinned to a concrete name from the start.

### Minor changes
- Update re_shelving_library_books so that it has the anchor _1
- When synset has multiple object categories, autogenerate_task_custom_list_template.py currently prompts for at least 1 object model per category -> allow empty input so that when appropriate we don't need to select |# categories| per synset
- Some tasks (e.g. re_shelving_library_books, putting_away_toys) requires multiple object instances of same synset - thought it would be nice if we can sample unique object models for each instance(sample without replacement)