### PR TITLE
Fix deleting particle group

### DIFF
--- a/OmniGibson/omnigibson/systems/macro_particle_system.py
+++ b/OmniGibson/omnigibson/systems/macro_particle_system.py
@@ -950,7 +950,9 @@ class MacroVisualParticleSystem(MacroParticleSystem, VisualParticleSystem):
         # Sanity check the common groups, we will recreate any where there is a mismatch
         for name in common_groups:
             info = name_to_info_mapping[name]
-            if self.num_group_particles(group=name) != info["n_particles"]:
+            current_idns = {self.particle_name2idn(p_name) for p_name in self._group_particles[name]}
+            desired_idns = {int(idn) for idn in info["particle_idns"]}
+            if current_idns != desired_idns:
                 log.debug(f"Got mismatch in particle group {name} when syncing, deleting and recreating group now.")
                 # Add this group to both the delete and creation pile
                 groups_to_delete.append(name)


### PR DESCRIPTION
Previously this only checks the particle number instead of an exact match, which sometimes causes a crash.