### PR TITLE
Refresh PhysX-Fabric bindings when restoring re-added scene objects

### DIFF
--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -930,7 +930,7 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
             for obj_to_add in objs_to_add
         ]
         og.sim.batch_add_objects(objects_to_add, scenes=[self] * len(objects_to_add))
-        
+
         # Rebuilding physics after re-adding objects lets PhysX-Fabric bind before state poses load.
         if objects_to_add and og.sim.is_playing():
             og.sim.refresh_physics_after_stage_update()

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -937,7 +937,7 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
         # Add new physics prims while stopped, then reuse play() to rebuild handles before loading poses.
 
         og.sim.batch_add_objects(objects_to_add, scenes=[self] * len(objects_to_add))
-        
+
         if restart_sim:
             og.sim.play()
 

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -930,6 +930,10 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
             for obj_to_add in objs_to_add
         ]
         og.sim.batch_add_objects(objects_to_add, scenes=[self] * len(objects_to_add))
+        
+        # Rebuilding physics after re-adding objects lets PhysX-Fabric bind before state poses load.
+        if objects_to_add and og.sim.is_playing():
+            og.sim.refresh_physics_after_stage_update()
 
         # Load state
         self.load_state(state, serialized=False)

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -929,11 +929,13 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
             create_object_from_init_info(scene_info["objects_info"]["init_info"][obj_to_add])
             for obj_to_add in objs_to_add
         ]
+        # Add new physics prims while stopped, then reuse play() to rebuild handles before loading poses.
+        restart_sim = objects_to_add and og.sim.is_playing()
+        if restart_sim:
+            og.sim.stop()
         og.sim.batch_add_objects(objects_to_add, scenes=[self] * len(objects_to_add))
-
-        # Rebuilding physics after re-adding objects lets PhysX-Fabric bind before state poses load.
-        if objects_to_add and og.sim.is_playing():
-            og.sim.refresh_physics_after_stage_update()
+        if restart_sim:
+            og.sim.play()
 
         # Load state
         self.load_state(state, serialized=False)

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -920,6 +920,11 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
         objs_to_remove = current_obj_names - load_obj_names
         objs_to_add = load_obj_names - current_obj_names
 
+        restart_sim = (objs_to_add or objs_to_remove) and og.sim.is_playing()
+
+        if restart_sim:
+            og.sim.stop()
+
         # Delete any extra objects that currently exist in the scene stage
         objects_to_remove = [self.object_registry("name", obj_to_remove) for obj_to_remove in objs_to_remove]
         og.sim.batch_remove_objects(objects_to_remove)
@@ -930,10 +935,9 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
             for obj_to_add in objs_to_add
         ]
         # Add new physics prims while stopped, then reuse play() to rebuild handles before loading poses.
-        restart_sim = objects_to_add and og.sim.is_playing()
-        if restart_sim:
-            og.sim.stop()
+
         og.sim.batch_add_objects(objects_to_add, scenes=[self] * len(objects_to_add))
+        
         if restart_sim:
             og.sim.play()
 

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -978,7 +978,6 @@ def _launch_simulator(*args, **kwargs):
             """
             playing = self.is_playing()
             if playing:
-                self.update_handles()
                 state = self.dump_state()
 
                 # Omniverse has a strange bug where if GPU dynamics is on and the object to remove is in contact with

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -1186,35 +1186,6 @@ def _launch_simulator(*args, **kwargs):
             RigidContactAPI.initialize_view()
             ControllableObjectViewAPI.initialize_view()
 
-        def refresh_physics_after_stage_update(self):
-            """
-            Refresh PhysX / Fabric state after physics prims have been added or removed while the simulator is running.
-            """
-            if not self.is_playing():
-                return
-
-            assert not self.currently_stepping, "Cannot refresh physics state during a physics step!"
-
-            channels = ["omni.usd", "omni.physicsschema.plugin", "omni.physx.plugin", "omni.physx.tensors.plugin"]
-            with suppress_omni_log(channels=channels):
-                self._in_sim_lifecycle += 1
-                try:
-                    self._sim_context.stop()
-                    self._sim_context.play()
-                finally:
-                    self._in_sim_lifecycle -= 1
-
-            self.render()
-            self.update_handles()
-
-            for scene in self.scenes:
-                for robot in scene.robots:
-                    if robot.initialized:
-                        robot.update_controller_mode()
-
-                if gm.ENABLE_TRANSITION_RULES:
-                    scene.transition_rule_api.refresh_all_rules()
-
         @with_profiler(name="_non_physics_step_profiler")
         def _non_physics_step(self):
             """

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -978,6 +978,7 @@ def _launch_simulator(*args, **kwargs):
             """
             playing = self.is_playing()
             if playing:
+                self.update_handles()
                 state = self.dump_state()
 
                 # Omniverse has a strange bug where if GPU dynamics is on and the object to remove is in contact with
@@ -1184,6 +1185,35 @@ def _launch_simulator(*args, **kwargs):
             # Finally update any unified views
             RigidContactAPI.initialize_view()
             ControllableObjectViewAPI.initialize_view()
+
+        def refresh_physics_after_stage_update(self):
+            """
+            Refresh PhysX / Fabric state after physics prims have been added or removed while the simulator is running.
+            """
+            if not self.is_playing():
+                return
+
+            assert not self.currently_stepping, "Cannot refresh physics state during a physics step!"
+
+            channels = ["omni.usd", "omni.physicsschema.plugin", "omni.physx.plugin", "omni.physx.tensors.plugin"]
+            with suppress_omni_log(channels=channels):
+                self._in_sim_lifecycle += 1
+                try:
+                    self._sim_context.stop()
+                    self._sim_context.play()
+                finally:
+                    self._in_sim_lifecycle -= 1
+
+            self.render()
+            self.update_handles()
+
+            for scene in self.scenes:
+                for robot in scene.robots:
+                    if robot.initialized:
+                        robot.update_controller_mode()
+
+                if gm.ENABLE_TRANSITION_RULES:
+                    scene.transition_rule_api.refresh_all_rules()
 
         @with_profiler(name="_non_physics_step_profiler")
         def _non_physics_step(self):


### PR DESCRIPTION
This PR rebuilds live PhysX/Fabric bindings after `Scene.restore` re-adds missing objects, before loading saved poses. This is done by a helper function that stop/plays the raw sim context, renders, and refreshes handles. Before this, readded rigid objects could have valid PhysX tensor handles while Fabric/render transforms stayed stale at the origin. A normal PhysX-to-Fabric update was not enough. The PhysX/Fabric publisher needed to be rebuilt before `load_state()` applied saved poses.