### PR TITLE
Allow skipping keep_still during replay obs

### DIFF
--- a/OmniGibson/omnigibson/envs/data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/data_wrapper.py
@@ -277,6 +277,7 @@ class DataPlaybackWrapper(DataWrapper):
         include_task_obs: bool = True,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        keep_still_on_replay: bool = True,
         load_room_instances: list[str] | None = None,
         **kwargs,
     ) -> "DataPlaybackWrapper":
@@ -331,6 +332,8 @@ class DataPlaybackWrapper(DataWrapper):
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all
                 objects to be visual_only
+            keep_still_on_replay (bool): Whether to zero object/system velocities after each replay state load when
+                contacts are disabled.
             load_room_instances (None or list of str): If specified, list of room instance names to load during
                 playback
             kwargs (dict): Any remaining keyword arguments to pass into class constructor
@@ -433,6 +436,7 @@ class DataPlaybackWrapper(DataWrapper):
             load_room_instances=load_room_instances,
             include_robot_control=include_robot_control,
             include_contacts=include_contacts,
+            keep_still_on_replay=keep_still_on_replay,
             **kwargs,
         )
 
@@ -450,6 +454,7 @@ class DataPlaybackWrapper(DataWrapper):
         load_room_instances: list[str] | None = None,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        keep_still_on_replay: bool = True,
         **kwargs,
     ):
         """
@@ -472,6 +477,8 @@ class DataPlaybackWrapper(DataWrapper):
             load_room_instances (None or list[str]): If specified, the room instances to load for playback.
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all objects to be visual_only
+            keep_still_on_replay (bool): Whether to zero object/system velocities after each replay state load when
+                contacts are disabled.
             kwargs (dict): Arguments to pass to super class
         """
         # Make sure transition rules are DISABLED for playback since we manually propagate transitions
@@ -515,6 +522,7 @@ class DataPlaybackWrapper(DataWrapper):
         self.current_episode_id = None
         self.include_robot_control = include_robot_control
         self.include_contacts = include_contacts
+        self.keep_still_on_replay = keep_still_on_replay
 
         self.video_writers = []
         self.video_output_dir = os.path.dirname(output_path)
@@ -683,7 +691,7 @@ class DataPlaybackWrapper(DataWrapper):
             # Restore the sim state, and take a very small step with the action to make sure physics are
             # properly propagated after the sim state update
             og.sim.load_state(s[: int(ss)], serialized=True)
-            if not self.include_contacts:
+            if not self.include_contacts and self.keep_still_on_replay:
                 # When all objects/systems are visual-only, keep them still on every step
                 for obj in self.scene.objects:
                     obj.keep_still()

--- a/OmniGibson/omnigibson/envs/hdf5_data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/hdf5_data_wrapper.py
@@ -623,6 +623,7 @@ class HDF5PlaybackWrapper(DataPlaybackWrapper, HDF5DataWrapper):
         load_room_instances: list[str] | None = None,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        keep_still_on_replay: bool = True,
         compression: dict | None = None,
     ):
         """
@@ -645,6 +646,8 @@ class HDF5PlaybackWrapper(DataPlaybackWrapper, HDF5DataWrapper):
             load_room_instances (None or str): If specified, the room instances to load for playback.
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all objects to be visual_only
+            keep_still_on_replay (bool): Whether to zero object/system velocities after each replay state load when
+                contacts are disabled.
             compression (None or dict): If specified, the compression arguments to use for the hdf5 file.
         """
         if flush_every_n_steps > 0:
@@ -665,6 +668,7 @@ class HDF5PlaybackWrapper(DataPlaybackWrapper, HDF5DataWrapper):
             load_room_instances=load_room_instances,
             include_robot_control=include_robot_control,
             include_contacts=include_contacts,
+            keep_still_on_replay=keep_still_on_replay,
             compression=compression,
         )
 

--- a/OmniGibson/omnigibson/envs/lerobot_data_wrapper.py
+++ b/OmniGibson/omnigibson/envs/lerobot_data_wrapper.py
@@ -372,6 +372,7 @@ class LeRobotPlaybackWrapper(DataPlaybackWrapper, LeRobotDataWrapper):
         load_room_instances: list[str] | None = None,
         include_robot_control: bool = True,
         include_contacts: bool = True,
+        keep_still_on_replay: bool = True,
         root_dir: str = HF_LEROBOT_HOME,
         robot_type: str | None = None,
         task_name: str | None = None,
@@ -397,6 +398,8 @@ class LeRobotPlaybackWrapper(DataPlaybackWrapper, LeRobotDataWrapper):
             load_room_instances (None or str): If specified, the room instances to load for playback.
             include_robot_control (bool): Whether or not to include robot control. If False, will disable all joint control.
             include_contacts (bool): Whether or not to include (enable) contacts in the sim. If False, will set all objects to be visual_only
+            keep_still_on_replay (bool): Whether to zero object/system velocities after each replay state load when
+                contacts are disabled.
             root_dir (str): Root directory to store output dataset files
             robot_type (None or str): Name of the robot within this dataset. If not specified, will be inferred
                 from environment
@@ -417,6 +420,7 @@ class LeRobotPlaybackWrapper(DataPlaybackWrapper, LeRobotDataWrapper):
             load_room_instances=load_room_instances,
             include_robot_control=include_robot_control,
             include_contacts=include_contacts,
+            keep_still_on_replay=keep_still_on_replay,
             root_dir=root_dir,
             robot_type=robot_type,
             task_name=task_name,

--- a/OmniGibson/scripts/learning/replay_obs.py
+++ b/OmniGibson/scripts/learning/replay_obs.py
@@ -31,6 +31,7 @@ def replay_hdf5_file(
     demo_id: int,
     output_format: str,
     flush_every_n_steps: int,
+    keep_still_on_replay: bool,
 ) -> int:
     """
     Replays a single HDF5 file and saves data to the specified format.
@@ -107,6 +108,7 @@ def replay_hdf5_file(
         robot_proprio_keys=list(PROPRIOCEPTION_INDICES["R1Pro"].keys()),
         robot_obs_modalities=["proprio", "rgb", "depth_linear"],
         include_contacts=False,
+        keep_still_on_replay=keep_still_on_replay,
     )
 
     if output_format == "hdf5":
@@ -159,6 +161,11 @@ def main():
         help="Output format: hdf5, lerobot",
     )
     parser.add_argument("--flush_every_n_steps", type=int, default=1000, help="Flush data every N steps")
+    parser.add_argument(
+        "--skip_keep_still",
+        action="store_true",
+        help="Skip per-frame keep_still() calls when replay contacts are disabled",
+    )
     parser.add_argument("--update_sheet", action="store_true", help="Include this flag to update the Google Sheet")
     parser.add_argument("--row", type=int, required=False, help="Row number to update")
 
@@ -185,6 +192,7 @@ def main():
         demo_id=args.demo_id,
         output_format=args.output_format,
         flush_every_n_steps=args.flush_every_n_steps,
+        keep_still_on_replay=not args.skip_keep_still,
     )
 
     if args.update_sheet:


### PR DESCRIPTION
Summary
- Add keep_still_on_replay to playback wrappers
- Add replay_obs --skip_keep_still flag
- Keep existing behavior as the default

Benchmark
- store_honey.hdf5, 3495 steps
- keep_still + batched replay loop: ~241.5s
- skip keep_still + batched replay loop: ~196.9s