### PR TITLE
Remove visual only objects from ignore set for is_in_contact

### DIFF
--- a/joylo/gello/utils/qa_utils.py
+++ b/joylo/gello/utils/qa_utils.py
@@ -1025,7 +1025,7 @@ def check_robot_nonarm_nonground_collision(env):
             env.scene.idx,
             non_arm_links,
             with_set=None,
-            ignore_set=ground_objects + [robot],
+            ignore_set=[obj for obj in ground_objects if obj.visual_only == False] + [robot],
             current_only=False,
         ):
             return True


### PR DESCRIPTION
This PR removes the visual only objects passed into ignore_set during qa check for the is_in_contact function, which currently raises error for carpet object in the Rs_int scene.