### PR TITLE
Actually build knowledgebase in pull-sheets workflow check

### DIFF
--- a/.github/workflows/pull-sheets-bddl.yml
+++ b/.github/workflows/pull-sheets-bddl.yml
@@ -89,10 +89,11 @@ jobs:
       working-directory: bddl3
       run: python -m bddl.data_generation.generate_datafiles
 
-    # We want to check if the knowledgebase imports correctly, and if not, we want to NOT do the pull
+    # We want to check if the knowledgebase builds correctly, and if not, we want to NOT do the pull
     # because it will result in a permamently broken knowledgebase that blocks sampling and website.
+    # load_wordnet=True enables the deeper WordNet-based validation of synset names.
     - name: Test if knowledgebase loads OK
-      run: python -c "from bddl.knowledge_base import *"
+      run: python -c "from bddl.knowledge_base import KnowledgeBase; KnowledgeBase(verbose=False, load_wordnet=True)"
 
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/pull-sheets-bddl.yml
+++ b/.github/workflows/pull-sheets-bddl.yml
@@ -89,10 +89,10 @@ jobs:
       working-directory: bddl3
       run: python -m bddl.data_generation.generate_datafiles
 
-    # We want to check if the knowledgebase builds correctly, and if not, we want to NOT do the pull
-    # because it will result in a permamently broken knowledgebase that blocks sampling and website.
-    # load_wordnet=True enables the deeper WordNet-based validation of synset names.
-    - name: Test if knowledgebase loads OK
+    # Validate that the generated knowledgebase still builds before auto-committing these refreshed files.
+    # If this step fails, the workflow stops and does not auto-commit/push a broken knowledgebase that
+    # would block sampling and the website. load_wordnet=True enables deeper WordNet-based synset validation.
+    - name: Test if knowledgebase builds OK
       run: python -c "from bddl.knowledge_base import KnowledgeBase; KnowledgeBase(verbose=False, load_wordnet=True)"
 
     - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
## Summary
- The `Test if knowledgebase loads OK` step in [.github/workflows/pull-sheets-bddl.yml](.github/workflows/pull-sheets-bddl.yml) was just running `from bddl.knowledge_base import *`, which used to trigger eager loading but no longer does — population now happens inside `KnowledgeBase.__init__`. The step was passing without actually validating anything.
- Now explicitly instantiates `KnowledgeBase(verbose=False, load_wordnet=True)`, which both builds the knowledgebase and enables the deeper WordNet-based synset validation (the same flag the test fixture uses in `bddl3/tests/test_knowledgebase.py`).

## Test plan
- [ ] Workflow run completes successfully and catches knowledgebase build errors before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)