### PR TITLE
Fix presampled robot pose ignoring scene frame in BehaviorTask

### DIFF
--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -258,7 +258,8 @@ class BehaviorTask(BaseTask):
                 else:
                     robot_pose = available_poses[0]  # Use first presampled pose
 
-                robot.set_position_orientation(robot_pose["position"], robot_pose["orientation"])
+                # Presampled poses are stored in scene-relative coordinates.
+                robot.set_position_orientation(robot_pose["position"], robot_pose["orientation"], frame="scene")
 
         # Force wake objects
         for env_idx in env_indices:


### PR DESCRIPTION
`BehaviorTask._reset_agent` was setting the presampled robot pose without `frame=\"scene\"`. The presampled poses in scene task-metadata are stored in scene-relative coordinates, so in vectorized envs the multi-scene offset was dropped and the robot for env N landed inside env 0's geometry.
🤖 Generated with [Claude Code](https://claude.com/claude-code)