### PR TITLE
Format bounding box sizes for super-thin objects

### DIFF
--- a/knowledgebase/build_static_site.py
+++ b/knowledgebase/build_static_site.py
@@ -31,7 +31,7 @@ from bddl.knowledge_base import (
 )
 
 # Import necessary components from existing code
-from knowledgebase.filters import status_color, status_color_transition_rule
+from knowledgebase.filters import status_color, status_color_transition_rule, format_size
 
 MODELS = [
     AttachmentPair,
@@ -130,6 +130,7 @@ def setup_jinja_env() -> Environment:
     env.filters["status_color"] = status_color
     env.filters["status_color_transition_rule"] = status_color_transition_rule
     env.filters["tocolor"] = status_color  # Alias for tocolor filter
+    env.filters["format_size"] = format_size
 
     # Add url_for function to global context
     env.globals["url_for"] = url_for

--- a/knowledgebase/knowledgebase/filters.py
+++ b/knowledgebase/knowledgebase/filters.py
@@ -26,6 +26,13 @@ def status_color(state):
     return color_map.get(state, "light")
 
 
+def format_size(value):
+    """Format a size value: 2 decimal places, but 1 sig fig if it would round to 0.00."""
+    if round(value, 2) == 0.0 and value != 0.0:
+        return f"{value:.1g}"
+    return f"{value:.2f}"
+
+
 def status_color_transition_rule(state):
     """Convert a TransitionRule state to a Bootstrap color class (for static generator)."""
     # For now, using the same mapping as status_color

--- a/knowledgebase/knowledgebase/templates/object_detail.html
+++ b/knowledgebase/knowledgebase/templates/object_detail.html
@@ -13,7 +13,7 @@
     Original category: {{ object.original_category_name }} | Provider: {{ object.provider }}
   </h4>
   <div class="text-center">
-    <b>Bounding Box Size:</b> {{ "%.2f"|format(object.bounding_box_size.0) }}, {{ "%.2f"|format(object.bounding_box_size.1) }}, {{ "%.2f"|format(object.bounding_box_size.2) }}
+    <b>Bounding Box Size:</b> {{ object.bounding_box_size.0|format_size }}, {{ object.bounding_box_size.1|format_size }}, {{ object.bounding_box_size.2|format_size }}
   </div>
 
   <div class="text-center mb-4">

--- a/knowledgebase/knowledgebase/templates/table_modules/object_table.html
+++ b/knowledgebase/knowledgebase/templates/table_modules/object_table.html
@@ -26,7 +26,7 @@
       {% endif %}
       <td>{{ object.owner.name }}</td>
       <td>{{ object.owner.synset.name }}</td>
-      <td>{{ "%.2f"|format(object.bounding_box_size.0) }}, {{ "%.2f"|format(object.bounding_box_size.1) }}, {{ "%.2f"|format(object.bounding_box_size.2) }}</td>
+      <td>{{ object.bounding_box_size.0|format_size }}, {{ object.bounding_box_size.1|format_size }}, {{ object.bounding_box_size.2|format_size }}</td>
       <td>{% for ml in object.meta_links %} {{ ml.name }}, {% endfor %}</td>
       <td>{{ object.roomobjects|length }}</td>
       <td class="{% if object.ready %}bg-success{% else %}bg-warning|tocolor{% endif %}">{{ object.ready }}</td>


### PR DESCRIPTION
Print super small bounding box sizes to 1 sig fig if they round down to zero.

Before:
<img width="1109" height="243" alt="2026-05-13-144430_1109x243_scrot" src="https://github.com/user-attachments/assets/3f066574-d121-41b3-9731-0c863e83d850" />

After:
<img width="404" height="145" alt="2026-05-13-144409_404x145_scrot" src="https://github.com/user-attachments/assets/8269e62d-72b7-4057-82ec-5c246ce0e4e4" />

Otherwise it's hard to know how to scale these objects