### PR TITLE
Tune behavior for thin objects

### DIFF
--- a/OmniGibson/omnigibson/macros.py
+++ b/OmniGibson/omnigibson/macros.py
@@ -183,6 +183,10 @@ gm.ENABLE_HQ_RENDERING = False
 # objects from tunneling through each other)
 gm.ENABLE_CCD = False
 
+# Minimum collision mesh dimension (meters) below which an object/link is considered "thin"
+# Used to trigger contact offset overrides, higher solver iterations, etc.
+gm.THIN_OBJECT_THRESHOLD = 0.05
+
 # Pairs setting -- USD default is 256 * 1024, physx default apparently is 32 * 1024.
 gm.GPU_PAIRS_CAPACITY = 256 * 1024
 # Aggregate pairs setting -- default is 1024, but is often insufficient for large scenes

--- a/OmniGibson/omnigibson/objects/usd_object.py
+++ b/OmniGibson/omnigibson/objects/usd_object.py
@@ -63,6 +63,7 @@ m.HIGHLIGHT_INTENSITY = 10000.0  # Highlight intensity to apply, range [0, 10000
 # Physics settings for objects -- see https://nvidia-omniverse.github.io/PhysX/physx/5.3.1/docs/RigidBodyDynamics.html?highlight=velocity%20iteration#solver-iterations
 m.DEFAULT_SOLVER_POSITION_ITERATIONS = 32
 m.DEFAULT_SOLVER_VELOCITY_ITERATIONS = 1
+m.THIN_SOLVER_POSITION_ITERATIONS = 64  # higher iteration count for thin objects
 
 m.STEAM_EMITTER_SIZE_RATIO = [0.8, 0.8, 0.4]  # (x,y,z) scale of generated steam relative to its object, range [0, inf)
 m.STEAM_EMITTER_DENSITY_CELL_RATIO = 0.1  # scale of steam density relative to its object, range [0, inf)
@@ -379,6 +380,17 @@ class USDObject(EntityPrim, Registerable, metaclass=ABCMeta):
         if self._prim_type != PrimType.CLOTH and not self.kinematic_only:
             self.solver_position_iteration_count = m.DEFAULT_SOLVER_POSITION_ITERATIONS
             self.solver_velocity_iteration_count = m.DEFAULT_SOLVER_VELOCITY_ITERATIONS
+            if gm.ENABLE_CCD:
+                for link in self._links.values():
+                    if hasattr(link, "ccd_enabled"):
+                        link.ccd_enabled = True
+
+            if any(
+                th.min(mesh.aabb_extent).item() < gm.THIN_OBJECT_THRESHOLD
+                for link in self._links.values()
+                for mesh in link.collision_meshes.values()
+            ):
+                self.solver_position_iteration_count = m.THIN_SOLVER_POSITION_ITERATIONS
 
         # Add link materials if specified
         if self._link_physics_materials is not None:

--- a/OmniGibson/omnigibson/prims/rigid_prim.py
+++ b/OmniGibson/omnigibson/prims/rigid_prim.py
@@ -92,6 +92,9 @@ class RigidPrim(XFormPrim):
         ensure_usd_api(self._prim, lazy.pxr.UsdPhysics.RigidBodyAPI)
         ensure_usd_api(self._prim, lazy.pxr.PhysxSchema.PhysxRigidBodyAPI)
         ensure_usd_api(self._prim, lazy.pxr.UsdPhysics.MassAPI)
+        # Pre-apply so that adding/removing collision filter targets during simulation
+        # only calls AddTarget/RemoveTarget (not Apply), avoiding PhysX tensor view rebuilds.
+        ensure_usd_api(self._prim, lazy.pxr.UsdPhysics.FilteredPairsAPI)
 
         # Check if it's part of an articulation view
         self._belongs_to_articulation = (

--- a/OmniGibson/omnigibson/prims/rigid_prim.py
+++ b/OmniGibson/omnigibson/prims/rigid_prim.py
@@ -198,6 +198,12 @@ class RigidPrim(XFormPrim):
 
         _find_geom_prims(self._prim)
 
+        # Set default contact/rest offsets on all PhysxCollisionAPIs
+        with og.sim.editing_usd():
+            for api in self._physx_collision_apis:
+                api.GetContactOffsetAttr().Set(m.DEFAULT_CONTACT_OFFSET)
+                api.GetRestOffsetAttr().Set(m.DEFAULT_REST_OFFSET)
+
         coms, vols = [], []
         for prim, is_collision in geom_prims:
             mesh_name, mesh_path = prim.GetName(), prim.GetPrimPath().__str__()
@@ -243,16 +249,6 @@ class RigidPrim(XFormPrim):
                     ):
                         # Make sure particlesource, particlesink and fillable meshes are not visible
                         mesh.purpose = "guide"
-
-        # Override contact/rest offsets for thin links (any collision mesh min dimension
-        # below gm.THIN_OBJECT_THRESHOLD) where PhysX's auto value would be too small.
-        if self._collision_meshes and any(
-            th.min(mesh.aabb_extent).item() < gm.THIN_OBJECT_THRESHOLD for mesh in self._collision_meshes.values()
-        ):
-            with og.sim.editing_usd():
-                for api in self._physx_collision_apis:
-                    api.GetContactOffsetAttr().Set(m.DEFAULT_CONTACT_OFFSET)
-                    api.GetRestOffsetAttr().Set(m.DEFAULT_REST_OFFSET)
 
         # If we have any collision meshes, compute the center of mass from collision geometry
         if len(coms) > 0:

--- a/OmniGibson/omnigibson/prims/rigid_prim.py
+++ b/OmniGibson/omnigibson/prims/rigid_prim.py
@@ -195,12 +195,6 @@ class RigidPrim(XFormPrim):
 
         _find_geom_prims(self._prim)
 
-        # Set default contact/rest offsets on all PhysxCollisionAPIs
-        with og.sim.editing_usd():
-            for api in self._physx_collision_apis:
-                api.GetContactOffsetAttr().Set(m.DEFAULT_CONTACT_OFFSET)
-                api.GetRestOffsetAttr().Set(m.DEFAULT_REST_OFFSET)
-
         coms, vols = [], []
         for prim, is_collision in geom_prims:
             mesh_name, mesh_path = prim.GetName(), prim.GetPrimPath().__str__()
@@ -246,6 +240,16 @@ class RigidPrim(XFormPrim):
                     ):
                         # Make sure particlesource, particlesink and fillable meshes are not visible
                         mesh.purpose = "guide"
+
+        # Override contact/rest offsets for thin links (any collision mesh min dimension
+        # below gm.THIN_OBJECT_THRESHOLD) where PhysX's auto value would be too small.
+        if self._collision_meshes and any(
+            th.min(mesh.aabb_extent).item() < gm.THIN_OBJECT_THRESHOLD for mesh in self._collision_meshes.values()
+        ):
+            with og.sim.editing_usd():
+                for api in self._physx_collision_apis:
+                    api.GetContactOffsetAttr().Set(m.DEFAULT_CONTACT_OFFSET)
+                    api.GetRestOffsetAttr().Set(m.DEFAULT_REST_OFFSET)
 
         # If we have any collision meshes, compute the center of mass from collision geometry
         if len(coms) > 0:

--- a/OmniGibson/omnigibson/robots/robot.py
+++ b/OmniGibson/omnigibson/robots/robot.py
@@ -2031,7 +2031,13 @@ class Robot(USDObject, GymObservable):
         assert self.is_manipulation
         arm = self.default_arm if arm == "default" else arm
 
-        # Remove joint and filtered collision restraints
+        # Remove filtered collision pairs between finger links and the grasped link
+        target_link = self._ag_obj_in_hand[arm].links[self._ag_obj_constraint_params[arm]["target_link_name"]]
+        with og.sim.editing_usd():
+            for finger_link in self.finger_links[arm]:
+                finger_link.remove_filtered_collision_pair(prim=target_link)
+
+        # Remove joint constraint
         delete_or_deactivate_prim(self._ag_obj_constraints[arm].GetPath().pathString)
         og.sim.update_handles()
         self._ag_obj_constraints[arm] = None
@@ -3587,6 +3593,14 @@ class Robot(USDObject, GymObservable):
         self._ag_obj_constraints[arm] = joint_prim
         self._ag_obj_in_hand[arm] = constraint_params["target_obj"]
         self._ag_obj_constraint_params[arm] = constraint_params
+
+        # Filter collisions between finger links and the grasped link to prevent the joint
+        # constraint and collision forces from fighting each other.
+        target_link = constraint_params["target_obj"].links[constraint_params["target_link_name"]]
+        with og.sim.editing_usd():
+            for finger_link in self.finger_links[arm]:
+                finger_link.add_filtered_collision_pair(prim=target_link)
+        og.sim.update_handles()
 
     def _convert_to_math_pi(self, ele):
         """

--- a/OmniGibson/omnigibson/robots/robot.py
+++ b/OmniGibson/omnigibson/robots/robot.py
@@ -2031,11 +2031,15 @@ class Robot(USDObject, GymObservable):
         assert self.is_manipulation
         arm = self.default_arm if arm == "default" else arm
 
-        # Remove filtered collision pairs between finger links and the grasped link
+        # Defer collision filter removal to the next step boundary (same reason as add).
+        finger_links = list(self.finger_links[arm])
         target_link = self._ag_obj_in_hand[arm].links[self._ag_obj_constraint_params[arm]["target_link_name"]]
-        with og.sim.editing_usd():
-            for finger_link in self.finger_links[arm]:
+
+        def _remove_filtered_pairs():
+            for finger_link in finger_links:
                 finger_link.remove_filtered_collision_pair(prim=target_link)
+
+        og.sim._deferred_usd_actions.append(_remove_filtered_pairs)
 
         # Remove joint constraint
         delete_or_deactivate_prim(self._ag_obj_constraints[arm].GetPath().pathString)
@@ -3594,13 +3598,16 @@ class Robot(USDObject, GymObservable):
         self._ag_obj_in_hand[arm] = constraint_params["target_obj"]
         self._ag_obj_constraint_params[arm] = constraint_params
 
-        # Filter collisions between finger links and the grasped link to prevent the joint
-        # constraint and collision forces from fighting each other.
+        # Defer collision filtering to the next step boundary to avoid invalidating
+        # tensor views inside the pre-physics-step callback.
+        finger_links = list(self.finger_links[arm])
         target_link = constraint_params["target_obj"].links[constraint_params["target_link_name"]]
-        with og.sim.editing_usd():
-            for finger_link in self.finger_links[arm]:
+
+        def _add_filtered_pairs():
+            for finger_link in finger_links:
                 finger_link.add_filtered_collision_pair(prim=target_link)
-        og.sim.update_handles()
+
+        og.sim._deferred_usd_actions.append(_add_filtered_pairs)
 
     def _convert_to_math_pi(self, ele):
         """

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -484,6 +484,8 @@ def _launch_simulator(*args, **kwargs):
             self._objects_to_initialize = []
             self._objects_require_joint_break_callback = False
             self._deferred_joint_breaks = []
+            # USD edits that must run between physics steps (not inside a physics callback)
+            self._deferred_usd_actions = []
 
             # Maps callback name to callback
             self._callbacks_on_play = dict()
@@ -1359,6 +1361,13 @@ def _launch_simulator(*args, **kwargs):
             # step() may not step physics
             if len(self._objects_to_initialize) > 0:
                 self.render()
+
+            # Run any USD edits that were deferred from inside physics callbacks
+            if self._deferred_usd_actions:
+                actions, self._deferred_usd_actions = self._deferred_usd_actions, []
+                for action in actions:
+                    action()
+                self.update_handles()
 
             # Clear all scenes' updated objects
             for scene in self.scenes:


### PR DESCRIPTION
1. Enable CCD on all rigid bodies when CCD mode is on.
2. For objects with thin meshes, increase solver position iterations to 64 (from 32).
~3. Only set contact offset for small objects, otherwise let it be set by Isaac using the default calculation. This should be a no-op for small objects but increase the contact offset for larger objects.~ removed this
4. Filter out collisions between gripper and gripped object when using assisted grasping. This removes the penetration issue that is seen when holding a thin object and moving the arm around.