### PR TITLE
Fix out-of-step refresh issue for time-dependent object states

### DIFF
--- a/OmniGibson/omnigibson/object_states/slicer_active.py
+++ b/OmniGibson/omnigibson/object_states/slicer_active.py
@@ -150,7 +150,7 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for survivors)
         super().initialize_view()
 
-        cls._LAST_UPDATE_STEP_INDEX = -1
+        cls._LAST_UPDATE_STEP_INDEX = og.sim.step_call_index
 
         S = len(cls.IDX_OBJS)
         O = len(cls.OBJ_IDXS)

--- a/OmniGibson/omnigibson/object_states/slicer_active.py
+++ b/OmniGibson/omnigibson/object_states/slicer_active.py
@@ -308,7 +308,7 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
 
     def _dump_state(self):
         if self.OBJ_IDXS is None or self.obj.relative_prim_path not in self.OBJ_IDXS:
-            return dict(value=True, previously_touching=False, delay_counter_seconds=0.0)
+            return dict(value=True, previously_touching=False, delay_counter=0.0)
         state = super()._dump_state()
         scene_idx = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
@@ -316,7 +316,7 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         prev_view = wp.to_torch(type(self).PREVIOUSLY_TOUCHING)
         delay_view = wp.to_torch(type(self).DELAY_COUNTER)
         state["previously_touching"] = bool(prev_view[scene_idx, obj_idx])
-        state["delay_counter_seconds"] = float(delay_view[scene_idx, obj_idx])
+        state["delay_counter"] = float(delay_view[scene_idx, obj_idx])
         return state
 
     def _load_state(self, state):
@@ -324,14 +324,14 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         s = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
         wp.to_torch(type(self).PREVIOUSLY_TOUCHING)[s, obj_idx] = int(state["previously_touching"])
-        wp.to_torch(type(self).DELAY_COUNTER)[s, obj_idx] = float(state["delay_counter_seconds"])
+        wp.to_torch(type(self).DELAY_COUNTER)[s, obj_idx] = float(state["delay_counter"])
 
     def serialize(self, state):
         state_flat = super().serialize(state=state)
         return th.cat(
             [
                 state_flat,
-                th.tensor([state["previously_touching"], state["delay_counter_seconds"]]),
+                th.tensor([state["previously_touching"], state["delay_counter"]]),
             ]
         )
 
@@ -339,5 +339,5 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         state_dict, idx = super().deserialize(state=state)
         state_dict[f"{self.value_name}"] = bool(state_dict[f"{self.value_name}"])
         state_dict["previously_touching"] = bool(state[idx])
-        state_dict["delay_counter_seconds"] = float(state[idx + 1])
+        state_dict["delay_counter"] = float(state[idx + 1])
         return state_dict, idx + 2

--- a/OmniGibson/omnigibson/object_states/slicer_active.py
+++ b/OmniGibson/omnigibson/object_states/slicer_active.py
@@ -1,5 +1,3 @@
-import math
-
 import torch as th
 import warp as wp
 
@@ -52,18 +50,19 @@ def _slicer_pre_clear_kernel(
 @wp.kernel
 def _slicer_post_update_kernel(
     values: wp.array2d(dtype=wp.uint8),  # (S, O) — public state, stays uint8
-    delay_counter: wp.array2d(dtype=wp.float32),  # (S, O)
+    delay_counter: wp.array2d(dtype=wp.float32),  # (S, O) — seconds elapsed since last touch
     currently_touching: wp.array2d(dtype=wp.int32),  # (S, O) — int32, written by atomic in is_in_contact_batch_warp
     prev_touching: wp.array2d(dtype=wp.int32),  # (S, O) — int32 to mirror currently_touching
-    steps_to_wait: wp.float32,
+    seconds_to_wait: wp.float32,
+    dt: wp.array(dtype=wp.float32),
 ):
     """
     Per (scene, obj) thread. Per thread does:
       - If the slicer is currently active: leave delay_counter alone (it's not in cooldown).
-      - If the slicer is inactive AND not touching anything: advance delay_counter by 1.
+      - If the slicer is inactive AND not touching anything: advance delay_counter by dt[0] seconds.
       - If the slicer is inactive AND still touching something: reset delay_counter to 0
         (touching restarts the wait — the slicer doesn't reactivate while in contact).
-      - If delay_counter has hit `steps_to_wait`, reactivate the slicer.
+      - If delay_counter has hit `seconds_to_wait`, reactivate the slicer.
       - Finally, mirror currently_touching into prev_touching for the next step's pre-clear pass.
     """
     s, o = wp.tid()
@@ -71,10 +70,10 @@ def _slicer_post_update_kernel(
     is_touching = currently_touching[s, o] != wp.int32(0)
     if not is_active:
         if not is_touching:
-            delay_counter[s, o] = delay_counter[s, o] + 1.0
+            delay_counter[s, o] = delay_counter[s, o] + dt[0]
         else:
             delay_counter[s, o] = 0.0
-    if delay_counter[s, o] >= steps_to_wait:
+    if delay_counter[s, o] >= seconds_to_wait:
         values[s, o] = wp.uint8(1)
     prev_touching[s, o] = currently_touching[s, o]
 
@@ -87,10 +86,7 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
     they depend on`RigidContactAPI.is_in_contact_batch_warp` whose output is int32.
     """
 
-    # int: Keep track of how many steps each object is waiting for
-    STEPS_TO_WAIT = None
-
-    # wp.array2d (S, O) float32 — current delay counter per slicer.
+    # wp.array2d (S, O) float32 — seconds elapsed since the last touch, per slicer.
     DELAY_COUNTER = None
 
     # wp.array2d (S, O) int32 — whether each slicer touched a sliceable in the previous step.
@@ -113,11 +109,6 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
     # Per-scene wp row slice views of _currently_touching, used as is_in_contact_batch_warp out=.
     _currently_touching_per_scene = None  # list[wp.array | None]
 
-    # Index of the last og.sim.step() call during which _update_values ran. The gate in
-    # _update_values uses this to skip ticking during lazy refreshes triggered between
-    # real sim steps (e.g. by sample_kinematics).
-    _LAST_UPDATE_STEP_INDEX = -1
-
     @classmethod
     def get_dependencies(cls):
         deps = super().get_dependencies()
@@ -128,8 +119,6 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         # Call super first
         super().global_initialize()
 
-        # Compute step-based reactivation threshold (constant for the lifetime of the simulator)
-        cls.STEPS_TO_WAIT = max(1, int(math.ceil(m.REACTIVATION_DELAY / og.sim.get_sim_step_dt())))
         cls._slicer_contact_query_masks = None
         cls._sliceable_contact_col_mask = None
         cls._currently_touching = None
@@ -149,8 +138,6 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
 
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for survivors)
         super().initialize_view()
-
-        cls._LAST_UPDATE_STEP_INDEX = og.sim.step_call_index
 
         S = len(cls.IDX_OBJS)
         O = len(cls.OBJ_IDXS)
@@ -246,11 +233,6 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
     def _update_values(cls, values):
         if cls.PREVIOUSLY_TOUCHING is None:
             return
-        # Out-of-step update
-        step = og.sim.step_call_index
-        if step == cls._LAST_UPDATE_STEP_INDEX:
-            return
-        cls._LAST_UPDATE_STEP_INDEX = step
         S, O = values.shape[:2]
 
         wp.launch(
@@ -280,7 +262,8 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
                 cls.DELAY_COUNTER,
                 cls._currently_touching,
                 cls.PREVIOUSLY_TOUCHING,
-                wp.float32(cls.STEPS_TO_WAIT),
+                wp.float32(m.REACTIVATION_DELAY),
+                cls._dt,
             ],
             device="cuda",
         )
@@ -325,7 +308,7 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
 
     def _dump_state(self):
         if self.OBJ_IDXS is None or self.obj.relative_prim_path not in self.OBJ_IDXS:
-            return dict(value=True, previously_touching=False, delay_counter=0)
+            return dict(value=True, previously_touching=False, delay_counter_seconds=0.0)
         state = super()._dump_state()
         scene_idx = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
@@ -333,7 +316,7 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         prev_view = wp.to_torch(type(self).PREVIOUSLY_TOUCHING)
         delay_view = wp.to_torch(type(self).DELAY_COUNTER)
         state["previously_touching"] = bool(prev_view[scene_idx, obj_idx])
-        state["delay_counter"] = int(delay_view[scene_idx, obj_idx])
+        state["delay_counter_seconds"] = float(delay_view[scene_idx, obj_idx])
         return state
 
     def _load_state(self, state):
@@ -341,14 +324,14 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         s = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
         wp.to_torch(type(self).PREVIOUSLY_TOUCHING)[s, obj_idx] = int(state["previously_touching"])
-        wp.to_torch(type(self).DELAY_COUNTER)[s, obj_idx] = float(state["delay_counter"])
+        wp.to_torch(type(self).DELAY_COUNTER)[s, obj_idx] = float(state["delay_counter_seconds"])
 
     def serialize(self, state):
         state_flat = super().serialize(state=state)
         return th.cat(
             [
                 state_flat,
-                th.tensor([state["previously_touching"], state["delay_counter"]]),
+                th.tensor([state["previously_touching"], state["delay_counter_seconds"]]),
             ]
         )
 
@@ -356,5 +339,5 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
         state_dict, idx = super().deserialize(state=state)
         state_dict[f"{self.value_name}"] = bool(state_dict[f"{self.value_name}"])
         state_dict["previously_touching"] = bool(state[idx])
-        state_dict["delay_counter"] = int(state[idx + 1])
+        state_dict["delay_counter_seconds"] = float(state[idx + 1])
         return state_dict, idx + 2

--- a/OmniGibson/omnigibson/object_states/slicer_active.py
+++ b/OmniGibson/omnigibson/object_states/slicer_active.py
@@ -113,6 +113,11 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
     # Per-scene wp row slice views of _currently_touching, used as is_in_contact_batch_warp out=.
     _currently_touching_per_scene = None  # list[wp.array | None]
 
+    # Index of the last og.sim.step() call during which _update_values ran. The gate in
+    # _update_values uses this to skip ticking during lazy refreshes triggered between
+    # real sim steps (e.g. by sample_kinematics).
+    _LAST_UPDATE_STEP_INDEX = -1
+
     @classmethod
     def get_dependencies(cls):
         deps = super().get_dependencies()
@@ -144,6 +149,8 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
 
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for survivors)
         super().initialize_view()
+
+        cls._LAST_UPDATE_STEP_INDEX = -1
 
         S = len(cls.IDX_OBJS)
         O = len(cls.OBJ_IDXS)
@@ -239,6 +246,11 @@ class SlicerActive(TensorizedAbsoluteState, BooleanStateMixin):
     def _update_values(cls, values):
         if cls.PREVIOUSLY_TOUCHING is None:
             return
+        # Out-of-step update
+        step = og.sim.step_call_index
+        if step == cls._LAST_UPDATE_STEP_INDEX:
+            return
+        cls._LAST_UPDATE_STEP_INDEX = step
         S, O = values.shape[:2]
 
         wp.launch(

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -48,7 +48,7 @@ class Temperature(TensorizedAbsoluteState):
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for survivors)
         super().initialize_view()
 
-        cls._LAST_UPDATE_STEP_INDEX = -1
+        cls._LAST_UPDATE_STEP_INDEX = og.sim.step_call_index
 
         # Initialize new VALUE slots (not carried over) to DEFAULT_TEMPERATURE
         for rel_path, obj_idx in cls.OBJ_IDXS.items():

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -13,14 +13,14 @@ def _temperature_decay_kernel(
     values: wp.array2d(dtype=wp.float32),
     default_temp: wp.float32,
     decay_rate: wp.float32,
-    dt: wp.float32,
+    dt: wp.array(dtype=wp.float32),
 ):
     """
     In-place exponential decay toward `default_temp`. One thread per (scene, obj).
-    Equivalent to: values += (default_temp - values) * decay_rate * dt
+    Equivalent to: values += (default_temp - values) * decay_rate * dt[0]
     """
     s, o = wp.tid()
-    values[s, o] = values[s, o] + (default_temp - values[s, o]) * decay_rate * dt
+    values[s, o] = values[s, o] + (default_temp - values[s, o]) * decay_rate * dt[0]
 
 
 # Create settings for this module
@@ -35,11 +35,6 @@ m.TEMPERATURE_DECAY_SPEED = 0.02  # per second. We'll do the conversion to steps
 
 
 class Temperature(TensorizedAbsoluteState):
-    # Index of the last og.sim.step() call during which _update_values ran. The gate in
-    # _update_values uses this to skip ticking during lazy refreshes triggered between
-    # real sim steps (e.g. by sample_kinematics).
-    _LAST_UPDATE_STEP_INDEX = -1
-
     @classmethod
     def initialize_view(cls):
         # Snapshot which relative paths existed before the rebuild
@@ -47,8 +42,6 @@ class Temperature(TensorizedAbsoluteState):
 
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for survivors)
         super().initialize_view()
-
-        cls._LAST_UPDATE_STEP_INDEX = og.sim.step_call_index
 
         # Initialize new VALUE slots (not carried over) to DEFAULT_TEMPERATURE
         for rel_path, obj_idx in cls.OBJ_IDXS.items():
@@ -90,14 +83,11 @@ class Temperature(TensorizedAbsoluteState):
 
     @classmethod
     def _update_values(cls, values):
-        # Apply temperature decay via Warp kernel
+        # Apply temperature decay via Warp kernel. dt is read from cls._dt at kernel-launch
+        # time inside the captured graph, so the per-frame value written in pre_update is
+        # visible without re-capturing the graph.
         if cls.VALUES_WP is None:
             return
-        # Out-of-step update
-        step = og.sim.step_call_index
-        if step == cls._LAST_UPDATE_STEP_INDEX:
-            return
-        cls._LAST_UPDATE_STEP_INDEX = step
         S, O = cls.VALUES.shape[:2]
         wp.launch(
             kernel=_temperature_decay_kernel,
@@ -106,7 +96,7 @@ class Temperature(TensorizedAbsoluteState):
                 cls.VALUES_WP,
                 wp.float32(m.DEFAULT_TEMPERATURE),
                 wp.float32(m.TEMPERATURE_DECAY_SPEED),
-                wp.float32(og.sim.get_sim_step_dt()),
+                cls._dt,
             ],
             device="cuda",
         )

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -35,6 +35,11 @@ m.TEMPERATURE_DECAY_SPEED = 0.02  # per second. We'll do the conversion to steps
 
 
 class Temperature(TensorizedAbsoluteState):
+    # Index of the last og.sim.step() call during which _update_values ran. The gate in
+    # _update_values uses this to skip ticking during lazy refreshes triggered between
+    # real sim steps (e.g. by sample_kinematics).
+    _LAST_UPDATE_STEP_INDEX = -1
+
     @classmethod
     def initialize_view(cls):
         # Snapshot which relative paths existed before the rebuild
@@ -42,6 +47,8 @@ class Temperature(TensorizedAbsoluteState):
 
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for survivors)
         super().initialize_view()
+
+        cls._LAST_UPDATE_STEP_INDEX = -1
 
         # Initialize new VALUE slots (not carried over) to DEFAULT_TEMPERATURE
         for rel_path, obj_idx in cls.OBJ_IDXS.items():
@@ -86,6 +93,11 @@ class Temperature(TensorizedAbsoluteState):
         # Apply temperature decay via Warp kernel
         if cls.VALUES_WP is None:
             return
+        # Out-of-step update
+        step = og.sim.step_call_index
+        if step == cls._LAST_UPDATE_STEP_INDEX:
+            return
+        cls._LAST_UPDATE_STEP_INDEX = step
         S, O = cls.VALUES.shape[:2]
         wp.launch(
             kernel=_temperature_decay_kernel,

--- a/OmniGibson/omnigibson/object_states/tensorized_absolute_state.py
+++ b/OmniGibson/omnigibson/object_states/tensorized_absolute_state.py
@@ -121,6 +121,8 @@ class TensorizedAbsoluteState(TensorizedState, AbsoluteObjectState):
         # are already covered by the time this fires.
         TensorizedState.graph_dirty = True
 
+        super().initialize_view()
+
     def _get_value(self):
         # Read from the pinned CPU mirror — no GPU stall for Python callers
         s = self.obj.scene.idx

--- a/OmniGibson/omnigibson/object_states/tensorized_relative_state.py
+++ b/OmniGibson/omnigibson/object_states/tensorized_relative_state.py
@@ -144,6 +144,8 @@ class TensorizedRelativeState(TensorizedState, RelativeObjectState):
         # Mark the captured wp.graph as stale — the simulator will re-capture before the next step.
         TensorizedState.graph_dirty = True
 
+        super().initialize_view()
+
     def _get_value(self, other):
         # Read from the pinned CPU mirror — no GPU stall for Python callers.
         s = self.obj.scene.idx

--- a/OmniGibson/omnigibson/object_states/tensorized_state.py
+++ b/OmniGibson/omnigibson/object_states/tensorized_state.py
@@ -83,6 +83,19 @@ class TensorizedState:
     # re-triggering a refresh. Set/cleared inside the simulator helper.
     _refresh_in_progress = False
 
+    # Simulator time (seconds) at the previous _update_values call. Used by pre_update
+    # to compute the seconds elapsed since the last tick and store it in _dt for subclasses
+    # that do time-dependent math (Temperature, ToggledOn, SlicerActive). Reset on initialize_view
+    # so a stop→play cycle (which resets og.sim.current_time to 0) does not produce a negative dt.
+    _last_update_time = 0.0
+
+    # Single-element wp.array on cuda holding the seconds elapsed since the last _update_values
+    # tick. Written in pre_update (outside the captured graph) and read by time-dependent
+    # subclasses' kernels inside the captured graph. We use a wp.array (not a wp.float32 scalar
+    # passed at launch) so per-frame mutation is visible to graph replays without re-capture —
+    # scalars passed via wp.float32(...) bake the value at capture time.
+    _dt = None
+
     @classmethod
     def maybe_refresh_caches(cls):
         """Helper for `get_value`: if caches are dirty (and we're not already
@@ -93,6 +106,21 @@ class TensorizedState:
 
             og.sim._refresh_state_caches()
 
+    @classmethod
+    def initialize_view(cls):
+        """
+        Δt-tracking setup shared across tensorized states. Subclasses' initialize_view should
+        call ``super().initialize_view()`` after they finish allocating VALUES.
+
+        Snapshots the current sim time so the next _update_values invocation sees Δt=0, and
+        allocates the 1-element wp.array that pre_update writes into each step.
+        """
+        import omnigibson as og  # local import to avoid module-level cycle
+
+        cls._last_update_time = og.sim.current_time
+        if cls._dt is None:
+            cls._dt = wp.zeros(shape=(1,), dtype=wp.float32, device="cuda")
+
     def get_value(self, *args, **kwargs):
         self.maybe_refresh_caches()
         return super().get_value(*args, **kwargs)
@@ -101,7 +129,8 @@ class TensorizedState:
     def pre_update(cls):
         """
         CPU-side prep run BEFORE global_update each step. Snapshots VALUES_CPU into
-        PREV_VALUES so post_update() can detect changes after the warp work completes.
+        PREV_VALUES so post_update() can detect changes after the warp work completes,
+        and refreshes cls._dt with the seconds elapsed since the previous update.
 
         Lives outside the captured wp.graph.
 
@@ -111,6 +140,16 @@ class TensorizedState:
         if cls.VALUES_CPU is None or cls.VALUES_CPU.numel() == 0:
             return
         cls.PREV_VALUES.copy_(cls.VALUES_CPU)
+
+        # Refresh dt for time-dependent kernels. max(0, …) guards against a stop→play cycle,
+        # which resets Isaac's current_time to 0 — without the clamp the next dt would be negative.
+        import omnigibson as og  # local import to avoid module-level cycle
+
+        curr_time = og.sim.current_time
+        dt_value = max(0.0, curr_time - cls._last_update_time)
+        cls._last_update_time = curr_time
+        if cls._dt is not None:
+            cls._dt.fill_(dt_value)
 
     @classmethod
     def global_update(cls):

--- a/OmniGibson/omnigibson/object_states/tensorized_state.py
+++ b/OmniGibson/omnigibson/object_states/tensorized_state.py
@@ -83,17 +83,11 @@ class TensorizedState:
     # re-triggering a refresh. Set/cleared inside the simulator helper.
     _refresh_in_progress = False
 
-    # Simulator time (seconds) at the previous _update_values call. Used by pre_update
-    # to compute the seconds elapsed since the last tick and store it in _dt for subclasses
-    # that do time-dependent math (Temperature, ToggledOn, SlicerActive). Reset on initialize_view
-    # so a stop→play cycle (which resets og.sim.current_time to 0) does not produce a negative dt.
-    _last_update_time = 0.0
-
-    # Single-element wp.array on cuda holding the seconds elapsed since the last _update_values
-    # tick. Written in pre_update (outside the captured graph) and read by time-dependent
-    # subclasses' kernels inside the captured graph. We use a wp.array (not a wp.float32 scalar
-    # passed at launch) so per-frame mutation is visible to graph replays without re-capture —
-    # scalars passed via wp.float32(...) bake the value at capture time.
+    # Single-element wp.array on cuda holding the seconds elapsed for the current logical step
+    # (the caller-provided dt, see pre_update). Read by time-dependent subclasses' kernels
+    # (Temperature, ToggledOn, SlicerActive) inside the captured graph. We use a wp.array (not a
+    # wp.float32 scalar passed at launch) so per-frame mutation is visible to graph replays without
+    # re-capture — scalars passed via wp.float32(...) bake the value at capture time.
     _dt = None
 
     @classmethod
@@ -112,12 +106,8 @@ class TensorizedState:
         Δt-tracking setup shared across tensorized states. Subclasses' initialize_view should
         call ``super().initialize_view()`` after they finish allocating VALUES.
 
-        Snapshots the current sim time so the next _update_values invocation sees Δt=0, and
-        allocates the 1-element wp.array that pre_update writes into each step.
+        Allocates the 1-element wp.array that pre_update fills with the per-step dt each step.
         """
-        import omnigibson as og  # local import to avoid module-level cycle
-
-        cls._last_update_time = og.sim.current_time
         if cls._dt is None:
             cls._dt = wp.zeros(shape=(1,), dtype=wp.float32, device="cuda")
 
@@ -126,11 +116,12 @@ class TensorizedState:
         return super().get_value(*args, **kwargs)
 
     @classmethod
-    def pre_update(cls):
+    def pre_update(cls, dt=0.0):
         """
         CPU-side prep run BEFORE global_update each step. Snapshots VALUES_CPU into
         PREV_VALUES so post_update() can detect changes after the warp work completes,
-        and refreshes cls._dt with the seconds elapsed since the previous update.
+        and stores the caller-provided ``dt`` (seconds elapsed for this logical step) into
+        cls._dt for time-dependent kernels to read inside the captured graph.
 
         Lives outside the captured wp.graph.
 
@@ -141,15 +132,8 @@ class TensorizedState:
             return
         cls.PREV_VALUES.copy_(cls.VALUES_CPU)
 
-        # Refresh dt for time-dependent kernels. max(0, …) guards against a stop→play cycle,
-        # which resets Isaac's current_time to 0 — without the clamp the next dt would be negative.
-        import omnigibson as og  # local import to avoid module-level cycle
-
-        curr_time = og.sim.current_time
-        dt_value = max(0.0, curr_time - cls._last_update_time)
-        cls._last_update_time = curr_time
         if cls._dt is not None:
-            cls._dt.fill_(dt_value)
+            cls._dt.fill_(dt)
 
     @classmethod
     def global_update(cls):

--- a/OmniGibson/omnigibson/object_states/toggle.py
+++ b/OmniGibson/omnigibson/object_states/toggle.py
@@ -233,7 +233,7 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
 
         S, O = len(cls.IDX_OBJS), len(cls.OBJ_IDXS)
 
-        cls._LAST_UPDATE_STEP_INDEX = -1
+        cls._LAST_UPDATE_STEP_INDEX = og.sim.step_call_index
 
         # Carry over _can_toggle_steps for surviving objects
         cls._robots_can_toggle_steps = th.zeros((S, O), dtype=th.float32, device="cuda")

--- a/OmniGibson/omnigibson/object_states/toggle.py
+++ b/OmniGibson/omnigibson/object_states/toggle.py
@@ -186,6 +186,11 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
     COLOR_ON = th.tensor([0, 1.0, 0])  # green  — toggle is on
     COLOR_OFF = th.tensor([1.0, 0, 0])  # red    — toggle is off
 
+    # Index of the last og.sim.step() call during which _update_values ran. The gate in
+    # _update_values uses this to skip ticking during lazy refreshes triggered between
+    # real sim steps (e.g. by sample_kinematics / settling loops).
+    _LAST_UPDATE_STEP_INDEX = -1
+
     @classproperty
     def value_type(cls):
         return th.bool
@@ -227,6 +232,19 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
         super().initialize_view()
 
         S, O = len(cls.IDX_OBJS), len(cls.OBJ_IDXS)
+
+        cls._LAST_UPDATE_STEP_INDEX = -1
+
+        # Carry over _can_toggle_steps for surviving objects
+        cls._robots_can_toggle_steps = th.zeros((S, O), dtype=th.float32, device="cuda")
+        if prev_steps is not None:
+            for relative_prim_path, obj_idx_old in prev_obj_idxs.items():
+                if relative_prim_path not in cls.OBJ_IDXS:
+                    continue
+                obj_idx = cls.OBJ_IDXS[relative_prim_path]
+                for scene_idx in range(min(prev_steps.shape[0], S)):
+                    cls._robots_can_toggle_steps[scene_idx, obj_idx] = prev_steps[scene_idx, obj_idx_old]
+        cls._robots_can_toggle_steps_wp = wp.from_torch(cls._robots_can_toggle_steps)
 
         cls._init_requires_closed_logic(O)
 
@@ -570,6 +588,11 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
         """
         if cls._mask_can_toggle_flat is None:
             return
+        # Out-of-step update
+        step = og.sim.step_call_index
+        if step == cls._LAST_UPDATE_STEP_INDEX:
+            return
+        cls._LAST_UPDATE_STEP_INDEX = step
         S, O = values.shape[:2]
 
         mask_flat = cls._mask_can_toggle_flat

--- a/OmniGibson/omnigibson/object_states/toggle.py
+++ b/OmniGibson/omnigibson/object_states/toggle.py
@@ -26,7 +26,8 @@ m = create_module_macros(module_path=__file__)
 
 m.TOGGLE_META_LINK_TYPE = "togglebutton"
 m.DEFAULT_SCALE = 0.1
-m.CAN_TOGGLE_STEPS = 5
+# Seconds a robot finger must stay in contact with the toggle marker before the state flips.
+m.CAN_TOGGLE_SECONDS = 0.15
 
 
 @wp.kernel
@@ -580,7 +581,10 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
         values_flat_wp = wp.from_torch(values.view(-1).view(th.uint8), dtype=wp.uint8)
         time_flat = cls._robots_can_toggle_time.reshape((S * O,))
 
-        threshold_seconds = m.CAN_TOGGLE_STEPS * og.sim.get_sim_step_dt()
+        threshold_seconds = m.CAN_TOGGLE_SECONDS
+        assert (
+            threshold_seconds > og.sim.get_sim_step_dt()
+        ), f"m.CAN_TOGGLE_SECONDS ({threshold_seconds}s) must exceed one sim step dt ({og.sim.get_sim_step_dt()}s)"
 
         mask_flat.zero_()
 

--- a/OmniGibson/omnigibson/object_states/toggle.py
+++ b/OmniGibson/omnigibson/object_states/toggle.py
@@ -743,27 +743,29 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
 
     def _dump_state(self):
         if self.OBJ_IDXS is None or self.obj.relative_prim_path not in self.OBJ_IDXS:
-            return dict(value=False, hand_in_marker_time=0.0)
+            return dict(value=False, hand_in_marker_steps=0.0)
         s = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
         # wp.to_torch is a zero-copy view of the wp.array storage.
         time_view = wp.to_torch(type(self)._robots_can_toggle_time)
         return dict(
             value=bool(self.VALUES[s, obj_idx].item()),
-            hand_in_marker_time=float(time_view[s, obj_idx].item()),
+            hand_in_marker_steps=float(time_view[s, obj_idx].item()),
         )
 
     def _load_state(self, state):
         # Restore toggle via _set_value so the visual marker color is also updated.
         self._set_value(state["value"])
-        # Restore the seconds counter directly into the wp.array via a zero-copy torch view.
+        if self.OBJ_IDXS is None or self.obj.relative_prim_path not in self.OBJ_IDXS:
+            return
         s = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
-        wp.to_torch(type(self)._robots_can_toggle_time)[s, obj_idx] = float(state["hand_in_marker_time"])
+        # Restore the seconds counter directly into the wp.array via a zero-copy torch view.
+        wp.to_torch(type(self)._robots_can_toggle_time)[s, obj_idx] = float(state["hand_in_marker_steps"])
 
     def serialize(self, state):
         # [toggle_state, can_toggle_time (seconds)] as float32
-        return th.tensor([state["value"], state["hand_in_marker_time"]], dtype=th.float32)
+        return th.tensor([state["value"], state["hand_in_marker_steps"]], dtype=th.float32)
 
     def deserialize(self, state):
-        return dict(value=bool(state[0].item()), hand_in_marker_time=float(state[1].item())), 2
+        return dict(value=bool(state[0].item()), hand_in_marker_steps=float(state[1].item())), 2

--- a/OmniGibson/omnigibson/object_states/toggle.py
+++ b/OmniGibson/omnigibson/object_states/toggle.py
@@ -86,18 +86,18 @@ def _check_requires_closed_kernel(
     requires_closed_idx_in_open: wp.array(dtype=wp.int32),  # (R,) flat idx into Open.VALUES
     open_values: wp.array(dtype=wp.uint8),  # Open.VALUES_WP flattened (S*O_open,)
     toggle_values: wp.array(dtype=wp.uint8),  # VALUES.view(-1) (S*O_toggle,)
-    robots_can_toggle_steps: wp.array(dtype=wp.float32),  # (S*O,)
+    robots_can_toggle_time: wp.array(dtype=wp.float32),  # (S*O,) — seconds accumulated
     mask_can_toggle: wp.array(dtype=wp.int32),  # (S*O,)
 ):
     """
     Each thread checks 1 object in 1 scene.
-    If Open.VALUES == True, Toggle.VALUES = False, robots_can_toggle_steps = 0, mask_can_toggle = False.
+    If Open.VALUES == True, Toggle.VALUES = False, robots_can_toggle_time = 0, mask_can_toggle = False.
     """
     thread_id = wp.tid()
     if open_values[requires_closed_idx_in_open[thread_id]] != wp.uint8(0):
         idx = requires_closed_idx_in_this[thread_id]
         toggle_values[idx] = wp.uint8(0)
-        robots_can_toggle_steps[idx] = 0.0
+        robots_can_toggle_time[idx] = 0.0
         mask_can_toggle[idx] = wp.int32(0)
 
 
@@ -105,14 +105,15 @@ def _check_requires_closed_kernel(
 def _set_toggle_value_kernel(
     values: wp.array2d(dtype=wp.uint8),  # (S, O)
     mask_can_toggle_flat: wp.array(dtype=wp.int32),  # (S*O,) — single cached 1D view (see _update_values)
-    robots_can_toggle_steps: wp.array2d(dtype=wp.float32),  # (S, O)
+    robots_can_toggle_time: wp.array2d(dtype=wp.float32),  # (S, O) — seconds accumulated this hold
     O: wp.int32,  # second dim of `values` — to flatten (s, o) → s*O+o for the mask
-    can_toggle_threshold: wp.float32,
+    can_toggle_threshold_seconds: wp.float32,
+    dt: wp.array(dtype=wp.float32),
 ):
     """
     Each thread works on 1 object in 1 scene.
     When mask == 2, all three requirements passed (contact, requires_closed, overlaps).
-    Increment step and flip values where the step reach threshold.
+    Accumulate dt seconds and flip values when the counter first crosses the threshold.
     Reset mask to 0.
     """
     s, o = wp.tid()
@@ -121,13 +122,15 @@ def _set_toggle_value_kernel(
     if mask_can_toggle_flat[idx] == wp.int32(2):
         eligible = wp.int32(1)
 
+    prev_time = robots_can_toggle_time[s, o]
     if eligible != wp.int32(0):
-        robots_can_toggle_steps[s, o] = robots_can_toggle_steps[s, o] + 1.0
+        robots_can_toggle_time[s, o] = prev_time + dt[0]
     else:
-        robots_can_toggle_steps[s, o] = 0.0
+        robots_can_toggle_time[s, o] = 0.0
 
+    new_time = robots_can_toggle_time[s, o]
     flip = wp.int32(0)
-    if robots_can_toggle_steps[s, o] == can_toggle_threshold:
+    if prev_time < can_toggle_threshold_seconds and new_time >= can_toggle_threshold_seconds:
         flip = eligible
 
     mask_can_toggle_flat[idx] = wp.int32(0)
@@ -144,8 +147,9 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
     # S = number of scenes
     # O = number of toggleable objects
 
-    # wp.array2d (S, O) float32 — robot finger-in-marker step counter
-    _robots_can_toggle_steps = None
+    # wp.array2d (S, O) float32 — seconds the robot finger has been overlapping the marker for
+    # the current hold session. Reset to 0 when eligibility breaks.
+    _robots_can_toggle_time = None
 
     # (O_requires_closed,) int32 — flat-index lookups into Open.VALUES and ToggledOn.VALUES.
     _requires_closed_obj_idxes_in_open_values = None
@@ -186,11 +190,6 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
     COLOR_ON = th.tensor([0, 1.0, 0])  # green  — toggle is on
     COLOR_OFF = th.tensor([1.0, 0, 0])  # red    — toggle is off
 
-    # Index of the last og.sim.step() call during which _update_values ran. The gate in
-    # _update_values uses this to skip ticking during lazy refreshes triggered between
-    # real sim steps (e.g. by sample_kinematics / settling loops).
-    _LAST_UPDATE_STEP_INDEX = -1
-
     @classproperty
     def value_type(cls):
         return th.bool
@@ -203,7 +202,7 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
     def global_initialize(cls):
         super().global_initialize()
 
-        cls._robots_can_toggle_steps = None
+        cls._robots_can_toggle_time = None
         cls._requires_closed_obj_idxes_in_open_values = None
         cls._requires_closed_obj_idxes_in_this_values = None
         cls.visual_markers = []
@@ -224,8 +223,8 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
         # Snapshot existing states. wp.to_torch shares storage with the wp array;
         # .cpu() forces a single GPU→CPU copy so the per-element carry-over reads stay on CPU.
         prev_obj_idxs = dict(cls.OBJ_IDXS) if cls.OBJ_IDXS is not None else {}
-        prev_steps_cpu = (
-            wp.to_torch(cls._robots_can_toggle_steps).cpu() if cls._robots_can_toggle_steps is not None else None
+        prev_time_cpu = (
+            wp.to_torch(cls._robots_can_toggle_time).cpu() if cls._robots_can_toggle_time is not None else None
         )
 
         # Base class rebuilds OBJ_IDXS, IDX_OBJS, VALUES (with value carry-over for toggle bool)
@@ -233,37 +232,24 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
 
         S, O = len(cls.IDX_OBJS), len(cls.OBJ_IDXS)
 
-        cls._LAST_UPDATE_STEP_INDEX = og.sim.step_call_index
-
-        # Carry over _can_toggle_steps for surviving objects
-        cls._robots_can_toggle_steps = th.zeros((S, O), dtype=th.float32, device="cuda")
-        if prev_steps is not None:
-            for relative_prim_path, obj_idx_old in prev_obj_idxs.items():
-                if relative_prim_path not in cls.OBJ_IDXS:
-                    continue
-                obj_idx = cls.OBJ_IDXS[relative_prim_path]
-                for scene_idx in range(min(prev_steps.shape[0], S)):
-                    cls._robots_can_toggle_steps[scene_idx, obj_idx] = prev_steps[scene_idx, obj_idx_old]
-        cls._robots_can_toggle_steps_wp = wp.from_torch(cls._robots_can_toggle_steps)
-
         cls._init_requires_closed_logic(O)
 
         if S == 0 or O == 0:
             cls._init_empty_states()
             return
 
-        # Carry over _can_toggle_steps for surviving objects via a CPU scratch tensor,
+        # Carry over _robots_can_toggle_time for surviving objects via a CPU scratch tensor,
         # then ship to a fresh GPU wp.array.
-        new_steps_cpu = th.zeros((S, O), dtype=th.float32)
-        if prev_steps_cpu is not None:
+        new_time_cpu = th.zeros((S, O), dtype=th.float32)
+        if prev_time_cpu is not None:
             for relative_prim_path, obj_idx_old in prev_obj_idxs.items():
                 if relative_prim_path not in cls.OBJ_IDXS:
                     continue
                 obj_idx = cls.OBJ_IDXS[relative_prim_path]
-                for scene_idx in range(min(prev_steps_cpu.shape[0], S)):
-                    new_steps_cpu[scene_idx, obj_idx] = prev_steps_cpu[scene_idx, obj_idx_old]
-        cls._robots_can_toggle_steps = lazy.isaacsim.core.utils.warp.tensor.create_tensor_from_list(
-            new_steps_cpu, "float32", device="cuda"
+                for scene_idx in range(min(prev_time_cpu.shape[0], S)):
+                    new_time_cpu[scene_idx, obj_idx] = prev_time_cpu[scene_idx, obj_idx_old]
+        cls._robots_can_toggle_time = lazy.isaacsim.core.utils.warp.tensor.create_tensor_from_list(
+            new_time_cpu, "float32", device="cuda"
         )
 
         marker_finger_pairs = cls._init_finger(S, O)
@@ -313,7 +299,7 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
         Empty-scene (S == 0 or O == 0) early-init: clear every per-scene/per-marker buffer
         to a safe default (None or empty list) so `_update_values` short-circuits cleanly.
         """
-        cls._robots_can_toggle_steps = None
+        cls._robots_can_toggle_time = None
         cls._finger_query_mask = []
         cls._toggable_objs_with_mask = []
         cls._mask_can_toggle = None
@@ -577,27 +563,24 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
 
         Stages (all run inside wp.graph):
         1. Zero the mask.
-        2. use is_in_contact_batch_warp to check whether finger and marekr is in contact,
+        2. use is_in_contact_batch_warp to check whether finger and marker is in contact,
             writes mask in {0, 1}.
         3. requires_closed: for objects that are Open yet require closed, force values=0,
-           steps=0, mask=0.
+           robots_can_toggle_time=0, mask=0.
         4. check_overlap kernel: for mask==1, run BVH point-mesh query; on hit, atomic_max
            the cell to 2.
-        5. Finalize: if mask == 2, increment step counter, XOR-flip values
-           when counter hits the threshold, then normalize mask back to {0, 1}.
+        5. Finalize: if mask == 2, accumulate dt seconds; flip values the first step the
+           counter crosses the seconds threshold; normalize mask back to {0, 1}.
         """
         if cls._mask_can_toggle_flat is None:
             return
-        # Out-of-step update
-        step = og.sim.step_call_index
-        if step == cls._LAST_UPDATE_STEP_INDEX:
-            return
-        cls._LAST_UPDATE_STEP_INDEX = step
         S, O = values.shape[:2]
 
         mask_flat = cls._mask_can_toggle_flat
         values_flat_wp = wp.from_torch(values.view(-1).view(th.uint8), dtype=wp.uint8)
-        steps_flat = cls._robots_can_toggle_steps.reshape((S * O,))
+        time_flat = cls._robots_can_toggle_time.reshape((S * O,))
+
+        threshold_seconds = m.CAN_TOGGLE_STEPS * og.sim.get_sim_step_dt()
 
         mask_flat.zero_()
 
@@ -629,7 +612,7 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
                     cls._requires_closed_obj_idxes_in_open_values,
                     open_flat_wp,
                     values_flat_wp,
-                    steps_flat,
+                    time_flat,
                     mask_flat,
                 ],
                 device="cuda",
@@ -653,16 +636,17 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
                 device="cuda",
             )
 
-        # flip value and increment step
+        # accumulate dt seconds onto the per-object counter; flip values on threshold crossing
         wp.launch(
             kernel=_set_toggle_value_kernel,
             dim=(S, O),
             inputs=[
                 cls.VALUES_WP,
                 cls._mask_can_toggle_flat,
-                cls._robots_can_toggle_steps,
+                cls._robots_can_toggle_time,
                 wp.int32(O),
-                wp.float32(m.CAN_TOGGLE_STEPS),
+                wp.float32(threshold_seconds),
+                cls._dt,
             ],
             device="cuda",
         )
@@ -754,32 +738,32 @@ class ToggledOn(TensorizedAbsoluteState, BooleanStateMixin, LinkBasedStateMixin)
 
     @property
     def state_size(self):
-        # Two floats: toggle_state + robot_can_toggle_steps. Same as the pre-tensorized value.
+        # Two floats: toggle_state + robot_can_toggle_time (seconds).
         return 2
 
     def _dump_state(self):
         if self.OBJ_IDXS is None or self.obj.relative_prim_path not in self.OBJ_IDXS:
-            return dict(value=False, hand_in_marker_steps=0)
+            return dict(value=False, hand_in_marker_time=0.0)
         s = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
         # wp.to_torch is a zero-copy view of the wp.array storage.
-        steps_view = wp.to_torch(type(self)._robots_can_toggle_steps)
+        time_view = wp.to_torch(type(self)._robots_can_toggle_time)
         return dict(
             value=bool(self.VALUES[s, obj_idx].item()),
-            hand_in_marker_steps=int(steps_view[s, obj_idx].item()),
+            hand_in_marker_time=float(time_view[s, obj_idx].item()),
         )
 
     def _load_state(self, state):
         # Restore toggle via _set_value so the visual marker color is also updated.
         self._set_value(state["value"])
-        # Restore step counter directly into the wp.array via a zero-copy torch view.
+        # Restore the seconds counter directly into the wp.array via a zero-copy torch view.
         s = self.obj.scene.idx
         obj_idx = self.OBJ_IDXS[self.obj.relative_prim_path]
-        wp.to_torch(type(self)._robots_can_toggle_steps)[s, obj_idx] = float(state["hand_in_marker_steps"])
+        wp.to_torch(type(self)._robots_can_toggle_time)[s, obj_idx] = float(state["hand_in_marker_time"])
 
     def serialize(self, state):
-        # [toggle_state, can_toggle_steps] as float32
-        return th.tensor([state["value"], state["hand_in_marker_steps"]], dtype=th.float32)
+        # [toggle_state, can_toggle_time (seconds)] as float32
+        return th.tensor([state["value"], state["hand_in_marker_time"]], dtype=th.float32)
 
     def deserialize(self, state):
-        return dict(value=bool(state[0].item()), hand_in_marker_steps=int(state[1].item())), 2
+        return dict(value=bool(state[0].item()), hand_in_marker_time=float(state[1].item())), 2

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -455,6 +455,11 @@ def _launch_simulator(*args, **kwargs):
             self.pre_step_exception = None
             self.post_step_exception = None
 
+            # Monotonically advances exactly once per og.sim.step() call.
+            # Time-dependent tensorized states gate on this so their
+            # _update_values doesn't tick during step_physics(). Reset to 0 in stop().
+            self._step_call_index = 0
+
             self._step_profiler = Profiler(deep=gm.ENABLE_DEEP_PROFILING)
             self._pre_physics_step_profiler = Profiler(deep=gm.ENABLE_DEEP_PROFILING)
             self._post_physics_step_profiler = Profiler(deep=gm.ENABLE_DEEP_PROFILING)
@@ -1213,24 +1218,15 @@ def _launch_simulator(*args, **kwargs):
                     if issubclass(state_type, TensorizedState):
                         state_type.initialize_view()
 
-        # TODO(vector) Calling this actually makes most time-sensitive states
-        # (temperature, toggle, sliceractive...) think a new step has happened.
-        # should update all of those states to track last-updated-time, and
-        # compare it against og.sim.current_timestep to compute how much delta
-        # should be applied to things
         def _refresh_state_caches(self):
             """
-            Run a full tensorized-state refresh outside the normal step path.
+            Run a full update for tensorized object state and view API.
 
-            This is the same pre/global/post pass that ``_non_physics_step`` runs once per
-            sim step, factored out so that callers which mutate poses/joints between sim
-            steps (``sample_kinematics``, ``Inside._set_value``, ad-hoc
-            ``set_position_orientation`` / ``JointPrim.set_pos``) can bring caches back into
-            sync without waiting for the next ``sim.step()``.
-
-            Triggered automatically from ``TensorizedAbsoluteState._get_value`` /
-            ``TensorizedRelativeState._get_value`` when ``TensorizedState.caches_dirty`` is
-            set, so callers don't have to remember to call it.
+            This function will be called in the following cases:
+            - in usual step, in ``_non_physics_step``
+            - anywhere that poses/joints are set between sim steps (sample_kinematics,
+            Inside._set_value, set_position_orientation / JointPrim.set_pos) and
+            any TensorizedAbsoluteState need to get_value
 
             Always clears ``TensorizedState.caches_dirty`` on completion.
             """
@@ -1447,9 +1443,23 @@ def _launch_simulator(*args, **kwargs):
                 finally:
                     self._in_sim_lifecycle -= 1
 
+            self._step_call_index = 0
+
             # Run all callbacks
             for callback in self._callbacks_on_stop.values():
                 callback()
+
+        @property
+        def step_call_index(self):
+            """
+            Monotonically increasing counter of og.sim.step() calls since the last stop().
+
+            Distinct from current_time_step_index: that one advances on every physics callback
+            (including step_physics()), while this only advances on logical step() invocations.
+            Time-dependent tensorized states (Temperature, ToggledOn, SlicerActive) gate on this
+            so their _update_values doesn't tick during step_physics() / sample_kinematics().
+            """
+            return self._step_call_index
 
         @property
         def n_physics_timesteps_per_render(self):
@@ -1470,6 +1480,8 @@ def _launch_simulator(*args, **kwargs):
             """
             self._check_usd_guard()
             assert self.is_playing(), "Simulator must be playing to step"
+
+            self._step_call_index += 1
 
             render = self._render_on_step
             if self.stage is None:
@@ -1559,7 +1571,10 @@ def _launch_simulator(*args, **kwargs):
                     ControllableObjectViewAPI.post_physics_step()
 
                 # Pull the contact sensor data — must run while currently_stepping is True,
-                # since RigidContactAPI.read_from_physx asserts on it.
+                # since RigidContactAPI.read_from_physx asserts on it. Unlike the pose/DOF
+                # view APIs (snapshot-only, drained once per render-step in
+                # _refresh_state_caches), contacts accumulate per sub-step into pending
+                # buffers that update() later walks, so they must be drained here.
                 RigidContactAPI.read_from_physx()
                 wp.synchronize()
 

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -455,11 +455,6 @@ def _launch_simulator(*args, **kwargs):
             self.pre_step_exception = None
             self.post_step_exception = None
 
-            # Monotonically advances exactly once per og.sim.step() call.
-            # Time-dependent tensorized states gate on this so their
-            # _update_values doesn't tick during step_physics(). Reset to 0 in stop().
-            self._step_call_index = 0
-
             self._step_profiler = Profiler(deep=gm.ENABLE_DEEP_PROFILING)
             self._pre_physics_step_profiler = Profiler(deep=gm.ENABLE_DEEP_PROFILING)
             self._post_physics_step_profiler = Profiler(deep=gm.ENABLE_DEEP_PROFILING)
@@ -1443,23 +1438,9 @@ def _launch_simulator(*args, **kwargs):
                 finally:
                     self._in_sim_lifecycle -= 1
 
-            self._step_call_index = 0
-
             # Run all callbacks
             for callback in self._callbacks_on_stop.values():
                 callback()
-
-        @property
-        def step_call_index(self):
-            """
-            Monotonically increasing counter of og.sim.step() calls since the last stop().
-
-            Distinct from current_time_step_index: that one advances on every physics callback
-            (including step_physics()), while this only advances on logical step() invocations.
-            Time-dependent tensorized states (Temperature, ToggledOn, SlicerActive) gate on this
-            so their _update_values doesn't tick during step_physics() / sample_kinematics().
-            """
-            return self._step_call_index
 
         @property
         def n_physics_timesteps_per_render(self):
@@ -1506,10 +1487,6 @@ def _launch_simulator(*args, **kwargs):
                             self._report_step_exceptions()
             finally:
                 self._in_sim_lifecycle -= 1
-
-            # Bump the logical step counter after a successful physics step but before non-physics updates,
-            # so time-dependent states observe the new index during _non_physics_step().
-            self._step_call_index += 1
 
             # Additionally run non physics things
             self._non_physics_step()

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -1213,15 +1213,20 @@ def _launch_simulator(*args, **kwargs):
                     if issubclass(state_type, TensorizedState):
                         state_type.initialize_view()
 
-        def _refresh_state_caches(self):
+        def _refresh_state_caches(self, dt=0.0):
             """
             Run a full update for tensorized object state and view API.
 
             This function will be called in the following cases:
-            - in usual step, in ``_non_physics_step``
+            - in usual step, in ``_non_physics_step`` (passes the sim-step dt)
+            - in ``step_physics`` (passes dt=0)
             - anywhere that poses/joints are set between sim steps (sample_kinematics,
             Inside._set_value, set_position_orientation / JointPrim.set_pos) and
-            any TensorizedAbsoluteState need to get_value
+            any TensorizedAbsoluteState need to get_value (default dt=0)
+
+            ``dt`` is the seconds elapsed for this logical step; it is forwarded to each
+            tensorized state's ``pre_update`` so time-dependent states advance by exactly the
+            sim-step dt on a real step and by 0 on physics-only / out-of-step refreshes.
 
             Always clears ``TensorizedState.caches_dirty`` on completion.
             """
@@ -1233,11 +1238,11 @@ def _launch_simulator(*args, **kwargs):
             ArticulatedObjectViewAPI.read_from_physx()
             wp.synchronize()
 
-            self._capture_warp_graph()
+            self._capture_warp_graph(dt)
 
             RigidContactAPI._PENDING_STEPS = 0
 
-        def _capture_warp_graph(self):
+        def _capture_warp_graph(self, dt=0.0):
             """
             Manage the per-step warp graph end-to-end (gating, pre/post bookkeeping, capture,
             and launch all live here so ``_refresh_state_caches`` stays thin).
@@ -1247,7 +1252,7 @@ def _launch_simulator(*args, **kwargs):
                  If the list is empty (object states disabled or none registered), run the
                  view-API ``update()``s directly and return — there is no pre/global/post
                  pipeline to drive.
-              2. Otherwise, run ``pre_update`` for each state, then either (re-)capture or
+              2. Otherwise, run ``pre_update(dt)`` for each state, then either (re-)capture or
                  replay the per-step graph (view-API H2D + tensorized state global_updates).
                  ``wp.ScopedCapture`` only RECORDS ops — the captured graph must be launched
                  explicitly via ``wp.capture_launch`` for its kernels to run this frame.
@@ -1278,7 +1283,7 @@ def _launch_simulator(*args, **kwargs):
                 TensorizedState.caches_dirty = True
 
                 for state_type in tensorized_states:
-                    state_type.pre_update()
+                    state_type.pre_update(dt)
 
                 if TensorizedState.graph_dirty:
                     if all(s.VALUES is None or s.VALUES.numel() == 0 for s in tensorized_states):
@@ -1350,8 +1355,10 @@ def _launch_simulator(*args, **kwargs):
                     for system in scene.active_systems.values():
                         system.update()
 
-                # Update view API data and tensorized states
-                self._refresh_state_caches()
+                # Update view API data and tensorized states. One _non_physics_step runs per
+                # og.sim.step(), which spans get_sim_step_dt() seconds — advance time-dependent
+                # states by exactly that.
+                self._refresh_state_caches(dt=self.get_sim_step_dt())
 
                 # Propagate states if the feature is enabled
                 if gm.ENABLE_OBJECT_STATES:
@@ -1511,7 +1518,8 @@ def _launch_simulator(*args, **kwargs):
 
             # Accumulate contact data from this physics step and then flush to cache.
             # We normally do this in _non_physics_step, but step_physics bypasses that so we do it here.
-            self._refresh_state_caches()
+            # dt=0: a bare physics step must not advance time-dependent states (matches legacy behavior).
+            self._refresh_state_caches(dt=0.0)
 
         @with_profiler(name="_pre_physics_step_profiler")
         def _on_pre_physics_step(self):

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -1481,8 +1481,6 @@ def _launch_simulator(*args, **kwargs):
             self._check_usd_guard()
             assert self.is_playing(), "Simulator must be playing to step"
 
-            self._step_call_index += 1
-
             render = self._render_on_step
             if self.stage is None:
                 raise Exception("There is no stage currently opened, init_stage needed before calling this func")
@@ -1508,6 +1506,10 @@ def _launch_simulator(*args, **kwargs):
                             self._report_step_exceptions()
             finally:
                 self._in_sim_lifecycle -= 1
+
+            # Bump the logical step counter after a successful physics step but before non-physics updates,
+            # so time-dependent states observe the new index during _non_physics_step().
+            self._step_call_index += 1
 
             # Additionally run non physics things
             self._non_physics_step()

--- a/OmniGibson/tests/test_object_states.py
+++ b/OmniGibson/tests/test_object_states.py
@@ -43,6 +43,7 @@ from omnigibson.object_states import (
     Under,
     Unfolded,
 )
+from omnigibson.object_states.slicer_active import SlicerActive
 from omnigibson.systems import VisualParticleSystem
 from omnigibson.utils.physx_utils import apply_force_at_pos
 from omnigibson.utils.usd_utils import RigidContactAPI
@@ -843,6 +844,67 @@ def test_toggled_on_requires_closed(env, microwave):
     assert not microwave.states[Open].get_value()
     assert microwave.states[ToggledOn].set_value(True)
     assert microwave.states[ToggledOn].get_value()
+
+
+def test_out_of_step_refresh_freezes_time_dependent_states(env, microwave, table_knife):
+    """
+    Time-dependent tensorized states
+    (Temperature, ToggledOn._robots_can_toggle_steps, SlicerActive.DELAY_COUNTER) must
+    not advance during lazy cache refreshes or step_physics() calls between real sim
+    steps — those events represent sampling / settling, not elapsed task time.
+    """
+    microwave = env.scene.object_registry("name", "microwave")
+    table_knife = env.scene.object_registry("name", "table_knife")
+
+    # One real step so all tensorized state views are fully initialized.
+    og.sim.step()
+
+    s_mw = microwave.scene.idx
+    temp_idx = Temperature.OBJ_IDXS[microwave.relative_prim_path]
+    toggle_idx = ToggledOn.OBJ_IDXS[microwave.relative_prim_path]
+    s_knife = table_knife.scene.idx
+    slicer_idx = SlicerActive.OBJ_IDXS[table_knife.relative_prim_path]
+
+    # Seed non-default values so any spurious tick would be visible.
+    Temperature.VALUES[s_mw, temp_idx] = 100.0
+    ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx] = 3.0
+    SlicerActive.DELAY_COUNTER[s_knife, slicer_idx] = 7.0
+
+    snap_temp = Temperature.VALUES[s_mw, temp_idx].clone()
+    snap_toggle = ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx].clone()
+    snap_slicer = SlicerActive.DELAY_COUNTER[s_knife, slicer_idx].clone()
+
+    step_idx_before = og.sim.step_call_index
+
+    # Five lazy refreshes followed by five step_physics() calls — neither path runs
+    # og.sim.step(), so step_call_index must be unchanged and all counters frozen.
+    for _ in range(5):
+        og.sim._refresh_state_caches()
+    for _ in range(5):
+        og.sim.step_physics()
+
+    assert (
+        og.sim.step_call_index == step_idx_before
+    ), f"step_call_index advanced unexpectedly: {step_idx_before} -> {og.sim.step_call_index}"
+    assert th.equal(Temperature.VALUES[s_mw, temp_idx], snap_temp), (
+        f"Temperature drifted on out-of-step refresh: "
+        f"{snap_temp.item()} -> {Temperature.VALUES[s_mw, temp_idx].item()}"
+    )
+    assert th.equal(ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx], snap_toggle), (
+        f"ToggledOn counter drifted on out-of-step refresh: "
+        f"{snap_toggle.item()} -> {ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx].item()}"
+    )
+    assert th.equal(SlicerActive.DELAY_COUNTER[s_knife, slicer_idx], snap_slicer), (
+        f"SlicerActive counter drifted on out-of-step refresh: "
+        f"{snap_slicer.item()} -> {SlicerActive.DELAY_COUNTER[s_knife, slicer_idx].item()}"
+    )
+
+    # One real step must advance the gate counter and unfreeze the kernels.
+    og.sim.step()
+    assert og.sim.step_call_index == step_idx_before + 1
+    assert (
+        Temperature.VALUES[s_mw, temp_idx].item() < 100.0
+    ), "Temperature should decay toward DEFAULT_TEMPERATURE after a real step"
 
 
 def test_particle_source(env, furniture_sink):

--- a/OmniGibson/tests/test_object_states.py
+++ b/OmniGibson/tests/test_object_states.py
@@ -822,20 +822,20 @@ def test_toggled_on_requires_closed(env, microwave):
     assert not microwave.states[ToggledOn].set_value(True)
     assert not microwave.states[ToggledOn].get_value()
 
-    # (b) Kernel knockdown: bypass set_value, force VALUES and steps directly, then step
-    # the sim once. The requires_closed kernel should zero both because Open is True.
+    # (b) Kernel knockdown: bypass set_value, force VALUES and the seconds counter directly,
+    # then step the sim once. The requires_closed kernel should zero both because Open is True.
     s = microwave.scene.idx
     obj_idx = ToggledOn.OBJ_IDXS[microwave.relative_prim_path]
     ToggledOn.VALUES[s, obj_idx] = 1
-    # _robots_can_toggle_steps is a wp.array — wp.to_torch gives a zero-copy view we can poke.
-    wp.to_torch(ToggledOn._robots_can_toggle_steps)[s, obj_idx] = 100.0
+    # _robots_can_toggle_time is a wp.array — wp.to_torch gives a zero-copy view we can poke.
+    wp.to_torch(ToggledOn._robots_can_toggle_time)[s, obj_idx] = 100.0
     og.sim.step()
     assert not microwave.states[
         ToggledOn
     ].get_value(), "requires_closed kernel should knock VALUES back to 0 while Open is True"
     assert (
-        wp.to_torch(ToggledOn._robots_can_toggle_steps)[s, obj_idx].item() == 0.0
-    ), "requires_closed kernel should reset step counter to 0"
+        wp.to_torch(ToggledOn._robots_can_toggle_time)[s, obj_idx].item() == 0.0
+    ), "requires_closed kernel should reset the seconds counter to 0"
 
     # Close the door — set_value should now succeed.
     microwave.states[Open].set_value(False)
@@ -846,12 +846,20 @@ def test_toggled_on_requires_closed(env, microwave):
     assert microwave.states[ToggledOn].get_value()
 
 
-def test_out_of_step_refresh_freezes_time_dependent_states(env, microwave, table_knife):
+def test_zero_dt_refresh_does_not_advance_time_dependent_states(env, microwave, table_knife):
     """
-    Time-dependent tensorized states
-    (Temperature, ToggledOn._robots_can_toggle_steps, SlicerActive.DELAY_COUNTER) must
-    not advance during lazy cache refreshes or step_physics() calls between real sim
-    steps — those events represent sampling / settling, not elapsed task time.
+    Time-dependent tensorized states are driven by Δt computed from og.sim.current_time. When
+    _refresh_state_caches() is called without any physics elapsing between the previous
+    update and this one, Δt is 0 and any pure-dt accumulation is a no-op.
+
+    Load-bearing case: lazy reads triggered between real sim steps (e.g. get_value() called
+    during sample_kinematics() / settling) must not artificially tick task-relevant timers.
+
+    We assert this only for Temperature and for the slicer in its default active state —
+    those are the cases where the kernel's behavior reduces to "multiply by Δt". The toggle
+    kernel (and the slicer's cooldown branch) also resets the counter unconditionally when
+    eligibility/contact breaks; that reset path is correct and runs regardless of Δt, so it
+    isn't meaningful to assert "counter frozen" without engineering real contact.
     """
     microwave = env.scene.object_registry("name", "microwave")
     table_knife = env.scene.object_registry("name", "table_knife")
@@ -861,47 +869,32 @@ def test_out_of_step_refresh_freezes_time_dependent_states(env, microwave, table
 
     s_mw = microwave.scene.idx
     temp_idx = Temperature.OBJ_IDXS[microwave.relative_prim_path]
-    toggle_idx = ToggledOn.OBJ_IDXS[microwave.relative_prim_path]
     s_knife = table_knife.scene.idx
     slicer_idx = SlicerActive.OBJ_IDXS[table_knife.relative_prim_path]
 
     # Seed non-default values so any spurious tick would be visible.
     Temperature.VALUES[s_mw, temp_idx] = 100.0
-    ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx] = 3.0
-    SlicerActive.DELAY_COUNTER[s_knife, slicer_idx] = 7.0
+    # Slicer starts active by default; in the active branch the kernel leaves DELAY_COUNTER alone,
+    # so seeding it lets us verify the kernel truly takes the no-op path under Δt=0.
+    wp.to_torch(SlicerActive.DELAY_COUNTER)[s_knife, slicer_idx] = 7.0
 
     snap_temp = Temperature.VALUES[s_mw, temp_idx].clone()
-    snap_toggle = ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx].clone()
-    snap_slicer = SlicerActive.DELAY_COUNTER[s_knife, slicer_idx].clone()
+    snap_slicer = wp.to_torch(SlicerActive.DELAY_COUNTER)[s_knife, slicer_idx].clone()
 
-    step_idx_before = og.sim.step_call_index
-
-    # Five lazy refreshes followed by five step_physics() calls — neither path runs
-    # og.sim.step(), so step_call_index must be unchanged and all counters frozen.
+    # Five back-to-back refreshes with no physics in between — Δt = 0 each time.
     for _ in range(5):
         og.sim._refresh_state_caches()
-    for _ in range(5):
-        og.sim.step_physics()
 
-    assert (
-        og.sim.step_call_index == step_idx_before
-    ), f"step_call_index advanced unexpectedly: {step_idx_before} -> {og.sim.step_call_index}"
     assert th.equal(Temperature.VALUES[s_mw, temp_idx], snap_temp), (
-        f"Temperature drifted on out-of-step refresh: "
-        f"{snap_temp.item()} -> {Temperature.VALUES[s_mw, temp_idx].item()}"
+        f"Temperature drifted on Δt=0 refresh: " f"{snap_temp.item()} -> {Temperature.VALUES[s_mw, temp_idx].item()}"
     )
-    assert th.equal(ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx], snap_toggle), (
-        f"ToggledOn counter drifted on out-of-step refresh: "
-        f"{snap_toggle.item()} -> {ToggledOn._robots_can_toggle_steps[s_mw, toggle_idx].item()}"
-    )
-    assert th.equal(SlicerActive.DELAY_COUNTER[s_knife, slicer_idx], snap_slicer), (
-        f"SlicerActive counter drifted on out-of-step refresh: "
-        f"{snap_slicer.item()} -> {SlicerActive.DELAY_COUNTER[s_knife, slicer_idx].item()}"
-    )
+    slicer_after = wp.to_torch(SlicerActive.DELAY_COUNTER)[s_knife, slicer_idx]
+    assert th.equal(
+        slicer_after, snap_slicer
+    ), f"SlicerActive counter drifted on Δt=0 refresh: {snap_slicer.item()} -> {slicer_after.item()}"
 
-    # One real step must advance the gate counter and unfreeze the kernels.
+    # A real og.sim.step() advances time by sim_step_dt — Temperature should decay.
     og.sim.step()
-    assert og.sim.step_call_index == step_idx_before + 1
     assert (
         Temperature.VALUES[s_mw, temp_idx].item() < 100.0
     ), "Temperature should decay toward DEFAULT_TEMPERATURE after a real step"

--- a/OmniGibson/tests/test_object_states.py
+++ b/OmniGibson/tests/test_object_states.py
@@ -766,7 +766,7 @@ def test_toggled_on(env, stove, robot):
     q[jnt_idxs["r_gripper_finger_joint"]] = 0.0
     robot.set_joint_positions(q, drive=False)
 
-    steps = m.object_states.toggle.CAN_TOGGLE_STEPS
+    steps = math.ceil(m.object_states.toggle.CAN_TOGGLE_SECONDS / og.sim.get_sim_step_dt())
     for _ in range(steps):
         og.sim.step()
 


### PR DESCRIPTION
`_refresh_state_caches` is called both inside `non_physic_step` but also `step_physics`, which doesn't involve time advancement, so `toggle`, `slicer_actice` and `temperature` should not advance. 