### PR TITLE
Speed up replay obs state loading

### DIFF
--- a/OmniGibson/omnigibson/envs/data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/data_wrapper.py
@@ -277,6 +277,7 @@ class DataPlaybackWrapper(DataWrapper):
         include_task_obs: bool = True,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        batch_state_load: bool = False,
         load_room_instances: list[str] | None = None,
         **kwargs,
     ) -> "DataPlaybackWrapper":
@@ -331,6 +332,8 @@ class DataPlaybackWrapper(DataWrapper):
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all
                 objects to be visual_only
+            batch_state_load (bool): Whether to batch nested USD edits during replay state loads so Fabric is synced
+                once per restored frame instead of once per prim setter.
             load_room_instances (None or list of str): If specified, list of room instance names to load during
                 playback
             kwargs (dict): Any remaining keyword arguments to pass into class constructor
@@ -433,6 +436,7 @@ class DataPlaybackWrapper(DataWrapper):
             load_room_instances=load_room_instances,
             include_robot_control=include_robot_control,
             include_contacts=include_contacts,
+            batch_state_load=batch_state_load,
             **kwargs,
         )
 
@@ -450,6 +454,7 @@ class DataPlaybackWrapper(DataWrapper):
         load_room_instances: list[str] | None = None,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        batch_state_load: bool = False,
         **kwargs,
     ):
         """
@@ -472,6 +477,8 @@ class DataPlaybackWrapper(DataWrapper):
             load_room_instances (None or list[str]): If specified, the room instances to load for playback.
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all objects to be visual_only
+            batch_state_load (bool): Whether to batch nested USD edits during replay state loads so Fabric is synced
+                once per restored frame instead of once per prim setter.
             kwargs (dict): Arguments to pass to super class
         """
         # Make sure transition rules are DISABLED for playback since we manually propagate transitions
@@ -515,6 +522,7 @@ class DataPlaybackWrapper(DataWrapper):
         self.current_episode_id = None
         self.include_robot_control = include_robot_control
         self.include_contacts = include_contacts
+        self.batch_state_load = batch_state_load
 
         self.video_writers = []
         self.video_output_dir = os.path.dirname(output_path)
@@ -583,6 +591,13 @@ class DataPlaybackWrapper(DataWrapper):
         step_data["terminated"] = terminated
         step_data["truncated"] = truncated
         return step_data
+
+    def _load_replay_state(self, state: th.Tensor) -> None:
+        if self.batch_state_load:
+            with og.sim.batched_usd_edits():
+                og.sim.load_state(state, serialized=True)
+        else:
+            og.sim.load_state(state, serialized=True)
 
     def playback_episode(
         self,
@@ -658,7 +673,7 @@ class DataPlaybackWrapper(DataWrapper):
                         )
 
         # Restore to initial state
-        og.sim.load_state(state[0, : int(state_size[0])], serialized=True)
+        self._load_replay_state(state[0, : int(state_size[0])])
         # take one sim step to propagate
         og.sim.step()
 
@@ -682,7 +697,7 @@ class DataPlaybackWrapper(DataWrapper):
                 log.info(f"Playing back episode {episode_id}, step {i}/{len(action)}")
             # Restore the sim state, and take a very small step with the action to make sure physics are
             # properly propagated after the sim state update
-            og.sim.load_state(s[: int(ss)], serialized=True)
+            self._load_replay_state(s[: int(ss)])
             if not self.include_contacts:
                 # When all objects/systems are visual-only, keep them still on every step
                 for obj in self.scene.objects:

--- a/OmniGibson/omnigibson/envs/hdf5_data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/hdf5_data_wrapper.py
@@ -623,6 +623,7 @@ class HDF5PlaybackWrapper(DataPlaybackWrapper, HDF5DataWrapper):
         load_room_instances: list[str] | None = None,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        batch_state_load: bool = False,
         compression: dict | None = None,
     ):
         """
@@ -645,6 +646,8 @@ class HDF5PlaybackWrapper(DataPlaybackWrapper, HDF5DataWrapper):
             load_room_instances (None or str): If specified, the room instances to load for playback.
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all objects to be visual_only
+            batch_state_load (bool): Whether to batch nested USD edits during replay state loads so Fabric is synced
+                once per restored frame instead of once per prim setter.
             compression (None or dict): If specified, the compression arguments to use for the hdf5 file.
         """
         if flush_every_n_steps > 0:
@@ -665,6 +668,7 @@ class HDF5PlaybackWrapper(DataPlaybackWrapper, HDF5DataWrapper):
             load_room_instances=load_room_instances,
             include_robot_control=include_robot_control,
             include_contacts=include_contacts,
+            batch_state_load=batch_state_load,
             compression=compression,
         )
 

--- a/OmniGibson/omnigibson/envs/lerobot_data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/lerobot_data_wrapper.py
@@ -372,6 +372,7 @@ class LeRobotPlaybackWrapper(DataPlaybackWrapper, LeRobotDataWrapper):
         load_room_instances: list[str] | None = None,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        batch_state_load: bool = False,
         root_dir: str = HF_LEROBOT_HOME,
         robot_type: str | None = None,
         task_name: str | None = None,
@@ -397,6 +398,8 @@ class LeRobotPlaybackWrapper(DataPlaybackWrapper, LeRobotDataWrapper):
             load_room_instances (None or str): If specified, the room instances to load for playback.
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all objects to be visual_only
+            batch_state_load (bool): Whether to batch nested USD edits during replay state loads so Fabric is synced
+                once per restored frame instead of once per prim setter.
             root_dir (str): Root directory to store output dataset files
             robot_type (None or str): Name of the robot within this dataset. If not specified, will be inferred
                 from environment
@@ -417,6 +420,7 @@ class LeRobotPlaybackWrapper(DataPlaybackWrapper, LeRobotDataWrapper):
             load_room_instances=load_room_instances,
             include_robot_control=include_robot_control,
             include_contacts=include_contacts,
+            batch_state_load=batch_state_load,
             root_dir=root_dir,
             robot_type=robot_type,
             task_name=task_name,

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -446,6 +446,7 @@ def _launch_simulator(*args, **kwargs):
 
             # USD edit guard: detects edits outside editing_usd() context
             self._editing_usd = False
+            self._allow_nested_usd_edits = False
             self._editing_usd_caller = None
             self._in_sim_lifecycle = 0
             self._deferred_usd_guard_error = None
@@ -1560,9 +1561,9 @@ def _launch_simulator(*args, **kwargs):
             to Fabric (via SynchronizeToFabric) when the block exits, so that code immediately
             after the block can rely on Fabric being up to date.
 
-            This context MUST NOT be nested — opening an editing_usd() context while another is
-            already open will raise an error. All USD edits within a single logical operation
-            should be in one context.
+            This context MUST NOT be nested directly — opening an editing_usd() context while another is
+            already open will raise an error. All USD edits within a single logical operation should be in one context.
+            Use batched_usd_edits() for the rare case where nested lower-level setters need to share one outer sync.
 
             A guard (enabled after simulator init) detects any USD edits that occur outside this
             context and raises a RuntimeError with a full backtrace.
@@ -1579,6 +1580,9 @@ def _launch_simulator(*args, **kwargs):
                 yield
                 return
 
+            if self._editing_usd and self._allow_nested_usd_edits:
+                yield
+                return
             caller = traceback.extract_stack(limit=3)[0]
             assert not self._editing_usd, (
                 f"Cannot nest editing_usd() contexts. All USD edits for a logical operation "
@@ -1595,6 +1599,23 @@ def _launch_simulator(*args, **kwargs):
                 self._editing_usd = False
                 self._editing_usd_caller = None
                 self.usdrt_stage.SynchronizeToFabric()
+
+        @contextlib.contextmanager
+        def batched_usd_edits(self):
+            """
+            Batch nested USD edits into a single Fabric synchronization.
+
+            This is useful for state replay, where many low-level setters each wrap their USD writes in editing_usd().
+            The outer context keeps the USD edit guard active while deferring Fabric sync until all nested edits finish.
+            """
+            assert not self._editing_usd, "Cannot start batched_usd_edits() while another editing_usd() context is open"
+            old_allow_nested_usd_edits = self._allow_nested_usd_edits
+            self._allow_nested_usd_edits = True
+            try:
+                with self.editing_usd():
+                    yield
+            finally:
+                self._allow_nested_usd_edits = old_allow_nested_usd_edits
 
         def _enable_usd_guard(self):
             """Enable the guard that detects USD edits outside editing_usd() context."""

--- a/OmniGibson/scripts/learning/replay_obs.py
+++ b/OmniGibson/scripts/learning/replay_obs.py
@@ -107,6 +107,7 @@ def replay_hdf5_file(
         robot_proprio_keys=list(PROPRIOCEPTION_INDICES["R1Pro"].keys()),
         robot_obs_modalities=["proprio", "rgb", "depth_linear"],
         include_contacts=False,
+        batch_state_load=True,
     )
 
     if output_format == "hdf5":


### PR DESCRIPTION
Summary
- Add batched_usd_edits() to batch nested USD edits into one Fabric sync
- Add batch_state_load to playback wrappers
- Enable batched replay state loading in replay_obs

Benchmark
- store_honey.hdf5, 3495 steps
- Batched replay loop: ~241.5s / 14.47 steps/s
- Unbatched replay loop: ~295.0s / 11.85 steps