### PR TITLE
Use th.as_tensor for bounding box construction

### DIFF
--- a/OmniGibson/omnigibson/objects/dataset_object.py
+++ b/OmniGibson/omnigibson/objects/dataset_object.py
@@ -251,7 +251,7 @@ class DatasetObject(USDObject):
             native_bb_attr = default_prim.GetAttribute("ig:nativeBB")
             if native_bb_attr.IsValid():
                 native_bb = th.tensor(list(native_bb_attr.Get()))
-                bb = th.tensor(bounding_box, dtype=th.float32)
+                bb = th.as_tensor(bounding_box, dtype=th.float32)
                 scale = th.ones(3)
                 valid_idxes = native_bb > 1e-4
                 scale[valid_idxes] = bb[valid_idxes] / native_bb[valid_idxes]


### PR DESCRIPTION
Bounding box may already be a torch tensor, and wrapping it with `th.tensor(...)` triggers PyTorch’s copy-construction warning. `th.as_tensor(..., dtype=th.float32)` handles existing tensors, numpy arrays, and lists cleanly while preserving the existing behavior needed for `_get_preapply_scale()`. Small cleanup with no behavior change.