### PR TITLE
Clear stale assisted-grasp state when removing objects

### DIFF
--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -1003,6 +1003,7 @@ def _launch_simulator(*args, **kwargs):
                         obj.name in obj_registry
                     ):  # a particle system template object might not exist in the registry when it's empty
                         obj_registry.pop(obj.name)
+                    # Remove stale articulated-grasp constraints for any robot arm targeting this object.
                     for robot in obj.scene.robots:
                         robot_state = obj_registry.get(robot.name)
                         ag_params = None if robot_state is None else robot_state.get("ag_obj_constraint_params")

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -1003,6 +1003,18 @@ def _launch_simulator(*args, **kwargs):
                         obj.name in obj_registry
                     ):  # a particle system template object might not exist in the registry when it's empty
                         obj_registry.pop(obj.name)
+                    for robot in obj.scene.robots:
+                        robot_state = obj_registry.get(robot.name)
+                        ag_params = None if robot_state is None else robot_state.get("ag_obj_constraint_params")
+                        if ag_params is None:
+                            continue
+                        for arm, arm_params in ag_params.items():
+                            if not arm_params:
+                                continue
+                            target_obj = arm_params.get("target_obj")
+                            target_obj_name = target_obj.name if hasattr(target_obj, "name") else target_obj
+                            if target_obj_name == obj.name or arm_params.get("ag_obj_prim_path") == obj.prim_path:
+                                ag_params[arm] = None
 
             # Run the main method
             try:


### PR DESCRIPTION
This PR clears robot assisted-grasp params that target an object being removed (e.g. egg is being grasped with assisted grasping and then knife touches the egg)