### PR TITLE
Add end-to-end goal-completion tests for multi-env BehaviorTask (+ test cleanup)

### DIFF
--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -176,7 +176,6 @@ class BehaviorTask(BaseTask):
         terminations["timeout"] = Timeout(max_steps=self._termination_config["max_steps"])
         # PredicateGoal calls check_goal_fn(env_idx); thread env_idx through to the predicate evaluator
         # so the (singular) compiled task evaluates against the right env's object_scope binding.
-        # TODO(vector): This needs to be extensively tested.
         terminations["predicate"] = PredicateGoal(
             check_goal_fn=lambda env_idx: self.compiled_task.check_goal(
                 lambda predicate_name, *entities: self._evaluate_predicate(env_idx, predicate_name, *entities)

--- a/OmniGibson/tests/test_multiple_envs_behavior_infra_api.py
+++ b/OmniGibson/tests/test_multiple_envs_behavior_infra_api.py
@@ -22,24 +22,6 @@ NUM_ENVS = 2
 ACTIVITY_NAME = "picking_up_trash"
 SCENE_MODEL = "house_double_floor_lower"
 
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 6}
-
-
-def _progress(test_name):
-    """Print progress for the current test."""
-    _test_counter["current"] += 1
-    n = _test_counter["current"]
-    total = _test_counter["total"]
-    print(f"\n{'='*60}")
-    print(f"[{n}/{total}] RUNNING: {test_name}")
-    print(f"{'='*60}")
-
-
-def _passed(test_name):
-    """Print pass confirmation."""
-    print(f"[PASSED] {test_name}")
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -123,7 +105,6 @@ class TestBehaviorEnvConstruction:
 
     def test_behavior_env_construction(self, behavior_env):
         """BehaviorTask env with num_envs=2 creates correct structure."""
-        _progress("TestBehaviorEnvConstruction::test_behavior_env_construction")
         env = behavior_env
 
         assert len(env.scenes) == NUM_ENVS
@@ -133,11 +114,8 @@ class TestBehaviorEnvConstruction:
         assert isinstance(env.task, BehaviorTask)
         assert env.task.activity_name == ACTIVITY_NAME
 
-        _passed("TestBehaviorEnvConstruction::test_behavior_env_construction")
-
     def test_scenes_spatially_separated(self, behavior_env):
         """BehaviorTask scenes occupy different spatial regions."""
-        _progress("TestBehaviorEnvConstruction::test_scenes_spatially_separated")
         env = behavior_env
 
         scene_positions = [s.get_position_orientation()[0] for s in env.scenes]
@@ -146,8 +124,6 @@ class TestBehaviorEnvConstruction:
                 dist = th.norm(scene_positions[i] - scene_positions[j])
                 print(f"  Scene {i} <-> Scene {j} distance: {dist:.2f}")
                 assert dist > 1.0, f"Scenes {i} and {j} are too close: {dist:.2f}"
-
-        _passed("TestBehaviorEnvConstruction::test_scenes_spatially_separated")
 
 
 # ===================================================================
@@ -160,7 +136,6 @@ class TestBehaviorStepAndReset:
 
     def test_step_return_shapes(self, behavior_env):
         """step() returns tensors of shape (num_envs,) for rewards/terminateds/truncateds."""
-        _progress("TestBehaviorStepAndReset::test_step_return_shapes")
         env = behavior_env
 
         actions = th.stack(
@@ -175,11 +150,8 @@ class TestBehaviorStepAndReset:
         assert truncateds.shape == (NUM_ENVS,) and truncateds.dtype == th.bool
         assert isinstance(infos, list) and len(infos) == NUM_ENVS
 
-        _passed("TestBehaviorStepAndReset::test_step_return_shapes")
-
     def test_selective_reset(self, behavior_env):
         """Resetting env_indices=[1] only resets scene 1, leaving scene 0 unchanged."""
-        _progress("TestBehaviorStepAndReset::test_selective_reset")
         env = behavior_env
 
         known_pos = th.tensor([1.0, 1.0, 0.5])
@@ -197,11 +169,8 @@ class TestBehaviorStepAndReset:
             pos_before, pos_after, atol=0.15
         ), f"Scene 0 robot moved after resetting only scene 1: {pos_before} vs {pos_after}"
 
-        _passed("TestBehaviorStepAndReset::test_selective_reset")
-
     def test_per_env_step_counters(self, behavior_env):
         """episode_steps is a (num_envs,) tensor that tracks steps independently."""
-        _progress("TestBehaviorStepAndReset::test_per_env_step_counters")
         env = behavior_env
 
         assert env.episode_steps.shape == (NUM_ENVS,)
@@ -220,8 +189,6 @@ class TestBehaviorStepAndReset:
         assert env.episode_steps[0] == 0
         assert env.episode_steps[1] == 1
 
-        _passed("TestBehaviorStepAndReset::test_per_env_step_counters")
-
 
 # ===================================================================
 #  Section 1b – Single-env construction (kept separate; needs num_envs=1)
@@ -233,14 +200,11 @@ class TestBehaviorStepAndReset:
 # what guarantees the correct ordering.
 
 
-# TODO(vector): Clean up all of these multiple envs tests to not use the weird progress/passed/etc. helpers.
-# Also read through everything to make sure they're not doing anything weird.
 class TestBehaviorSingleEnv:
     """BehaviorTask with num_envs=1. Cannot share the module-scope 2-env fixture."""
 
     def test_single_env_behavior(self):
         """BehaviorTask with num_envs=1 works; scene property returns first scene."""
-        _progress("TestBehaviorEnvConstruction::test_single_env_behavior")
         # Tear down the module-scope `behavior_env` (built with num_envs=2) before constructing
         # the num_envs=1 variant. _init_macros only stops the sim; without an explicit clear,
         # the new env's object-state machinery references prims from the previous scenes and
@@ -260,4 +224,3 @@ class TestBehaviorSingleEnv:
         assert len(obs_list) == 1
 
         og.clear()
-        _passed("TestBehaviorEnvConstruction::test_single_env_behavior")

--- a/OmniGibson/tests/test_multiple_envs_behavior_infra_scene.py
+++ b/OmniGibson/tests/test_multiple_envs_behavior_infra_scene.py
@@ -27,24 +27,6 @@ NUM_ENVS = 2
 ACTIVITY_NAME = "picking_up_trash"
 SCENE_MODEL = "house_double_floor_lower"
 
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 8}
-
-
-def _progress(test_name):
-    """Print progress for the current test."""
-    _test_counter["current"] += 1
-    n = _test_counter["current"]
-    total = _test_counter["total"]
-    print(f"\n{'='*60}")
-    print(f"[{n}/{total}] RUNNING: {test_name}")
-    print(f"{'='*60}")
-
-
-def _passed(test_name):
-    """Print pass confirmation."""
-    print(f"[PASSED] {test_name}")
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -128,7 +110,6 @@ class TestBehaviorTaskTensors:
 
     def test_task_step_tensors(self, behavior_env):
         """Task reward / done / success are (num_envs,) tensors."""
-        _progress("TestBehaviorTaskTensors::test_task_step_tensors")
         env = behavior_env
 
         actions = th.stack(
@@ -141,11 +122,8 @@ class TestBehaviorTaskTensors:
         assert env.task.done.shape == (NUM_ENVS,)
         assert env.task.success.shape == (NUM_ENVS,)
 
-        _passed("TestBehaviorTaskTensors::test_task_step_tensors")
-
     def test_reward_tensor_returns(self, behavior_env):
         """PotentialReward returns (num_envs,) float tensor."""
-        _progress("TestBehaviorTaskTensors::test_reward_tensor_returns")
         env = behavior_env
 
         actions = th.stack(
@@ -163,11 +141,8 @@ class TestBehaviorTaskTensors:
         assert "potential" in env.task._reward_functions
         assert isinstance(env.task._reward_functions["potential"], PotentialReward)
 
-        _passed("TestBehaviorTaskTensors::test_reward_tensor_returns")
-
     def test_termination_tensor_returns(self, behavior_env):
         """Timeout and PredicateGoal return (num_envs,) bool tensors."""
-        _progress("TestBehaviorTaskTensors::test_termination_tensor_returns")
         env = behavior_env
 
         actions = th.stack(
@@ -188,8 +163,6 @@ class TestBehaviorTaskTensors:
         assert isinstance(env.task._termination_conditions["timeout"], Timeout)
         assert isinstance(env.task._termination_conditions["predicate"], PredicateGoal)
 
-        _passed("TestBehaviorTaskTensors::test_termination_tensor_returns")
-
 
 # ===================================================================
 #  Section 4 – Scene coordinate system tests
@@ -201,7 +174,6 @@ class TestBehaviorSceneCoordinates:
 
     def test_dump_load_states(self, behavior_env):
         """Scene state can be saved and restored correctly with BehaviorTask."""
-        _progress("TestBehaviorSceneCoordinates::test_dump_load_states")
         env = behavior_env
 
         pose_0 = (th.tensor([1, 1, 1], dtype=th.float32), th.tensor([0, 0, 0, 1], dtype=th.float32))
@@ -239,11 +211,8 @@ class TestBehaviorSceneCoordinates:
         assert th.allclose(initial_pos_0[1], post_pos_0[1], atol=1e-3)
         assert th.allclose(initial_pos_1[1], post_pos_1[1], atol=1e-3)
 
-        _passed("TestBehaviorSceneCoordinates::test_dump_load_states")
-
     def test_get_local_position(self, behavior_env):
         """Robot scene-frame position + scene origin equals world position."""
-        _progress("TestBehaviorSceneCoordinates::test_get_local_position")
         env = behavior_env
 
         robot_local = env.scenes[1].robots[0].get_position_orientation(frame="scene")[0]
@@ -253,11 +222,8 @@ class TestBehaviorSceneCoordinates:
         print(f"  local={robot_local}, global={robot_global}, scene_origin={scene_pos}")
         assert th.allclose(robot_global, scene_pos + robot_local, atol=1e-3)
 
-        _passed("TestBehaviorSceneCoordinates::test_get_local_position")
-
     def test_position_orientation_relative_to_scene(self, behavior_env):
         """set/get position in scene frame is consistent."""
-        _progress("TestBehaviorSceneCoordinates::test_position_orientation_relative_to_scene")
         env = behavior_env
 
         robot = env.scenes[1].robots[0]
@@ -278,8 +244,6 @@ class TestBehaviorSceneCoordinates:
         expected_global_ori = quat_multiply(scene_ori, new_relative_ori)
         assert th.allclose(global_ori, expected_global_ori, atol=1e-3)
 
-        _passed("TestBehaviorSceneCoordinates::test_position_orientation_relative_to_scene")
-
 
 # ===================================================================
 #  Section 5 – Robot getter/setter tests (R1Pro only)
@@ -291,7 +255,6 @@ class TestBehaviorRobotGetterSetter:
 
     def test_getter(self, behavior_env):
         """Position getter works in both world and scene frames."""
-        _progress("TestBehaviorRobotGetterSetter::test_getter")
         env = behavior_env
 
         # Scene 0 robot: world == scene (scene 0 at origin)
@@ -314,11 +277,8 @@ class TestBehaviorRobotGetterSetter:
         assert th.allclose(r1_world_pos, combined_pos, atol=1e-3)
         assert th.allclose(r1_world_ori, combined_ori, atol=1e-3)
 
-        _passed("TestBehaviorRobotGetterSetter::test_getter")
-
     def test_setter(self, behavior_env):
         """Position setter works in both world and scene frames."""
-        _progress("TestBehaviorRobotGetterSetter::test_setter")
         env = behavior_env
 
         robot = env.scenes[1].robots[0]
@@ -350,5 +310,3 @@ class TestBehaviorRobotGetterSetter:
 
         got_world_pos2, _ = robot.get_position_orientation()
         assert not th.allclose(got_world_pos2, new_world_pos, atol=1e-3)
-
-        _passed("TestBehaviorRobotGetterSetter::test_setter")

--- a/OmniGibson/tests/test_multiple_envs_behavior_task.py
+++ b/OmniGibson/tests/test_multiple_envs_behavior_task.py
@@ -27,24 +27,6 @@ SCENE_MODEL = "house_double_floor_lower"
 # Reward weight used in the task config; the completing env.step should earn ~R_POTENTIAL.
 R_POTENTIAL = 1.0
 
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 12}
-
-
-def _progress(test_name):
-    """Print progress for the current test."""
-    _test_counter["current"] += 1
-    n = _test_counter["current"]
-    total = _test_counter["total"]
-    print(f"\n{'='*60}")
-    print(f"[{n}/{total}] RUNNING: {test_name}")
-    print(f"{'='*60}")
-
-
-def _passed(test_name):
-    """Print pass confirmation."""
-    print(f"[PASSED] {test_name}")
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -175,7 +157,6 @@ class TestBehaviorTaskLogic:
 
     def test_object_scope_per_env(self, behavior_env):
         """Each env has its own independent object scope bound to its own scene's robot."""
-        _progress("TestBehaviorTaskLogic::test_object_scope_per_env")
         env = behavior_env
 
         for env_idx in range(NUM_ENVS):
@@ -195,11 +176,8 @@ class TestBehaviorTaskLogic:
         # Scopes are independent dict objects
         assert env.task.object_scope[0] is not env.task.object_scope[1]
 
-        _passed("TestBehaviorTaskLogic::test_object_scope_per_env")
-
     def test_potential_reward_computation(self, behavior_env):
         """get_potential returns a finite float for each env."""
-        _progress("TestBehaviorTaskLogic::test_potential_reward_computation")
         env = behavior_env
 
         for env_idx in range(NUM_ENVS):
@@ -211,8 +189,6 @@ class TestBehaviorTaskLogic:
             assert potential <= 0.0, f"get_potential({env_idx}) = {potential}, expected <= 0"
             print(f"  env {env_idx}: potential={potential:.4f}")
 
-        _passed("TestBehaviorTaskLogic::test_potential_reward_computation")
-
     def test_task_obs_per_env(self, behavior_env):
         """task.get_obs produces a per-env low-dim observation vector.
 
@@ -220,7 +196,6 @@ class TestBehaviorTaskLogic:
         test_step_return_shapes in test_multiple_envs_behavior_infra_api.py; here
         we exercise the BehaviorTask-specific get_obs content directly.)
         """
-        _progress("TestBehaviorTaskLogic::test_task_obs_per_env")
         env = behavior_env
 
         for env_idx in range(NUM_ENVS):
@@ -234,11 +209,8 @@ class TestBehaviorTaskLogic:
                 assert low_dim.shape[0] > 0
                 print(f"  env {env_idx}: low_dim obs dim={low_dim.shape[0]}")
 
-        _passed("TestBehaviorTaskLogic::test_task_obs_per_env")
-
     def test_presampled_robot_pose(self, behavior_env):
         """Robot is positioned at a presampled pose after reset (verifies case-insensitive lookup)."""
-        _progress("TestBehaviorTaskLogic::test_presampled_robot_pose")
         env = behavior_env
 
         for env_idx in range(NUM_ENVS):
@@ -257,11 +229,8 @@ class TestBehaviorTaskLogic:
                 ori_norm, th.tensor(1.0), atol=1e-2
             ), f"Robot {env_idx} orientation not unit quaternion: norm={ori_norm:.4f}"
 
-        _passed("TestBehaviorTaskLogic::test_presampled_robot_pose")
-
     def test_activity_attributes(self, behavior_env):
         """BehaviorTask has correct activity attributes after construction."""
-        _progress("TestBehaviorTaskLogic::test_activity_attributes")
         env = behavior_env
 
         from omnigibson.utils.bddl_utils import BDDLSampler
@@ -293,11 +262,8 @@ class TestBehaviorTaskLogic:
         print(f"  task name: {env.task.name}")
         print(f"  NL goal conditions: {env.task.activity_natural_language_goal_conditions}")
 
-        _passed("TestBehaviorTaskLogic::test_activity_attributes")
-
     def test_show_instruction(self, behavior_env):
         """show_instruction returns valid instruction data per env."""
-        _progress("TestBehaviorTaskLogic::test_show_instruction")
         env = behavior_env
 
         # Need a step for goal evaluation to populate goal_status
@@ -323,8 +289,6 @@ class TestBehaviorTaskLogic:
         assert new_idx == expected_idx, f"iterate_instruction: expected idx {expected_idx}, got {new_idx}"
         print(f"  iterate_instruction: {initial_idx} -> {new_idx} (total={total_conditions})")
 
-        _passed("TestBehaviorTaskLogic::test_show_instruction")
-
 
 # ===================================================================
 #  End-to-end goal completion (move objects to goal state, verify success)
@@ -345,7 +309,6 @@ class TestBehaviorTaskGoalCompletion:
 
     def test_no_completion_under_random_actions(self, behavior_env):
         """With nothing moved to the goal, no env ever reports success (none combination)."""
-        _progress("TestBehaviorTaskGoalCompletion::test_no_completion_under_random_actions")
         env = behavior_env
 
         for _ in range(10):
@@ -355,11 +318,8 @@ class TestBehaviorTaskGoalCompletion:
                 gs = infos[env_idx]["done"]["goal_status"]
                 assert len(gs["unsatisfied"]) > 0, f"env {env_idx} goal satisfied without placing cans"
 
-        _passed("TestBehaviorTaskGoalCompletion::test_no_completion_under_random_actions")
-
     def test_single_env_completion_and_reward(self, behavior_env):
         """Completing only env 0 makes env 0 (and only env 0) succeed, with correct reward."""
-        _progress("TestBehaviorTaskGoalCompletion::test_single_env_completion_and_reward")
         env = behavior_env
 
         cans, ashcan = _goal_objects(env, 0)
@@ -389,11 +349,8 @@ class TestBehaviorTaskGoalCompletion:
         assert abs(env.task.get_potential(env, 0) - (-1.0)) < 1e-6, "env 0 potential not -1.0 at success"
         assert env.task.get_potential(env, 1) > -1.0, "env 1 potential indicates success without placement"
 
-        _passed("TestBehaviorTaskGoalCompletion::test_single_env_completion_and_reward")
-
     def test_all_envs_completion(self, behavior_env):
         """Completing every env makes every env succeed (all combination)."""
-        _progress("TestBehaviorTaskGoalCompletion::test_all_envs_completion")
         env = behavior_env
 
         for env_idx in range(NUM_ENVS):
@@ -408,11 +365,8 @@ class TestBehaviorTaskGoalCompletion:
             assert infos[env_idx]["done"]["termination_conditions"]["predicate"]["done"]
             assert len(infos[env_idx]["done"]["goal_status"]["unsatisfied"]) == 0, f"env {env_idx} goal unsatisfied"
 
-        _passed("TestBehaviorTaskGoalCompletion::test_all_envs_completion")
-
     def test_partial_progress_does_not_complete(self, behavior_env):
         """Placing all-but-one can leaves the goal unsatisfied (some combination)."""
-        _progress("TestBehaviorTaskGoalCompletion::test_partial_progress_does_not_complete")
         env = behavior_env
 
         cans, ashcan = _goal_objects(env, 0)
@@ -435,11 +389,8 @@ class TestBehaviorTaskGoalCompletion:
         assert abs(env.task.get_potential(env, 0)) < 1e-6, "potential nonzero before full completion"
         assert abs(rewards[0].item()) < 1e-3, f"env 0 earned reward {rewards[0].item()} on partial progress"
 
-        _passed("TestBehaviorTaskGoalCompletion::test_partial_progress_does_not_complete")
-
     def test_selective_reset_clears_completion(self, behavior_env):
         """Resetting env 0 only clears its goal completion, leaving env 1 untouched."""
-        _progress("TestBehaviorTaskGoalCompletion::test_selective_reset_clears_completion")
         env = behavior_env
 
         # Complete env 0
@@ -457,8 +408,6 @@ class TestBehaviorTaskGoalCompletion:
         assert abs(env.task.get_potential(env, 0)) < 1e-6, "potential not restored to baseline after reset"
         cans0, ashcan0 = _goal_objects(env, 0)
         assert not any(can.states[Inside].get_value(ashcan0) for can in cans0), "cans still inside ashcan after reset"
-
-        _passed("TestBehaviorTaskGoalCompletion::test_selective_reset_clears_completion")
 
 
 # ===================================================================
@@ -481,7 +430,6 @@ class TestBehaviorTaskNoPresample:
         TestBehaviorTaskLogic::test_presampled_robot_pose; this variant only needs
         to prove the use_presampled_robot_pose=False path doesn't crash.)
         """
-        _progress("TestBehaviorTaskNoPresample::test_no_presampled_robot_pose")
         # Tear down the module-scope `behavior_env` (built with use_presampled_robot_pose=True)
         # before constructing the variant. _init_macros only stops the sim; without an explicit
         # clear, the new env's object-state machinery references prims from the previous scenes
@@ -498,4 +446,3 @@ class TestBehaviorTaskNoPresample:
             print(f"  env {env_idx}: robot pos={pos}, ori={ori}")
 
         og.clear()
-        _passed("TestBehaviorTaskNoPresample::test_no_presampled_robot_pose")

--- a/OmniGibson/tests/test_multiple_envs_behavior_task.py
+++ b/OmniGibson/tests/test_multiple_envs_behavior_task.py
@@ -111,13 +111,16 @@ def _zero_actions(env):
     already placed, so a step purely re-evaluates the goal/reward.
     """
     return th.stack(
-        [th.zeros_like(th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float()) for i in range(NUM_ENVS)]
+        [
+            th.zeros_like(th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float())
+            for i in range(env.num_envs)
+        ]
     )
 
 
 def _random_actions(env):
     """Build a (num_envs, action_dim) random action sampled per robot."""
-    return th.stack([th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(NUM_ENVS)])
+    return th.stack([th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)])
 
 
 # ---------------------------------------------------------------------------
@@ -397,17 +400,30 @@ class TestBehaviorTaskGoalCompletion:
         cans, ashcan = _goal_objects(env, 0)
         for i, can in enumerate(cans):
             assert _place_inside(can, ashcan), f"failed to place can {i} inside ashcan"
-        _, _, terminateds, _, _ = env.step(_zero_actions(env))
+        _, _, terminateds, _, infos = env.step(_zero_actions(env))
         assert terminateds[0], "env 0 should be complete before reset"
+        # env 1 was never touched: capture its (incomplete) state to confirm the reset leaves it alone
+        assert not terminateds[1], "env 1 unexpectedly complete before reset"
+        env1_potential_before = env.task.get_potential(env, 1)
+        env1_unsatisfied_before = len(infos[1]["done"]["goal_status"]["unsatisfied"])
 
         # Reset only env 0; step once so kinematic caches refresh against the restored poses
         env.reset(env_indices=th.tensor([0]))
-        _, _, terminateds2, _, _ = env.step(_zero_actions(env))
+        _, _, terminateds2, _, infos2 = env.step(_zero_actions(env))
 
         assert not terminateds2[0], "env 0 still terminating after reset"
         assert abs(env.task.get_potential(env, 0)) < 1e-6, "potential not restored to baseline after reset"
         cans0, ashcan0 = _goal_objects(env, 0)
         assert not any(can.states[Inside].get_value(ashcan0) for can in cans0), "cans still inside ashcan after reset"
+
+        # env 1 must be untouched by the selective reset: still incomplete, same potential and goal status
+        assert not terminateds2[1], "selective reset of env 0 disturbed env 1's termination state"
+        assert (
+            abs(env.task.get_potential(env, 1) - env1_potential_before) < 1e-6
+        ), "selective reset of env 0 changed env 1's potential"
+        assert (
+            len(infos2[1]["done"]["goal_status"]["unsatisfied"]) == env1_unsatisfied_before
+        ), "selective reset of env 0 changed env 1's goal status"
 
 
 # ===================================================================

--- a/OmniGibson/tests/test_multiple_envs_behavior_task.py
+++ b/OmniGibson/tests/test_multiple_envs_behavior_task.py
@@ -3,8 +3,9 @@ test_multi_env_behavior_task.py
 ===============================
 Multi-environment BehaviorTask-specific logic tests with R1Pro.
 
-Covers BDDL object scope, goal conditions, potential reward, task observations,
-presampled robot pose, goal status, activity attributes, and instructions.
+Covers BDDL object scope, potential reward, task observations, presampled robot
+pose, activity attributes, instructions, and end-to-end goal completion (moving
+objects into the goal state and verifying per-env success / reward / reset).
 
 Uses the ``picking_up_trash`` activity on ``house_double_floor_lower``.
 Infrastructure tests live in ``test_multi_env_behavior_infra.py``.
@@ -15,6 +16,7 @@ import torch as th
 
 import omnigibson as og
 from omnigibson.macros import gm
+from omnigibson.object_states import Inside
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -22,9 +24,11 @@ from omnigibson.macros import gm
 NUM_ENVS = 2
 ACTIVITY_NAME = "picking_up_trash"
 SCENE_MODEL = "house_double_floor_lower"
+# Reward weight used in the task config; the completing env.step should earn ~R_POTENTIAL.
+R_POTENTIAL = 1.0
 
 # Test counter for progress tracking
-_test_counter = {"current": 0, "total": 9}
+_test_counter = {"current": 0, "total": 12}
 
 
 def _progress(test_name):
@@ -76,7 +80,7 @@ def setup_behavior_environment(num_envs=NUM_ENVS, use_presampled_robot_pose=True
             "online_object_sampling": False,
             "use_presampled_robot_pose": use_presampled_robot_pose,
             "termination_config": {"max_steps": 500},
-            "reward_config": {"r_potential": 1.0},
+            "reward_config": {"r_potential": R_POTENTIAL},
         },
     }
     print(
@@ -86,6 +90,52 @@ def setup_behavior_environment(num_envs=NUM_ENVS, use_presampled_robot_pose=True
     env = og.Environment(configs=cfg)
     print("  BehaviorTask environment created successfully")
     return env
+
+
+# ---------------------------------------------------------------------------
+# Goal-completion helpers
+# ---------------------------------------------------------------------------
+def _goal_objects(env, env_idx):
+    """Return ([can_of_soda, ...], ashcan) bound in @env_idx's BDDL object scope.
+
+    picking_up_trash's goal is `forall can: inside(can, ashcan)`; these are the
+    objects we move to drive the task to success.
+    """
+    scope = env.task.object_scope[env_idx]
+    ashcans = [scope[k] for k in sorted(scope) if k.startswith("ashcan.n.01")]
+    cans = [scope[k] for k in sorted(scope) if k.startswith("can__of__soda.n.01")]
+    assert len(ashcans) == 1 and ashcans[0] is not None, f"ashcan not bound in scope[{env_idx}]"
+    assert len(cans) >= 1 and all(c is not None for c in cans), f"cans not bound in scope[{env_idx}]"
+    return cans, ashcans[0]
+
+
+def _place_inside(can, ashcan, retries=3):
+    """Place @can Inside @ashcan via kinematic sampling, retrying for flakiness.
+
+    Inside.set_value rejection-samples a pose, settles physics, and verifies the
+    object is still inside; it returns False on a failed sample. Retry a few times
+    before giving up (sample_kinematics is known to be occasionally flaky).
+    """
+    for _ in range(retries):
+        if can.states[Inside].set_value(ashcan, True):
+            return True
+    return False
+
+
+def _zero_actions(env):
+    """Build a (num_envs, action_dim) all-zeros action that holds the robots still.
+
+    Zero (rather than random) actions keep the robot from disturbing cans we've
+    already placed, so a step purely re-evaluates the goal/reward.
+    """
+    return th.stack(
+        [th.zeros_like(th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float()) for i in range(NUM_ENVS)]
+    )
+
+
+def _random_actions(env):
+    """Build a (num_envs, action_dim) random action sampled per robot."""
+    return th.stack([th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(NUM_ENVS)])
 
 
 # ---------------------------------------------------------------------------
@@ -119,15 +169,12 @@ def _reset_behavior_env(request):
 # ===================================================================
 
 
-# TODO(vector): Add the actual BEHAVIOR tests - start a task, move the objects to the goal state,
-# check that the task is successful, and that the reward is correct (also that they are not complete
-# before you move them etc.) - do this for various combinations of none/some/all scenes in the env
 class TestBehaviorTaskLogic:
-    """Tests for logic unique to BehaviorTask: BDDL scope, goal conditions,
-    potential reward, task observations, presampled robot pose, and goal status."""
+    """Tests for logic unique to BehaviorTask: BDDL scope, potential reward,
+    task observations, presampled robot pose, activity attributes, instructions."""
 
     def test_object_scope_per_env(self, behavior_env):
-        """Each env has its own independent object scope."""
+        """Each env has its own independent object scope bound to its own scene's robot."""
         _progress("TestBehaviorTaskLogic::test_object_scope_per_env")
         env = behavior_env
 
@@ -136,33 +183,19 @@ class TestBehaviorTaskLogic:
             assert scope is not None, f"object_scope[{env_idx}] is None"
             assert isinstance(scope, dict)
             assert "agent.n.01_1" in scope, f"agent not found in object_scope[{env_idx}]"
-            # Agent entity should be this scene's robot (raw sim object after #2040 BDDLEntity removal)
+            # Agent entity should be *this* scene's robot (raw sim object after #2040 BDDLEntity removal),
+            # not some other env's robot — this is what guarantees per-env predicate evaluation is isolated.
             agent_entity = scope["agent.n.01_1"]
             assert agent_entity is not None
+            assert (
+                agent_entity is env.scenes[env_idx].robots[0]
+            ), f"agent in scope[{env_idx}] is not scene {env_idx}'s robot"
             print(f"  env {env_idx}: scope has {len(scope)} entries, agent={agent_entity.name}")
 
         # Scopes are independent dict objects
         assert env.task.object_scope[0] is not env.task.object_scope[1]
 
         _passed("TestBehaviorTaskLogic::test_object_scope_per_env")
-
-    def test_goal_conditions_per_env(self, behavior_env):
-        """Goal conditions / ground goal state options are shared (singular) across envs."""
-        _progress("TestBehaviorTaskLogic::test_goal_conditions_per_env")
-        env = behavior_env
-
-        goals = env.task.activity_goal_conditions
-        assert goals is not None, "activity_goal_conditions is None"
-        assert len(goals) > 0, "activity_goal_conditions is empty"
-
-        ggo = env.task.ground_goal_state_options
-        assert ggo is not None, "ground_goal_state_options is None"
-        assert isinstance(ggo, list)
-        assert len(ggo) > 0, "ground_goal_state_options is empty"
-
-        print(f"  shared: {len(goals)} goal conditions, {len(ggo)} ground goal state options")
-
-        _passed("TestBehaviorTaskLogic::test_goal_conditions_per_env")
 
     def test_potential_reward_computation(self, behavior_env):
         """get_potential returns a finite float for each env."""
@@ -181,26 +214,15 @@ class TestBehaviorTaskLogic:
         _passed("TestBehaviorTaskLogic::test_potential_reward_computation")
 
     def test_task_obs_per_env(self, behavior_env):
-        """Task observations are produced per env and contain expected keys."""
+        """task.get_obs produces a per-env low-dim observation vector.
+
+        (The env.step()->obs "task" key plumbing is already covered by
+        test_step_return_shapes in test_multiple_envs_behavior_infra_api.py; here
+        we exercise the BehaviorTask-specific get_obs content directly.)
+        """
         _progress("TestBehaviorTaskLogic::test_task_obs_per_env")
         env = behavior_env
 
-        actions = th.stack(
-            [th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(NUM_ENVS)]
-        )
-        obs_list, rewards, terminateds, truncateds, infos = env.step(actions)
-
-        # Verify each env has observations
-        for env_idx in range(NUM_ENVS):
-            obs = obs_list[env_idx]
-            assert isinstance(obs, dict), f"obs_list[{env_idx}] is not a dict"
-            # Task observations should be under "task" key
-            assert "task" in obs, f"obs_list[{env_idx}] missing 'task' key, keys: {list(obs.keys())}"
-            task_obs = obs["task"]
-            assert isinstance(task_obs, dict), f"task obs for env {env_idx} is not a dict"
-            print(f"  env {env_idx}: task obs keys={list(task_obs.keys())}")
-
-        # Also test task.get_obs directly
         for env_idx in range(NUM_ENVS):
             task_obs = env.task.get_obs(env=env, env_idx=env_idx)
             assert isinstance(task_obs, dict)
@@ -236,37 +258,6 @@ class TestBehaviorTaskLogic:
             ), f"Robot {env_idx} orientation not unit quaternion: norm={ori_norm:.4f}"
 
         _passed("TestBehaviorTaskLogic::test_presampled_robot_pose")
-
-    def test_goal_status_in_info(self, behavior_env):
-        """Step info contains goal_status from PredicateGoal termination condition."""
-        _progress("TestBehaviorTaskLogic::test_goal_status_in_info")
-        env = behavior_env
-
-        actions = th.stack(
-            [th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(NUM_ENVS)]
-        )
-        obs_list, rewards, terminateds, truncateds, infos = env.step(actions)
-
-        for env_idx in range(NUM_ENVS):
-            info = infos[env_idx]
-            assert "done" in info, f"info[{env_idx}] missing 'done' key"
-            done_info = info["done"]
-            assert "goal_status" in done_info, f"done info[{env_idx}] missing 'goal_status'"
-            goal_status = done_info["goal_status"]
-            assert "satisfied" in goal_status, f"goal_status[{env_idx}] missing 'satisfied'"
-            assert "unsatisfied" in goal_status, f"goal_status[{env_idx}] missing 'unsatisfied'"
-            assert isinstance(goal_status["satisfied"], list)
-            assert isinstance(goal_status["unsatisfied"], list)
-            n_sat = len(goal_status["satisfied"])
-            n_unsat = len(goal_status["unsatisfied"])
-            print(f"  env {env_idx}: satisfied={n_sat}, unsatisfied={n_unsat}")
-
-            # Termination conditions should be reported per condition
-            assert "termination_conditions" in done_info
-            assert "timeout" in done_info["termination_conditions"]
-            assert "predicate" in done_info["termination_conditions"]
-
-        _passed("TestBehaviorTaskLogic::test_goal_status_in_info")
 
     def test_activity_attributes(self, behavior_env):
         """BehaviorTask has correct activity attributes after construction."""
@@ -336,6 +327,141 @@ class TestBehaviorTaskLogic:
 
 
 # ===================================================================
+#  End-to-end goal completion (move objects to goal state, verify success)
+# ===================================================================
+#
+# picking_up_trash's goal is a single quantified condition,
+#   forall ?can: inside(?can, ashcan),
+# so get_potential / goal_status are binary at the goal-condition granularity:
+# the one goal condition is unsatisfied (potential 0.0) until *every* can is
+# inside, at which point it flips satisfied (potential -1.0). Per-can progress is
+# therefore checked via the public states[Inside].get_value, not goal_status.
+
+
+class TestBehaviorTaskGoalCompletion:
+    """Drive the task to its goal state and verify success, reward, and reset,
+    across the none / some / all and per-env-isolation combinations called for
+    by the picking_up_trash goal."""
+
+    def test_no_completion_under_random_actions(self, behavior_env):
+        """With nothing moved to the goal, no env ever reports success (none combination)."""
+        _progress("TestBehaviorTaskGoalCompletion::test_no_completion_under_random_actions")
+        env = behavior_env
+
+        for _ in range(10):
+            _, _, terminateds, _, infos = env.step(_random_actions(env))
+            assert not terminateds.any(), f"task terminated under random actions: {terminateds}"
+            for env_idx in range(NUM_ENVS):
+                gs = infos[env_idx]["done"]["goal_status"]
+                assert len(gs["unsatisfied"]) > 0, f"env {env_idx} goal satisfied without placing cans"
+
+        _passed("TestBehaviorTaskGoalCompletion::test_no_completion_under_random_actions")
+
+    def test_single_env_completion_and_reward(self, behavior_env):
+        """Completing only env 0 makes env 0 (and only env 0) succeed, with correct reward."""
+        _progress("TestBehaviorTaskGoalCompletion::test_single_env_completion_and_reward")
+        env = behavior_env
+
+        cans, ashcan = _goal_objects(env, 0)
+        for i, can in enumerate(cans):
+            assert _place_inside(can, ashcan), f"failed to place can {i} inside ashcan (env 0)"
+
+        # Stored potential is 0.0 from the pre-test reset; placing cans does not touch it,
+        # so this completing step should earn reward == r_potential * (0 - (-1)) for env 0.
+        _, rewards, terminateds, _, infos = env.step(_zero_actions(env))
+
+        # env 0 succeeds, env 1 (untouched) does not
+        assert terminateds[0], "env 0 not terminated after all cans placed"
+        assert not terminateds[1], "env 1 terminated despite no cans placed"
+        assert infos[0]["done"]["termination_conditions"]["predicate"]["done"]
+        assert len(infos[0]["done"]["goal_status"]["unsatisfied"]) == 0, "env 0 goal still unsatisfied"
+        assert len(infos[1]["done"]["goal_status"]["unsatisfied"]) > 0, "env 1 goal unexpectedly satisfied"
+
+        # All cans actually register Inside in env 0
+        assert all(can.states[Inside].get_value(ashcan) for can in cans), "not all cans report Inside in env 0"
+
+        # Reward is the potential delta on the completing step (env 1 sees no change)
+        print(f"  rewards={rewards}")
+        assert abs(rewards[0].item() - R_POTENTIAL) < 1e-3, f"env 0 reward {rewards[0].item()} != {R_POTENTIAL}"
+        assert abs(rewards[1].item()) < 1e-3, f"env 1 reward {rewards[1].item()} != 0"
+
+        # Potential reflects full success in env 0 only
+        assert abs(env.task.get_potential(env, 0) - (-1.0)) < 1e-6, "env 0 potential not -1.0 at success"
+        assert env.task.get_potential(env, 1) > -1.0, "env 1 potential indicates success without placement"
+
+        _passed("TestBehaviorTaskGoalCompletion::test_single_env_completion_and_reward")
+
+    def test_all_envs_completion(self, behavior_env):
+        """Completing every env makes every env succeed (all combination)."""
+        _progress("TestBehaviorTaskGoalCompletion::test_all_envs_completion")
+        env = behavior_env
+
+        for env_idx in range(NUM_ENVS):
+            cans, ashcan = _goal_objects(env, env_idx)
+            for i, can in enumerate(cans):
+                assert _place_inside(can, ashcan), f"failed to place can {i} inside ashcan (env {env_idx})"
+
+        _, _, terminateds, _, infos = env.step(_zero_actions(env))
+
+        assert terminateds.all(), f"not all envs terminated: {terminateds}"
+        for env_idx in range(NUM_ENVS):
+            assert infos[env_idx]["done"]["termination_conditions"]["predicate"]["done"]
+            assert len(infos[env_idx]["done"]["goal_status"]["unsatisfied"]) == 0, f"env {env_idx} goal unsatisfied"
+
+        _passed("TestBehaviorTaskGoalCompletion::test_all_envs_completion")
+
+    def test_partial_progress_does_not_complete(self, behavior_env):
+        """Placing all-but-one can leaves the goal unsatisfied (some combination)."""
+        _progress("TestBehaviorTaskGoalCompletion::test_partial_progress_does_not_complete")
+        env = behavior_env
+
+        cans, ashcan = _goal_objects(env, 0)
+        for i, can in enumerate(cans[:-1]):
+            assert _place_inside(can, ashcan), f"failed to place can {i} inside ashcan"
+
+        _, rewards, terminateds, _, infos = env.step(_zero_actions(env))
+
+        # Goal is a single forall: partial progress does not satisfy it
+        assert not terminateds[0], "env 0 terminated with partial progress"
+        gs = infos[0]["done"]["goal_status"]
+        assert len(gs["satisfied"]) == 0, f"forall goal counted satisfied with partial progress: {gs}"
+        assert len(gs["unsatisfied"]) > 0, "goal unexpectedly fully satisfied"
+
+        # ...but per-can progress is real: exactly the placed cans report Inside
+        n_inside = sum(bool(can.states[Inside].get_value(ashcan)) for can in cans)
+        assert n_inside == len(cans) - 1, f"expected {len(cans) - 1} cans inside, got {n_inside}"
+
+        # Binary potential => still 0.0, and no reward delta, until the last can goes in
+        assert abs(env.task.get_potential(env, 0)) < 1e-6, "potential nonzero before full completion"
+        assert abs(rewards[0].item()) < 1e-3, f"env 0 earned reward {rewards[0].item()} on partial progress"
+
+        _passed("TestBehaviorTaskGoalCompletion::test_partial_progress_does_not_complete")
+
+    def test_selective_reset_clears_completion(self, behavior_env):
+        """Resetting env 0 only clears its goal completion, leaving env 1 untouched."""
+        _progress("TestBehaviorTaskGoalCompletion::test_selective_reset_clears_completion")
+        env = behavior_env
+
+        # Complete env 0
+        cans, ashcan = _goal_objects(env, 0)
+        for i, can in enumerate(cans):
+            assert _place_inside(can, ashcan), f"failed to place can {i} inside ashcan"
+        _, _, terminateds, _, _ = env.step(_zero_actions(env))
+        assert terminateds[0], "env 0 should be complete before reset"
+
+        # Reset only env 0; step once so kinematic caches refresh against the restored poses
+        env.reset(env_indices=th.tensor([0]))
+        _, _, terminateds2, _, _ = env.step(_zero_actions(env))
+
+        assert not terminateds2[0], "env 0 still terminating after reset"
+        assert abs(env.task.get_potential(env, 0)) < 1e-6, "potential not restored to baseline after reset"
+        cans0, ashcan0 = _goal_objects(env, 0)
+        assert not any(can.states[Inside].get_value(ashcan0) for can in cans0), "cans still inside ashcan after reset"
+
+        _passed("TestBehaviorTaskGoalCompletion::test_selective_reset_clears_completion")
+
+
+# ===================================================================
 #  No-presample variant (kept separate; needs use_presampled_robot_pose=False)
 # ===================================================================
 #
@@ -349,8 +475,13 @@ class TestBehaviorTaskNoPresample:
     """BehaviorTask with use_presampled_robot_pose=False. Cannot share the module-scope env."""
 
     def test_no_presampled_robot_pose(self):
-        """Robot has valid pose after reset without presampled pose."""
-        _progress("TestBehaviorTaskLogic::test_no_presampled_robot_pose")
+        """BehaviorTask constructs, resets, and steps without a presampled pose.
+
+        (Pose validity/unit-quaternion checks are covered by
+        TestBehaviorTaskLogic::test_presampled_robot_pose; this variant only needs
+        to prove the use_presampled_robot_pose=False path doesn't crash.)
+        """
+        _progress("TestBehaviorTaskNoPresample::test_no_presampled_robot_pose")
         # Tear down the module-scope `behavior_env` (built with use_presampled_robot_pose=True)
         # before constructing the variant. _init_macros only stops the sim; without an explicit
         # clear, the new env's object-state machinery references prims from the previous scenes
@@ -358,19 +489,13 @@ class TestBehaviorTaskNoPresample:
         og.clear()
         env = setup_behavior_environment(use_presampled_robot_pose=False)
         env.reset()
+        env.step(_zero_actions(env))
 
         for env_idx in range(NUM_ENVS):
-            robot = env.scenes[env_idx].robots[0]
-            pos, ori = robot.get_position_orientation(frame="scene")
-            print(f"  env {env_idx}: robot pos={pos}, ori={ori}")
-
+            pos, ori = env.scenes[env_idx].robots[0].get_position_orientation(frame="scene")
             assert th.isfinite(pos).all(), f"Robot {env_idx} position has non-finite values"
             assert th.isfinite(ori).all(), f"Robot {env_idx} orientation has non-finite values"
-
-            ori_norm = ori.norm()
-            assert th.allclose(
-                ori_norm, th.tensor(1.0), atol=1e-2
-            ), f"Robot {env_idx} orientation not unit quaternion: norm={ori_norm:.4f}"
+            print(f"  env {env_idx}: robot pos={pos}, ori={ori}")
 
         og.clear()
-        _passed("TestBehaviorTaskLogic::test_no_presampled_robot_pose")
+        _passed("TestBehaviorTaskNoPresample::test_no_presampled_robot_pose")

--- a/OmniGibson/tests/test_multiple_envs_dummy_api.py
+++ b/OmniGibson/tests/test_multiple_envs_dummy_api.py
@@ -5,23 +5,10 @@ import omnigibson as og
 
 from utils import (
     MULTI_ENV_ROBOTS,
-    multi_env_progress,
-    multi_env_passed,
     setup_multi_environment,
 )
 
 TASK_TYPE = "DummyTask"
-
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 18}
-
-
-def _progress(test_name):
-    multi_env_progress(test_name, _test_counter)
-
-
-def _passed(test_name):
-    multi_env_passed(test_name)
 
 
 # ===================================================================
@@ -34,18 +21,15 @@ class TestEnvConstruction:
 
     def test_env_construction(self):
         """Environment with num_envs=3 creates 3 scenes."""
-        _progress("TestEnvConstruction::test_env_construction")
         env = setup_multi_environment(num_of_envs=3)
         assert len(env.scenes) == 3
         assert env.num_envs == 3
         for scene in env.scenes:
             assert len(scene.robots) == 1
         og.clear()
-        _passed("TestEnvConstruction::test_env_construction")
 
     def test_single_env_compat(self):
         """num_envs=1 (default) should still work; scene property returns first scene."""
-        _progress("TestEnvConstruction::test_single_env_compat")
         env = setup_multi_environment(num_of_envs=1)
         env.reset()
 
@@ -58,11 +42,9 @@ class TestEnvConstruction:
         assert rewards.shape == (1,)
         assert len(obs_list) == 1
         og.clear()
-        _passed("TestEnvConstruction::test_single_env_compat")
 
     def test_scenes_spatially_separated(self):
         """Each scene occupies a different spatial region (no overlap)."""
-        _progress("TestEnvConstruction::test_scenes_spatially_separated")
         num_envs = 3
         env = setup_multi_environment(num_of_envs=num_envs)
 
@@ -73,7 +55,6 @@ class TestEnvConstruction:
                 print(f"  Scene {i} <-> Scene {j} distance: {dist:.2f}")
                 assert dist > 1.0, f"Scenes {i} and {j} are too close: {dist:.2f}"
         og.clear()
-        _passed("TestEnvConstruction::test_scenes_spatially_separated")
 
 
 # ===================================================================
@@ -86,7 +67,6 @@ class TestStepAndReset:
 
     def test_step_return_shapes(self):
         """step() returns tensors of shape (num_envs,) for rewards/terminateds/truncateds."""
-        _progress("TestStepAndReset::test_step_return_shapes")
         num_envs = 3
         env = setup_multi_environment(num_of_envs=num_envs)
         env.reset()
@@ -104,11 +84,9 @@ class TestStepAndReset:
         assert truncateds.shape == (num_envs,) and truncateds.dtype == th.bool
         assert isinstance(infos, list) and len(infos) == num_envs
         og.clear()
-        _passed("TestStepAndReset::test_step_return_shapes")
 
     def test_selective_reset(self):
         """Resetting env_indices=[1] only resets scene 1, leaving 0 and 2 unchanged."""
-        _progress("TestStepAndReset::test_selective_reset")
         num_envs = 3
         env = setup_multi_environment(num_of_envs=num_envs)
         env.reset()
@@ -127,11 +105,9 @@ class TestStepAndReset:
             pos_before, pos_after, atol=0.05
         ), f"Scene 0 robot moved after resetting only scene 1: {pos_before} vs {pos_after}"
         og.clear()
-        _passed("TestStepAndReset::test_selective_reset")
 
     def test_per_env_step_counters(self):
         """episode_steps is a (num_envs,) tensor that tracks steps independently."""
-        _progress("TestStepAndReset::test_per_env_step_counters")
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs)
         env.reset()
@@ -152,7 +128,6 @@ class TestStepAndReset:
         assert env.episode_steps[0] == 0
         assert env.episode_steps[1] == 1
         og.clear()
-        _passed("TestStepAndReset::test_per_env_step_counters")
 
 
 # ===================================================================
@@ -166,8 +141,6 @@ class TestTaskTensors:
 
     def test_task_step_tensors(self, robot):
         """Task reward / done / success are (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_task_step_tensors[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
 
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
@@ -183,12 +156,9 @@ class TestTaskTensors:
         assert env.task.done.shape == (num_envs,)
         assert env.task.success.shape == (num_envs,)
         og.clear()
-        _passed(test_id)
 
     def test_reward_tensor_returns(self, robot):
         """Reward functions return (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_reward_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -204,12 +174,9 @@ class TestTaskTensors:
                 num_envs,
             ), f"Reward function '{rf_name}' _reward has wrong shape: {rf._reward.shape}"
         og.clear()
-        _passed(test_id)
 
     def test_termination_tensor_returns(self, robot):
         """Termination conditions return (num_envs,) bool tensors."""
-        test_id = f"TestTaskTensors::test_termination_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -226,4 +193,3 @@ class TestTaskTensors:
             ), f"Termination condition '{tc_name}' _done has wrong shape: {tc._done.shape}"
             assert tc._done.dtype == th.bool
         og.clear()
-        _passed(test_id)

--- a/OmniGibson/tests/test_multiple_envs_dummy_scene.py
+++ b/OmniGibson/tests/test_multiple_envs_dummy_scene.py
@@ -9,21 +9,8 @@ from omnigibson.utils.transform_utils import quat_multiply
 
 from utils import (
     MULTI_ENV_ROBOTS,
-    multi_env_progress,
-    multi_env_passed,
     setup_multi_environment,
 )
-
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 18}
-
-
-def _progress(test_name):
-    multi_env_progress(test_name, _test_counter)
-
-
-def _passed(test_name):
-    multi_env_passed(test_name)
 
 
 # ===================================================================
@@ -35,7 +22,6 @@ class TestSceneCoordinates:
     """Multi-scene position/orientation and state dump/load tests."""
 
     def test_multi_scene_dump_load_states(self):
-        _progress("TestSceneCoordinates::test_multi_scene_dump_load_states")
         env = setup_multi_environment(3)
         robot_0 = env.scenes[0].robots[0]
         robot_1 = env.scenes[1].robots[0]
@@ -101,10 +87,8 @@ class TestSceneCoordinates:
         assert th.allclose(initial_robot_pos_scene_2[1], post_robot_pos_scene_2[1], atol=1e-3)
 
         og.clear()
-        _passed("TestSceneCoordinates::test_multi_scene_dump_load_states")
 
     def test_multi_scene_get_local_position(self):
-        _progress("TestSceneCoordinates::test_multi_scene_get_local_position")
         env = setup_multi_environment(3)
 
         robot_1_pos_local = env.scenes[1].robots[0].get_position_orientation(frame="scene")[0]
@@ -115,10 +99,8 @@ class TestSceneCoordinates:
         print(f"  local={robot_1_pos_local}, global={robot_1_pos_global}, scene_origin={pos_scene}")
         assert th.allclose(robot_1_pos_global, pos_scene + robot_1_pos_local, atol=1e-3)
         og.clear()
-        _passed("TestSceneCoordinates::test_multi_scene_get_local_position")
 
     def test_multi_scene_set_local_position(self):
-        _progress("TestSceneCoordinates::test_multi_scene_set_local_position")
         env = setup_multi_environment(3)
 
         robot = env.scenes[1].robots[0]
@@ -149,10 +131,8 @@ class TestSceneCoordinates:
         ), f"Global position change {global_pos_change} does not match expected change {expected_change}"
 
         og.clear()
-        _passed("TestSceneCoordinates::test_multi_scene_set_local_position")
 
     def test_multi_scene_scene_prim(self):
-        _progress("TestSceneCoordinates::test_multi_scene_scene_prim")
         env = setup_multi_environment(1)
         original_robot_pos = env.scenes[0].robots[0].get_position_orientation()[0]
         scene_prim_displacement = th.tensor([10.0, 0.0, 0.0], dtype=th.float32)
@@ -166,10 +146,8 @@ class TestSceneCoordinates:
         assert th.allclose(new_robot_pos - original_robot_pos, scene_prim_displacement, atol=1e-2)
 
         og.clear()
-        _passed("TestSceneCoordinates::test_multi_scene_scene_prim")
 
     def test_multi_scene_position_orientation_relative_to_scene(self):
-        _progress("TestSceneCoordinates::test_multi_scene_position_orientation_relative_to_scene")
         env = setup_multi_environment(3)
 
         robot = env.scenes[1].robots[0]
@@ -202,7 +180,6 @@ class TestSceneCoordinates:
         ), f"Global orientation {global_ori} does not match expected {expected_global_ori}"
 
         og.clear()
-        _passed("TestSceneCoordinates::test_multi_scene_position_orientation_relative_to_scene")
 
 
 # ===================================================================
@@ -215,8 +192,6 @@ class TestRobotGetterSetter:
     """Position/orientation getter and setter correctness across robots."""
 
     def test_getter(self, robot):
-        test_id = f"TestRobotGetterSetter::test_getter[{robot}]"
-        _progress(test_id)
         env = setup_multi_environment(2, robot=robot)
         robot1 = env.scenes[0].robots[0]
 
@@ -243,11 +218,8 @@ class TestRobotGetterSetter:
         assert th.allclose(robot2_world_orientation, combined_orientation, atol=1e-3)
 
         og.clear()
-        _passed(test_id)
 
     def test_setter(self, robot):
-        test_id = f"TestRobotGetterSetter::test_setter[{robot}]"
-        _progress(test_id)
         env = setup_multi_environment(2, robot=robot)
 
         robot_obj = env.scenes[1].robots[0]
@@ -282,12 +254,9 @@ class TestRobotGetterSetter:
         assert not th.allclose(got_world_ori2, new_world_ori, atol=1e-3)
 
         og.clear()
-        _passed(test_id)
 
     def test_setter_sim_stopped(self, robot):
         """Getter/setter should work even when the simulator is stopped."""
-        test_id = f"TestRobotGetterSetter::test_setter_sim_stopped[{robot}]"
-        _progress(test_id)
         env = setup_multi_environment(2, robot=robot)
         og.sim.stop()
         print("  Sim stopped")
@@ -325,7 +294,6 @@ class TestRobotGetterSetter:
         assert not th.allclose(got_world_ori2, new_world_ori, atol=1e-3)
 
         og.clear()
-        _passed(test_id)
 
 
 # ===================================================================
@@ -335,7 +303,6 @@ class TestRobotGetterSetter:
 
 class TestParticles:
     def test_multi_scene_particle_source(self):
-        _progress("TestParticles::test_multi_scene_particle_source")
         sink_cfg = dict(
             type="DatasetObject",
             name="sink",
@@ -370,4 +337,3 @@ class TestParticles:
             og.sim.step()
 
         og.clear()
-        _passed("TestParticles::test_multi_scene_particle_source")

--- a/OmniGibson/tests/test_multiple_envs_grasp.py
+++ b/OmniGibson/tests/test_multiple_envs_grasp.py
@@ -7,23 +7,10 @@ from utils import (
     MULTI_ENV_ROBOTS,
     _init_multi_env_macros,
     multi_env_task_cfg,
-    multi_env_progress,
-    multi_env_passed,
     setup_multi_environment,
 )
 
 TASK_TYPE = "GraspTask"
-
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 16}
-
-
-def _progress(test_name):
-    multi_env_progress(test_name, _test_counter)
-
-
-def _passed(test_name):
-    multi_env_passed(test_name)
 
 
 # ===================================================================
@@ -37,8 +24,6 @@ class TestTaskTensors:
 
     def test_task_step_tensors(self, robot):
         """Task reward / done / success are (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_task_step_tensors[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
 
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
@@ -54,12 +39,9 @@ class TestTaskTensors:
         assert env.task.done.shape == (num_envs,)
         assert env.task.success.shape == (num_envs,)
         og.clear()
-        _passed(test_id)
 
     def test_reward_tensor_returns(self, robot):
         """Reward functions return (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_reward_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -75,12 +57,9 @@ class TestTaskTensors:
                 num_envs,
             ), f"Reward function '{rf_name}' _reward has wrong shape: {rf._reward.shape}"
         og.clear()
-        _passed(test_id)
 
     def test_termination_tensor_returns(self, robot):
         """Termination conditions return (num_envs,) bool tensors."""
-        test_id = f"TestTaskTensors::test_termination_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -97,7 +76,6 @@ class TestTaskTensors:
             ), f"Termination condition '{tc_name}' _done has wrong shape: {tc._done.shape}"
             assert tc._done.dtype == th.bool
         og.clear()
-        _passed(test_id)
 
 
 # ===================================================================
@@ -111,8 +89,6 @@ class TestGraspTask:
 
     def test_grasp_task_precached_reset(self, robot):
         """GraspTask resets correctly using precached_reset_pose_path."""
-        test_id = f"TestGraspTask::test_grasp_task_precached_reset[{robot}]"
-        _progress(test_id)
         num_envs = 2
 
         _init_multi_env_macros()
@@ -140,4 +116,3 @@ class TestGraspTask:
         # Reset again to verify repeated resets work
         env.reset()
         og.clear()
-        _passed(test_id)

--- a/OmniGibson/tests/test_multiple_envs_point_navigation.py
+++ b/OmniGibson/tests/test_multiple_envs_point_navigation.py
@@ -5,23 +5,10 @@ import omnigibson as og
 
 from utils import (
     MULTI_ENV_ROBOTS,
-    multi_env_progress,
-    multi_env_passed,
     setup_multi_environment,
 )
 
 TASK_TYPE = "PointNavigationTask"
-
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 16}
-
-
-def _progress(test_name):
-    multi_env_progress(test_name, _test_counter)
-
-
-def _passed(test_name):
-    multi_env_passed(test_name)
 
 
 # ===================================================================
@@ -35,8 +22,6 @@ class TestTaskTensors:
 
     def test_task_step_tensors(self, robot):
         """Task reward / done / success are (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_task_step_tensors[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
 
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
@@ -52,12 +37,9 @@ class TestTaskTensors:
         assert env.task.done.shape == (num_envs,)
         assert env.task.success.shape == (num_envs,)
         og.clear()
-        _passed(test_id)
 
     def test_reward_tensor_returns(self, robot):
         """Reward functions return (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_reward_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -73,12 +55,9 @@ class TestTaskTensors:
                 num_envs,
             ), f"Reward function '{rf_name}' _reward has wrong shape: {rf._reward.shape}"
         og.clear()
-        _passed(test_id)
 
     def test_termination_tensor_returns(self, robot):
         """Termination conditions return (num_envs,) bool tensors."""
-        test_id = f"TestTaskTensors::test_termination_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -95,7 +74,6 @@ class TestTaskTensors:
             ), f"Termination condition '{tc_name}' _done has wrong shape: {tc._done.shape}"
             assert tc._done.dtype == th.bool
         og.clear()
-        _passed(test_id)
 
 
 # ===================================================================
@@ -109,8 +87,6 @@ class TestNavigationTasks:
 
     def test_multi_step_and_goal_shape(self, robot):
         """Run a few steps and verify goal positions exist per env."""
-        test_id = f"TestNavigationTasks::test_multi_step_and_goal_shape[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -130,4 +106,3 @@ class TestNavigationTasks:
             print(f"  env {env_idx} goal_pos={goal}")
             assert goal.shape == (3,)
         og.clear()
-        _passed(test_id)

--- a/OmniGibson/tests/test_multiple_envs_point_reaching.py
+++ b/OmniGibson/tests/test_multiple_envs_point_reaching.py
@@ -5,23 +5,10 @@ import omnigibson as og
 
 from utils import (
     MULTI_ENV_ROBOTS,
-    multi_env_progress,
-    multi_env_passed,
     setup_multi_environment,
 )
 
 TASK_TYPE = "PointReachingTask"
-
-# Test counter for progress tracking
-_test_counter = {"current": 0, "total": 16}
-
-
-def _progress(test_name):
-    multi_env_progress(test_name, _test_counter)
-
-
-def _passed(test_name):
-    multi_env_passed(test_name)
 
 
 # ===================================================================
@@ -35,8 +22,6 @@ class TestTaskTensors:
 
     def test_task_step_tensors(self, robot):
         """Task reward / done / success are (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_task_step_tensors[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
 
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
@@ -52,12 +37,9 @@ class TestTaskTensors:
         assert env.task.done.shape == (num_envs,)
         assert env.task.success.shape == (num_envs,)
         og.clear()
-        _passed(test_id)
 
     def test_reward_tensor_returns(self, robot):
         """Reward functions return (num_envs,) tensors."""
-        test_id = f"TestTaskTensors::test_reward_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -73,12 +55,9 @@ class TestTaskTensors:
                 num_envs,
             ), f"Reward function '{rf_name}' _reward has wrong shape: {rf._reward.shape}"
         og.clear()
-        _passed(test_id)
 
     def test_termination_tensor_returns(self, robot):
         """Termination conditions return (num_envs,) bool tensors."""
-        test_id = f"TestTaskTensors::test_termination_tensor_returns[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -95,7 +74,6 @@ class TestTaskTensors:
             ), f"Termination condition '{tc_name}' _done has wrong shape: {tc._done.shape}"
             assert tc._done.dtype == th.bool
         og.clear()
-        _passed(test_id)
 
 
 # ===================================================================
@@ -109,8 +87,6 @@ class TestNavigationTasks:
 
     def test_multi_step_and_goal_shape(self, robot):
         """Run a few steps and verify goal positions exist per env."""
-        test_id = f"TestNavigationTasks::test_multi_step_and_goal_shape[{TASK_TYPE}-{robot}]"
-        _progress(test_id)
         num_envs = 2
         env = setup_multi_environment(num_of_envs=num_envs, robot=robot, task_type=TASK_TYPE)
         env.reset()
@@ -130,4 +106,3 @@ class TestNavigationTasks:
             print(f"  env {env_idx} goal_pos={goal}")
             assert goal.shape == (3,)
         og.clear()
-        _passed(test_id)

--- a/OmniGibson/tests/utils.py
+++ b/OmniGibson/tests/utils.py
@@ -124,21 +124,6 @@ def multi_env_task_cfg(task_type, robot="fetch"):
     return {"type": task_type}
 
 
-def multi_env_progress(test_name, counter):
-    """Print progress for the current test."""
-    counter["current"] += 1
-    n = counter["current"]
-    total = counter["total"]
-    print(f"\n{'='*60}")
-    print(f"[{n}/{total}] RUNNING: {test_name}")
-    print(f"{'='*60}")
-
-
-def multi_env_passed(test_name):
-    """Print pass confirmation."""
-    print(f"[PASSED] {test_name}")
-
-
 def _init_multi_env_macros():
     """Set simulator macros (only once, before first Environment is created)."""
     if og.sim is None:


### PR DESCRIPTION
## What

Fills the `TODO(vector)` in the multi-env BehaviorTask tests: until now the suite only checked that scopes/conditions/obs *exist* and have the right shapes — nothing verified that a task can actually be driven to its goal and report success. This adds tests that move objects into the goal state and assert success, reward, and reset behavior, then removes the decorative print scaffolding the TODO called out across all the multi-env test files.

## Changes

**New goal-completion coverage** (`test_multiple_envs_behavior_task.py`)

New `TestBehaviorTaskGoalCompletion` class on the `picking_up_trash` activity (`house_double_floor_lower` ×2, r1pro):
- `test_no_completion_under_random_actions` — *none*: random actions never satisfy the goal.
- `test_single_env_completion_and_reward` — *some + isolation*: completing only env 0 → `terminateds == [True, False]`, reward[0] ≈ `r_potential`, env 1 untouched.
- `test_all_envs_completion` — *all*: both envs complete → `terminateds.all()`.
- `test_partial_progress_does_not_complete` — 2/3 cans placed → not done, goal unsatisfied, but exactly 2 cans report `Inside` (per-can progress is real).
- `test_selective_reset_clears_completion` — completing env 0 then resetting only env 0 clears its goal state without touching env 1.

Goal completion is driven through the public `states[Inside].set_value` (with retry for sampler flakiness) and verified via `states[Inside].get_value`.

Also tightened the existing logic tests: `test_object_scope_per_env` now asserts the scope's agent **is** that scene's own robot (per-env isolation); deleted two existence-only tests (`test_goal_conditions_per_env`, `test_goal_status_in_info`) now subsumed by the content checks; trimmed duplicated obs/pose assertions.

**Scaffolding cleanup** (8 `test_multiple_envs_*` files + `utils.py`)

Removed the `_progress`/`_passed`/`_test_counter` helpers and the `multi_env_progress`/`multi_env_passed` utils equivalents, plus their per-test call sites and `test_id` strings. These printed `[n/total] RUNNING`/`[PASSED]` banners with a hand-maintained counter that had already drifted from the real test count. Pure deletion — no asserts, fixtures, diagnostic prints, or test logic changed.

**Source** (`behavior_task.py`): removed the now-satisfied `TODO(vector): This needs to be extensively tested.` on the `PredicateGoal` `env_idx` threading — that path is exactly what the new completion tests exercise.

## Notes / design

`picking_up_trash`'s goal is a single `forall`, so `get_potential`/`goal_status` are **binary** (0.0 until every can is inside, then -1.0) — per-can progress is therefore checked via `states[Inside]`, not `goal_status`. Reward correctness is asserted as the potential delta on the completing step.

## Testing

`OMNIGIBSON_HEADLESS=1 pytest tests/test_multiple_envs_behavior_task.py` → **12/12 pass**. All 8 multi-env files compile and collect (110 tests). ruff pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)