### PR TITLE
Add tiled rendering into vec env

### DIFF
--- a/OmniGibson/omnigibson/envs/env_base.py
+++ b/OmniGibson/omnigibson/envs/env_base.py
@@ -11,7 +11,7 @@ from omnigibson.objects import REGISTERED_OBJECTS
 from omnigibson.robots import Robot, REGISTERED_ROBOTS
 from omnigibson.scene_graphs.graph_builder import SceneGraphBuilder
 from omnigibson.scenes import REGISTERED_SCENES
-from omnigibson.sensors import VisionSensor, create_sensor
+from omnigibson.sensors import TiledVisionSensor, VisionSensor, create_sensor
 from omnigibson.tasks import REGISTERED_TASKS
 from omnigibson.utils.config_utils import parse_config
 from omnigibson.utils.gym_utils import (
@@ -71,6 +71,10 @@ class Environment(gym.Env, GymObservable, Recreatable):
         self._automatic_reset = self.env_config["automatic_reset"]
         self._flatten_action_space = self.env_config["flatten_action_space"]
         self._flatten_obs_space = self.env_config["flatten_obs_space"]
+        # Number of render steps performed after a reset so that camera observations reflect the reset state.
+        # Setting this to 0 skips the extra renders (IsaacLab's num_rerenders_on_reset convention): cheaper, but
+        # image observations returned by reset() will be stale (last pre-reset frame).
+        self._num_rerenders_on_reset = self.env_config["num_rerenders_on_reset"]
         self.device = self.env_config["device"] if self.env_config["device"] else "cpu"
 
         physics_dt = 1.0 / self.env_config["physics_frequency"]
@@ -107,6 +111,7 @@ class Environment(gym.Env, GymObservable, Recreatable):
 
         # Initialize other placeholders that will be filled in later
         self._task = None
+        self._tiled_sensor = None
         self._external_sensors = None
         self._external_sensors_include_in_obs = None
         self._loaded = None
@@ -461,6 +466,20 @@ class Environment(gym.Env, GymObservable, Recreatable):
         self._load_task()
         self._load_external_sensors()
 
+        # When running multiple envs, batch all per-env robot cameras into a single tiled render product
+        # so that one render pass serves every env. Must be created before play (mirrors camera prims on the stage).
+        if self._tiled_sensor is not None:
+            # In case of a reload, remove the stale tiled sensor first (no-op if og.clear() already did)
+            self._tiled_sensor.remove()
+            self._tiled_sensor = None
+        has_vision_sensors = any(
+            isinstance(sensor, VisionSensor) for robot in self._scenes[0].robots for sensor in robot.sensors.values()
+        )
+        if self.num_envs > 1 and has_vision_sensors:
+            # Creating the tiled render product and attaching annotators edits the USD stage
+            with og.sim.editing_usd():
+                self._tiled_sensor = TiledVisionSensor(envs=self._scenes)
+
         # Play and complete loading
         og.sim.play()
         # Run any additional task post-loading behavior
@@ -476,6 +495,14 @@ class Environment(gym.Env, GymObservable, Recreatable):
 
         # Build sensor registry for get_obs()
         self._build_sensor_registry()
+
+        # Robot camera observations come from the tiled render product in multi-env mode, so hide the
+        # per-sensor viewports (their individual render products are unused for obs).
+        if self._tiled_sensor is not None:
+            for sensors in self._robot_sensor_map.values():
+                for sensor in sensors:
+                    if isinstance(sensor, VisionSensor):
+                        sensor.viewer_visibility = False
 
         self.reset()
 
@@ -535,6 +562,9 @@ class Environment(gym.Env, GymObservable, Recreatable):
         all_obs = [{} for _ in env_indices]
         all_info = [{} for _ in env_indices]
 
+        # Grab the batched tiled camera buffers once; per-env observations are slices (views) of these
+        tiled_obs = self._tiled_sensor.get_obs() if self._tiled_sensor is not None else None
+
         # --- Robot observations ---
         for robot_idx, robot_0 in enumerate(self._scenes[0].robots):
             robot_name = robot_0.name
@@ -550,7 +580,21 @@ class Environment(gym.Env, GymObservable, Recreatable):
             for (rname, sensor_name), sensors in self._robot_sensor_map.items():
                 if rname != robot_name:
                     continue
-                # TODO: Replace with a single batched tiled rendering call
+                if tiled_obs is not None and sensor_name in tiled_obs:
+                    # Vision sensors in multi-env mode: slice the per-env tile out of the batched buffer.
+                    # NOTE: segmentation modalities are raw (unremapped) Replicator IDs in this path, and the
+                    # per-modality info dicts (e.g. seg ID mappings) are not available.
+                    for i, env_idx in enumerate(env_indices):
+                        s_obs = dict()
+                        for modality in self._tiled_sensor.modalities[sensor_name]:
+                            data = tiled_obs[sensor_name][modality][env_idx]
+                            # Match the per-sensor observation space: single-channel modalities are (H, W)
+                            if data.shape[-1] == 1:
+                                data = data.squeeze(-1)
+                            s_obs[modality] = data
+                        all_obs[i][robot_name][sensor_name] = s_obs
+                        all_info[i][robot_name][sensor_name] = dict()
+                    continue
                 for i, env_idx in enumerate(env_indices):
                     s_obs, s_info = sensors[env_idx].get_obs()
                     # Convert pointcloud from world frame to robot base frame
@@ -806,8 +850,9 @@ class Environment(gym.Env, GymObservable, Recreatable):
         if get_obs:
             # Run a single simulator step and a replicator step
             og.sim.step()
-            # Render 3 times to make sure we can grab updated observations
-            for _ in range(3):
+            # Render to make sure we can grab updated observations. With 0 rerenders (IsaacLab-style),
+            # camera observations are one step stale; the default of 3 guarantees fresh annotator data.
+            for _ in range(self._num_rerenders_on_reset):
                 og.sim.render()
             # Grab and return observations
             obs_list, info_list = self.get_obs(env_indices=env_indices)
@@ -978,6 +1023,8 @@ class Environment(gym.Env, GymObservable, Recreatable):
                 "flatten_obs_space": False,
                 "external_sensors": None,
                 "num_envs": 1,
+                # Number of render steps after a reset before grabbing observations (see __init__)
+                "num_rerenders_on_reset": 3,
             },
             # Rendering kwargs
             "render": {

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -388,17 +388,21 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
                 )
 
         # Position the scene prim based on the last scene's right edge
+        # NOTE: for empty scenes (no objects), the computed AABB is degenerate, so we manually use a zero extent
         if self.idx != 0:
             aabb_min, aabb_max = lazy.omni.usd.get_context().compute_path_world_bounding_box(scene_absolute_path)
-            left_edge_to_center = -aabb_min[0]
+            left_edge_to_center = 0.0 if len(self._init_objs) == 0 else -aabb_min[0]
             scene_position = th.tensor([last_scene_edge + scene_margin + left_edge_to_center, 0, 0])
             identity_quat = th.tensor([0.0, 0.0, 0.0, 1.0])
             self._scene_prim.set_position_orientation(position=scene_position, orientation=identity_quat)
-            new_scene_edge = last_scene_edge + scene_margin + (aabb_max[0] - aabb_min[0])
+            if len(self._init_objs) == 0:
+                new_scene_edge = last_scene_edge + scene_margin
+            else:
+                new_scene_edge = last_scene_edge + scene_margin + (aabb_max[0] - aabb_min[0])
         else:
             scene_position = th.zeros(3)
             aabb_min, aabb_max = lazy.omni.usd.get_context().compute_path_world_bounding_box(scene_absolute_path)
-            new_scene_edge = aabb_max[0]
+            new_scene_edge = 0.0 if len(self._init_objs) == 0 else aabb_max[0]
 
         return new_scene_edge, scene_position
 

--- a/OmniGibson/omnigibson/sensors/__init__.py
+++ b/OmniGibson/omnigibson/sensors/__init__.py
@@ -2,6 +2,7 @@ from omnigibson.sensors.dropout_sensor_noise import DropoutSensorNoise
 from omnigibson.sensors.scan_sensor import ScanSensor
 from omnigibson.sensors.sensor_base import ALL_SENSOR_MODALITIES, REGISTERED_SENSORS, BaseSensor
 from omnigibson.sensors.sensor_noise_base import REGISTERED_SENSOR_NOISES, BaseSensorNoise
+from omnigibson.sensors.tiled_sensor import TiledVisionSensor
 from omnigibson.sensors.vision_sensor import VisionSensor
 from omnigibson.utils.python_utils import assert_valid_key
 
@@ -85,5 +86,6 @@ __all__ = [
     "REGISTERED_SENSOR_NOISES",
     "REGISTERED_SENSORS",
     "ScanSensor",
+    "TiledVisionSensor",
     "VisionSensor",
 ]

--- a/OmniGibson/omnigibson/sensors/tiled_sensor.py
+++ b/OmniGibson/omnigibson/sensors/tiled_sensor.py
@@ -3,14 +3,19 @@ import omnigibson as og
 import omnigibson.lazy as lazy
 import torch as th
 from omnigibson.sensors.vision_sensor import VisionSensor
+from omnigibson.utils.ui_utils import create_module_logger
 from typing import Any, Tuple, List
+
+# Create module logger
+log = create_module_logger(module_name=__name__)
 
 
 class TiledVisionSensor:
     """
     Tiled vision sensor that leverages Omniverse Replicator to render tiled images from multiple cameras
     Args:
-        envs (Iterable[og.Environment]): List of environments to create tiled sensors for.
+        envs (Iterable): Robot containers to create tiled sensors for -- any objects exposing a .robots list
+            (e.g. the per-env Scene instances of a multi-env Environment), one per environment, in env order.
         tile_all_sensors (bool): Whether to tile all cameras in the envs or only those with matching names. Defaults to False.
             NOTE: If True, all cameras must have the same modalities and resolution.
     """
@@ -74,7 +79,10 @@ class TiledVisionSensor:
             for sensor_name in self._annotators:
                 for annotator in self._annotators[sensor_name].values():
                     # Passing an explicit list is bugged -- see VisionSensor._remove_modality_from_backend
-                    annotator.detach(self._render_product_paths[sensor_name])
+                    try:
+                        annotator.detach(self._render_product_paths[sensor_name])
+                    except TypeError:
+                        log.warning(f"Failed to cleanly detach tiled annotator for {sensor_name}; skipping")
         # Render so the syntheticdata graph settles before the render product is destroyed -- destroying
         # with pending graph edits leaves invalid nodes that break subsequent annotator detach calls
         og.sim.render()

--- a/OmniGibson/omnigibson/sensors/tiled_sensor.py
+++ b/OmniGibson/omnigibson/sensors/tiled_sensor.py
@@ -1,0 +1,212 @@
+import math
+import omnigibson as og
+import omnigibson.lazy as lazy
+import torch as th
+from omnigibson.sensors.vision_sensor import VisionSensor
+from typing import Any, Tuple, List
+
+
+class TiledVisionSensor:
+    """
+    Tiled vision sensor that leverages Omniverse Replicator to render tiled images from multiple cameras
+    Args:
+        envs (Iterable[og.Environment]): List of environments to create tiled sensors for.
+        tile_all_sensors (bool): Whether to tile all cameras in the envs or only those with matching names. Defaults to False.
+            NOTE: If True, all cameras must have the same modalities and resolution.
+    """
+
+    # Registry of all created tiled sensors, used for cleanup on og.clear()
+    TILED_SENSORS = []
+
+    def __init__(self, envs: List[Any], tile_all_sensors: bool = False) -> None:
+        camera_prim_paths = dict()
+        self.modalities = dict()
+        self._camera_resolution = dict()
+        self._camera_prims = dict()
+        self._annotators = dict()
+
+        stage = lazy.omni.usd.get_context().get_stage()
+        for env in envs:
+            for robot in env.robots:
+                for sensor_name, sensor in robot.sensors.items():
+                    if tile_all_sensors:
+                        sensor_name = "sensor"
+                    if isinstance(sensor, VisionSensor):
+                        if sensor_name not in camera_prim_paths:
+                            camera_prim_paths[sensor_name] = []
+                            self.modalities[sensor_name] = sensor.modalities
+                            self._camera_resolution[sensor_name] = (sensor.image_width, sensor.image_height)
+                            self._camera_prims[sensor_name] = []
+                        assert (
+                            sensor.modalities == self.modalities[sensor_name]
+                        ), f"All sensors named {sensor_name} must have the same modalities!"
+                        assert self._camera_resolution[sensor_name] == (
+                            sensor.image_width,
+                            sensor.image_height,
+                        ), f"All sensors named {sensor_name} must have the same resolution!"
+                        camera_prim_paths[sensor_name].append(sensor.prim_path)
+                        camera_prim = stage.GetPrimAtPath(sensor.prim_path)
+                        self._camera_prims[sensor_name].append(lazy.pxr.UsdGeom.Camera(camera_prim))
+        self._render_product_paths = {
+            sensor_name: lazy.omni.replicator.core.create.render_product_tiled(
+                cameras=camera_prim_paths[sensor_name], tile_resolution=self._camera_resolution[sensor_name]
+            )
+            for sensor_name in camera_prim_paths
+        }
+        self._create_annotators()
+        # Attach the annotator to the render product
+        for sensor_name in self._annotators:
+            for modality in self._annotators[sensor_name]:
+                self._annotators[sensor_name][modality].attach([self._render_product_paths[sensor_name]])
+
+        # Create internal buffers
+        self._create_buffers()
+
+        # Register for cleanup on og.clear()
+        TiledVisionSensor.TILED_SENSORS.append(self)
+
+    def remove(self) -> None:
+        """Detach all annotators and destroy the tiled render products. Idempotent."""
+        if self not in TiledVisionSensor.TILED_SENSORS:
+            return
+        TiledVisionSensor.TILED_SENSORS.remove(self)
+        with og.sim.editing_usd():
+            for sensor_name in self._annotators:
+                for annotator in self._annotators[sensor_name].values():
+                    # Passing an explicit list is bugged -- see VisionSensor._remove_modality_from_backend
+                    annotator.detach(self._render_product_paths[sensor_name])
+        # Render so the syntheticdata graph settles before the render product is destroyed -- destroying
+        # with pending graph edits leaves invalid nodes that break subsequent annotator detach calls
+        og.sim.render()
+        with og.sim.editing_usd():
+            for render_product in self._render_product_paths.values():
+                render_product.destroy()
+        og.sim.render()
+        self._annotators = dict()
+        self._render_product_paths = dict()
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove all tiled vision sensors. Called on og.clear() before scenes (and their cameras) are removed."""
+        for sensor in tuple(cls.TILED_SENSORS):
+            sensor.remove()
+
+    def _create_annotators(self) -> None:
+        self._annotators = dict()
+        for sensor_name in self.modalities:
+            self._annotators[sensor_name] = dict()
+            for modality in self.modalities[sensor_name]:
+                annotator_type = VisionSensor.RAW_SENSOR_TYPES[modality]
+                annotator = lazy.omni.replicator.core.AnnotatorRegistry.get_annotator(
+                    annotator_type, device="cuda:0", do_array_copy=False
+                )
+                self._annotators[sensor_name][modality] = annotator
+
+    def _create_buffers(self, device: str = "cuda:0") -> None:
+        self._output_buffer = dict()
+        for sensor_name in self._camera_prims:
+            self._output_buffer[sensor_name] = dict()
+            for modality in self.modalities[sensor_name]:
+                if modality == "rgb":
+                    self._output_buffer[sensor_name][modality] = th.zeros(
+                        (
+                            self._camera_count(sensor_name=sensor_name),
+                            self._camera_resolution[sensor_name][1],
+                            self._camera_resolution[sensor_name][0],
+                            4,
+                        ),
+                        device=device,
+                        dtype=th.uint8,
+                    ).contiguous()
+                elif modality == "depth" or modality == "depth_linear":
+                    self._output_buffer[sensor_name][modality] = th.zeros(
+                        (
+                            self._camera_count(sensor_name=sensor_name),
+                            self._camera_resolution[sensor_name][1],
+                            self._camera_resolution[sensor_name][0],
+                            1,
+                        ),
+                        device=device,
+                        dtype=th.float32,
+                    ).contiguous()
+                elif modality == "seg_semantic" or modality == "seg_instance" or modality == "seg_instance_id":
+                    # unlike VisionSensor.get_obs(), the tiled path returns RAW Replicator segmentation
+                    # IDs -- they are arbitrary, change between sessions, and are NOT remapped to OmniGibson's
+                    # stable semantic/instance IDs (see VisionSensor._remap_semantic_segmentation). No id->name
+                    # mapping info dict is available either. Do NOT train on these values until a batched remap
+                    # is implemented; use the single-env per-sensor path for correct segmentation labels.
+                    self._output_buffer[sensor_name][modality] = th.zeros(
+                        (
+                            self._camera_count(sensor_name=sensor_name),
+                            self._camera_resolution[sensor_name][1],
+                            self._camera_resolution[sensor_name][0],
+                            1,
+                        ),
+                        device=device,
+                        dtype=th.uint32,
+                    ).contiguous()
+                elif modality == "flow":
+                    self._output_buffer[sensor_name][modality] = th.zeros(
+                        (
+                            self._camera_count(sensor_name=sensor_name),
+                            self._camera_resolution[sensor_name][1],
+                            self._camera_resolution[sensor_name][0],
+                            2,
+                        ),
+                        device=device,
+                        dtype=th.float32,
+                    ).contiguous()
+                elif modality == "normal":
+                    self._output_buffer[sensor_name][modality] = th.zeros(
+                        (
+                            self._camera_count(sensor_name=sensor_name),
+                            self._camera_resolution[sensor_name][1],
+                            self._camera_resolution[sensor_name][0],
+                            3,
+                        ),
+                        device=device,
+                        dtype=th.uint8,
+                    ).contiguous()
+                else:
+                    raise ValueError(f"Unsupported modality {modality} for tiled vision sensor!")
+
+    def _camera_count(self, sensor_name: str) -> int:
+        return len(self._camera_prims[sensor_name])
+
+    def _tiled_grid_shape(self, sensor_name: str) -> Tuple[int, int]:
+        cols = math.ceil(math.sqrt(self._camera_count(sensor_name=sensor_name)))
+        rows = math.ceil(self._camera_count(sensor_name=sensor_name) / cols)
+        return (cols, rows)
+
+    def _tiled_img_shape(self, sensor_name: str) -> Tuple[int, int]:
+        cols, rows = self._tiled_grid_shape(sensor_name=sensor_name)
+        width, height = self._camera_resolution[sensor_name]
+        return (width * cols, height * rows)
+
+    def get_obs(self):
+        from omnigibson.utils.deprecated_utils import reshape_tiled_image
+
+        for sensor_name in self._annotators:
+            for modality in self.modalities[sensor_name]:
+                tiled_data_buffer = self._annotators[sensor_name][modality].get_data().to("cuda:0")
+                # For flow, we only require the first two channels of the tiled buffer
+                # Note: Not doing this breaks the alignment of the data (check: https://github.com/isaac-sim/IsaacLab/issues/2003)
+                if modality == "flow":
+                    tiled_data_buffer = tiled_data_buffer[:, :, :2].contiguous()
+                lazy.warp.launch(
+                    kernel=reshape_tiled_image,
+                    dim=(
+                        self._camera_count(sensor_name=sensor_name),
+                        self._camera_resolution[sensor_name][1],
+                        self._camera_resolution[sensor_name][0],
+                    ),
+                    inputs=[
+                        tiled_data_buffer.flatten(),
+                        lazy.warp.from_torch(self._output_buffer[sensor_name][modality]),  # zero-copy alias
+                        *list(self._output_buffer[sensor_name][modality].shape[1:]),  # height, width, num_channels
+                        self._tiled_grid_shape(sensor_name=sensor_name)[0],  # num_tiles_x
+                    ],
+                    device="cuda:0",
+                )
+
+        return self._output_buffer

--- a/OmniGibson/omnigibson/sensors/vision_sensor.py
+++ b/OmniGibson/omnigibson/sensors/vision_sensor.py
@@ -75,6 +75,25 @@ class VisionSensor(BaseSensor):
         "pointcloud",
     )
 
+    RAW_SENSOR_TYPES = dict(
+        rgb="rgb",
+        depth="distance_to_camera",
+        depth_linear="distance_to_image_plane",
+        normal="normals",
+        # Semantic segmentation shows the category each pixel belongs to
+        seg_semantic="semantic_segmentation",
+        # Instance segmentation shows the name of the object each pixel belongs to
+        seg_instance="instance_segmentation",
+        # Instance ID segmentation shows the prim path of the visual mesh each pixel belongs to
+        seg_instance_id="instance_id_segmentation",
+        flow="motion_vectors",
+        bbox_2d_tight="bounding_box_2d_tight",
+        bbox_2d_loose="bounding_box_2d_loose",
+        bbox_3d="bounding_box_3d",
+        camera_params="camera_params",
+        pointcloud="pointcloud",
+    )
+
     # Documentation for the different types of segmentation for particle systems:
     # - Cloth (e.g. `dishtowel`):
     #   - semantic: all shows up under one semantic label (e.g. `"4207839377": "dishtowel"`)
@@ -141,28 +160,9 @@ class VisionSensor(BaseSensor):
         self._image_height = image_height  # used when viewport is not created
         self._image_width = image_width  # used when viewport is not created
 
-        self._RAW_SENSOR_TYPES = dict(
-            rgb="rgb",
-            depth="distance_to_camera",
-            depth_linear="distance_to_image_plane",
-            normal="normals",
-            # Semantic segmentation shows the category each pixel belongs to
-            seg_semantic="semantic_segmentation",
-            # Instance segmentation shows the name of the object each pixel belongs to
-            seg_instance="instance_segmentation",
-            # Instance ID segmentation shows the prim path of the visual mesh each pixel belongs to
-            seg_instance_id="instance_id_segmentation",
-            flow="motion_vectors",
-            bbox_2d_tight="bounding_box_2d_tight",
-            bbox_2d_loose="bounding_box_2d_loose",
-            bbox_3d="bounding_box_3d",
-            camera_params="camera_params",
-            pointcloud="pointcloud",
-        )
-
-        assert {key for key in self._RAW_SENSOR_TYPES.keys() if key != "camera_params"} == set(
+        assert {key for key in self.raw_sensor_types.keys() if key != "camera_params"} == set(
             self.all_modalities
-        ), "VisionSensor._RAW_SENSOR_TYPES must have the same keys as VisionSensor.all_modalities!"
+        ), "VisionSensor.RAW_SENSOR_TYPES must have the same keys as VisionSensor.ALL_MODALITIES!"
 
         if modalities == "all":
             modalities = self.all_modalities
@@ -283,7 +283,7 @@ class VisionSensor(BaseSensor):
 
         Args:
             names (str or list of str): Name of the raw sensor(s) to initialize.
-                If they are not part of self._RAW_SENSOR_TYPES' keys, we will simply pass over them
+                If they are not part of self.raw_sensor_types' keys, we will simply pass over them
         """
         names = {names} if isinstance(names, str) else set(names)
         for name in names:
@@ -589,7 +589,7 @@ class VisionSensor(BaseSensor):
         if self._annotators.get(modality, None) is None:
             with og.sim.editing_usd():
                 self._annotators[modality] = lazy.omni.replicator.core.AnnotatorRegistry.get_annotator(
-                    self._RAW_SENSOR_TYPES[modality]
+                    self.raw_sensor_types[modality]
                 )
                 self._annotators[modality].attach([self._render_product])
 
@@ -604,7 +604,14 @@ class VisionSensor(BaseSensor):
             # Passing an explicit list is bugged -- see omni source code
             # So we only pass in the product directly, which gets post-processed correctly
             with og.sim.editing_usd():
-                self._annotators[modality].detach(self._render_product)
+                try:
+                    self._annotators[modality].detach(self._render_product)
+                except TypeError:
+                    # omni.syntheticdata's node deactivation walk is fragile once a tiled render product
+                    # has existed in the session: cached graph node handles become invalid and detach raises
+                    # "Invalid NodeObj object". The annotator's nodes are already gone at that point, so we
+                    # just drop our reference (teardown-only; nothing further to clean up)
+                    log.warning(f"Failed to cleanly detach annotator for modality {modality}; skipping")
             self._annotators[modality] = None
 
     def remove(self):
@@ -996,6 +1003,10 @@ class VisionSensor(BaseSensor):
     @classproperty
     def all_modalities(cls):
         return {modality for modality in cls.ALL_MODALITIES if modality != "camera_params"}
+
+    @classproperty
+    def raw_sensor_types(cls):
+        return cls.RAW_SENSOR_TYPES.copy()
 
     @classproperty
     def no_noise_modalities(cls):

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -1088,7 +1088,8 @@ def _launch_simulator(*args, **kwargs):
             Args:
                 objs (Iterable[USDObject]): list of objects to remove
             """
-            if objs != []:
+            objs = list(objs)
+            if len(objs) > 0:
                 with self.removing_objects(objs=objs):
                     for obj in objs:
                         obj.scene.remove_object(obj, _batched_call=True)

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -29,6 +29,7 @@ from omnigibson.objects.usd_object import USDObject
 from omnigibson.prims import XFormPrim
 from omnigibson.prims.material_prim import MaterialPrim
 from omnigibson.scenes import Scene
+from omnigibson.sensors.tiled_sensor import TiledVisionSensor
 from omnigibson.sensors.vision_sensor import VisionSensor
 from omnigibson.systems.macro_particle_system import MacroPhysicalParticleSystem
 from omnigibson.utils.asset_utils import ensure_omnigibson_robot_assets_version, get_dataset_path
@@ -1087,9 +1088,10 @@ def _launch_simulator(*args, **kwargs):
             Args:
                 objs (Iterable[USDObject]): list of objects to remove
             """
-            with self.removing_objects(objs=objs):
-                for obj in objs:
-                    obj.scene.remove_object(obj, _batched_call=True)
+            if objs != []:
+                with self.removing_objects(objs=objs):
+                    for obj in objs:
+                        obj.scene.remove_object(obj, _batched_call=True)
 
         def remove_prim(self, prim):
             """
@@ -2115,6 +2117,10 @@ def _launch_simulator(*args, **kwargs):
             self._pre_physics_step_callback.unsubscribe()
             self._post_physics_step_callback.unsubscribe()
             self._simulation_event_callback.unsubscribe()
+
+            # Clear all tiled vision sensors first -- their render products reference per-scene cameras,
+            # so they must be destroyed before the scenes (and the cameras) are removed
+            TiledVisionSensor.clear()
 
             # Clear all scenes
             for scene in self.scenes:

--- a/OmniGibson/omnigibson/utils/deprecated_utils.py
+++ b/OmniGibson/omnigibson/utils/deprecated_utils.py
@@ -3,7 +3,7 @@ A set of utility functions slated to be deprecated once Omniverse bugs are fixed
 """
 
 import math
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import carb
 import numpy as np
@@ -1055,3 +1055,59 @@ def colorize_bboxes(bboxes_2d_data, bboxes_2d_rgb, num_channels=3):
         rgb_img_draw.rectangle([(bbox_2d[1], bbox_2d[2]), (bbox_2d[3], bbox_2d[4])], outline=outline, width=2)
     bboxes_2d_rgb = np.array(rgb_img)
     return bboxes_2d_rgb
+
+
+@wp.kernel(enable_backward=False)
+def reshape_tiled_image(
+    tiled_image_buffer: Any,
+    batched_image: Any,
+    image_height: int,
+    image_width: int,
+    num_channels: int,
+    num_tiles_x: int,
+):
+    """Reshapes a tiled image into a batch of images.
+    This function reshapes the input tiled image buffer into a batch of images. The input image buffer
+    is assumed to be tiled in the x and y directions. The output image is a batch of images with the
+    specified height, width, and number of channels.
+    Args:
+        tiled_image_buffer: The input image buffer. Shape is (height * width * num_channels * num_cameras,).
+        batched_image: The output image. Shape is (num_cameras, height, width, num_channels).
+        image_width: The width of the image.
+        image_height: The height of the image.
+        num_channels: The number of channels in the image.
+        num_tiles_x: The number of tiles in x-direction.
+    """
+    # get the thread id
+    camera_id, height_id, width_id = wp.tid()
+
+    # resolve the tile indices
+    tile_x_id = camera_id % num_tiles_x
+    tile_y_id = camera_id // num_tiles_x
+    # compute the start index of the pixel in the tiled image buffer
+    pixel_start = (
+        num_channels * num_tiles_x * image_width * (image_height * tile_y_id + height_id)
+        + num_channels * tile_x_id * image_width
+        + num_channels * width_id
+    )
+
+    # copy the pixel values into the batched image
+    for i in range(num_channels):
+        batched_image[camera_id, height_id, width_id, i] = tiled_image_buffer[pixel_start + i]
+
+
+# uint32 -> int32 conversion is required for non-colored segmentation annotators
+wp.overload(
+    reshape_tiled_image,
+    {"tiled_image_buffer": wp.array(dtype=wp.uint32), "batched_image": wp.array(dtype=wp.uint32, ndim=4)},
+)
+# uint8 is used for 4 channel annotators
+wp.overload(
+    reshape_tiled_image,
+    {"tiled_image_buffer": wp.array(dtype=wp.uint8), "batched_image": wp.array(dtype=wp.uint8, ndim=4)},
+)
+# float32 is used for single channel annotators
+wp.overload(
+    reshape_tiled_image,
+    {"tiled_image_buffer": wp.array(dtype=wp.float32), "batched_image": wp.array(dtype=wp.float32, ndim=4)},
+)

--- a/OmniGibson/omnigibson/utils/deprecated_utils.py
+++ b/OmniGibson/omnigibson/utils/deprecated_utils.py
@@ -1096,7 +1096,7 @@ def reshape_tiled_image(
         batched_image[camera_id, height_id, width_id, i] = tiled_image_buffer[pixel_start + i]
 
 
-# uint32 -> int32 conversion is required for non-colored segmentation annotators
+# uint32 is used for non-colored segmentation annotators (raw IDs, no dtype conversion is performed)
 wp.overload(
     reshape_tiled_image,
     {"tiled_image_buffer": wp.array(dtype=wp.uint32), "batched_image": wp.array(dtype=wp.uint32, ndim=4)},

--- a/OmniGibson/tests/test_tiled_rendering.py
+++ b/OmniGibson/tests/test_tiled_rendering.py
@@ -1,0 +1,230 @@
+"""
+Tests for tiled rendering in multi-env (vectorized) environments.
+
+In multi-env mode (num_envs > 1), all per-env robot cameras are batched into a single tiled render
+product (TiledVisionSensor), and per-env camera observations are slices of the batched buffer.
+"""
+
+import pytest
+import torch as th
+
+import omnigibson as og
+import omnigibson.utils.transform_utils as T
+from omnigibson.macros import gm
+from omnigibson.sensors import VisionSensor
+
+# Deliberately use 5 envs: the tile grid is 3x2 with one empty tile, which exercises the
+# non-square indexing math of the reshape_tiled_image warp kernel.
+NUM_ENVS = 5
+
+# Distance of the marker cube in front of each env's camera (distinct per env so that tile<->env
+# misalignment is detectable via depth). NOTE: the fetch camera looks downward and its optical axis
+# hits the floor at ~1.14m, so distances must stay below that for the marker to remain above the floor.
+MARKER_DISTANCES = [0.4 + 0.15 * i for i in range(NUM_ENVS)]
+MARKER_SIZE = 0.4
+# Tile<->env misalignment shifts the measured depth by >= the 0.15 distance spacing, so a tolerance
+# below that detects any tile shuffle while absorbing rendering noise
+DEPTH_TOLERANCE = 0.07
+
+MARKER_CFG = [
+    {
+        "type": "PrimitiveObject",
+        "name": "marker",
+        "primitive_type": "Cube",
+        "rgba": [1.0, 0, 0, 1.0],
+        "size": MARKER_SIZE,
+        "visual_only": True,
+        # Initially hidden far below the floor; tests teleport it in front of each env's camera
+        "position": [0, 0, -50.0],
+    }
+]
+
+
+def _init_macros():
+    """Set simulator macros (only once, before the first Environment is created)."""
+    if og.sim is None:
+        gm.RENDER_VIEWER_CAMERA = False
+        gm.USE_GPU_DYNAMICS = False
+        gm.ENABLE_TRANSITION_RULES = False
+        gm.ENABLE_OBJECT_STATES = False
+    else:
+        og.sim.stop()
+
+
+def _setup_vec_env(num_envs, obs_modalities, scene_cfg=None, objects_cfg=None, env_cfg_extra=None):
+    _init_macros()
+    cfg = {
+        "env": {"num_envs": num_envs, **(env_cfg_extra or {})},
+        "scene": scene_cfg
+        or {
+            "type": "InteractiveTraversableScene",
+            "scene_model": "Rs_int",
+            "load_object_categories": ["floors", "walls"],
+        },
+        "robots": [{"model": "fetch", "obs_modalities": list(obs_modalities)}],
+        "task": {"type": "DummyTask"},
+    }
+    if objects_cfg:
+        cfg["objects"] = objects_cfg
+    return og.Environment(configs=cfg)
+
+
+def _camera_sensor_name(robot):
+    return next(name for name, sensor in robot.sensors.items() if isinstance(sensor, VisionSensor))
+
+
+def _place_markers(env, distances):
+    """Teleport each scene's marker cube directly in front of that env's camera at the given distance."""
+    for env_idx, scene in enumerate(env.scenes):
+        robot = scene.robots[0]
+        cam = robot.sensors[_camera_sensor_name(robot)]
+        cam_pos, cam_quat = cam.get_position_orientation()
+        # USD cameras look down their local -z axis
+        cam_forward = T.quat2mat(cam_quat) @ th.tensor([0.0, 0.0, -1.0])
+        marker = scene.object_registry("name", "marker")
+        marker.set_position_orientation(position=cam_pos + cam_forward * distances[env_idx])
+    # Step + render so that annotator buffers reflect the new marker poses
+    og.sim.step()
+    for _ in range(3):
+        og.sim.render()
+
+
+def _center_patch(img, half=8):
+    h, w = img.shape[0], img.shape[1]
+    return img[h // 2 - half : h // 2 + half, w // 2 - half : w // 2 + half]
+
+
+def test_tiled_rendering_core():
+    """Alignment, shapes/dtypes, proprio, per-sensor parity, obs space conformance and reset freshness."""
+    try:
+        env = _setup_vec_env(
+            num_envs=NUM_ENVS,
+            obs_modalities=["rgb", "depth_linear", "proprio"],
+            objects_cfg=MARKER_CFG,
+        )
+        robot_name = env.scenes[0].robots[0].name
+        cam_name = _camera_sensor_name(env.scenes[0].robots[0])
+
+        # --- Tiled sensor is active and covers the camera with the requested modalities ---
+        assert env._tiled_sensor is not None, "Tiled sensor should be created when num_envs > 1"
+        assert cam_name in env._tiled_sensor.modalities
+        assert {"rgb", "depth_linear"} == set(env._tiled_sensor.modalities[cam_name])
+
+        # --- Knob plumbing: default number of re-renders on reset ---
+        assert env._num_rerenders_on_reset == 3
+
+        _place_markers(env, MARKER_DISTANCES)
+        obs_list, info_list = env.get_obs()
+        assert len(obs_list) == NUM_ENVS
+
+        expected_center_depths = [d - MARKER_SIZE / 2 for d in MARKER_DISTANCES]
+        for i in range(NUM_ENVS):
+            cam_obs = obs_list[i][robot_name][cam_name]
+
+            # --- Shapes / dtypes / device ---
+            rgb = cam_obs["rgb"]
+            depth = cam_obs["depth_linear"]
+            assert rgb.shape == (128, 128, 4), f"env {i}: rgb shape {rgb.shape}"
+            assert rgb.dtype == th.uint8
+            assert rgb.is_cuda, "Tiled rgb should live on GPU"
+            assert depth.shape == (128, 128), f"env {i}: depth shape {depth.shape}"
+            assert depth.dtype == th.float32
+
+            # --- Tile <-> env alignment: the marker cube of env i must appear in tile i at distance d_i ---
+            center_depth = _center_patch(depth).median().item()
+            assert abs(center_depth - expected_center_depths[i]) < DEPTH_TOLERANCE, (
+                f"env {i}: center depth {center_depth:.3f} does not match expected "
+                f"{expected_center_depths[i]:.3f} -- tile/env misalignment?"
+            )
+            # The marker is pure red: red must dominate green/blue at the image center
+            center_rgb = _center_patch(rgb).float()
+            red, green, blue = center_rgb[..., 0].mean(), center_rgb[..., 1].mean(), center_rgb[..., 2].mean()
+            assert (
+                red > green + 20 and red > blue + 20
+            ), f"env {i}: expected red marker at center, got rgb=({red:.1f}, {green:.1f}, {blue:.1f})"
+
+            # --- Proprio must be preserved in multi-env mode ---
+            proprio = obs_list[i][robot_name]["proprio"]
+            assert proprio.numel() > 0 and th.all(th.isfinite(proprio)), f"env {i}: invalid proprio"
+
+        # --- Parity with per-sensor rendering. Depth is the strict geometric check; rgb is loose since
+        # the tiled and per-sensor render products denoise/accumulate samples differently ---
+        for i in range(NUM_ENVS):
+            sensor = env.scenes[i].robots[0].sensors[cam_name]
+            s_obs, _ = sensor.get_obs()
+            tiled_rgb = obs_list[i][robot_name][cam_name]["rgb"].float().cpu()
+            sensor_rgb = s_obs["rgb"].float().cpu()
+            mean_diff = (tiled_rgb - sensor_rgb).abs().mean().item()
+            assert mean_diff < 40.0, f"env {i}: tiled vs per-sensor rgb mean abs diff {mean_diff:.1f}"
+            tiled_depth_center = _center_patch(obs_list[i][robot_name][cam_name]["depth_linear"].cpu()).median()
+            sensor_depth_center = _center_patch(s_obs["depth_linear"].cpu()).median()
+            assert abs(tiled_depth_center - sensor_depth_center) < 0.2, f"env {i}: tiled vs per-sensor depth mismatch"
+
+        # --- Reset: returned observations must conform to the observation space (checked internally by
+        # reset()) and, with num_rerenders_on_reset > 0, reflect the *reset* state (markers back below
+        # the floor), not the pre-reset frame ---
+        pre_reset_center_depth = _center_patch(obs_list[0][robot_name][cam_name]["depth_linear"]).median().item()
+        reset_obs_list, _ = env.reset()
+        assert len(reset_obs_list) == NUM_ENVS
+        post_reset_center_depth = _center_patch(reset_obs_list[0][robot_name][cam_name]["depth_linear"]).median().item()
+        assert post_reset_center_depth > pre_reset_center_depth + 0.3, (
+            f"reset() returned a stale frame: center depth {post_reset_center_depth:.3f} still matches the "
+            f"pre-reset marker at {pre_reset_center_depth:.3f}"
+        )
+
+        # --- step() returns tiled observations as well ---
+        actions = th.stack(
+            [th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)]
+        )
+        obs_list, _, _, _, _ = env.step(actions)
+        assert obs_list[0][robot_name][cam_name]["rgb"].shape == (128, 128, 4)
+    finally:
+        og.clear()
+
+
+def test_tiled_rendering_empty_scene():
+    """Multi-env layout of object-less scenes must produce finite, increasing scene offsets (AABB fix)."""
+    try:
+        env = _setup_vec_env(
+            num_envs=3,
+            obs_modalities=["rgb"],
+            scene_cfg={"type": "Scene", "use_floor_plane": True},
+            env_cfg_extra={"num_rerenders_on_reset": 2},
+        )
+
+        # --- Knob plumbing: custom number of re-renders on reset ---
+        assert env._num_rerenders_on_reset == 2
+
+        # --- Scene offsets must be finite and strictly increasing along x ---
+        xs = [scene.get_position_orientation()[0][0].item() for scene in env.scenes]
+        assert all(th.isfinite(th.tensor(xs))), f"Non-finite scene positions: {xs}"
+        assert xs[0] == pytest.approx(0.0, abs=1e-3)
+        assert xs[1] > xs[0] and xs[2] > xs[1], f"Scene positions not increasing: {xs}"
+
+        # --- Robots must be placed apart accordingly ---
+        robot_xs = [scene.robots[0].get_position_orientation()[0][0].item() for scene in env.scenes]
+        assert robot_xs[1] > robot_xs[0] and robot_xs[2] > robot_xs[1], f"Robot positions not increasing: {robot_xs}"
+
+        # --- Stepping and tiled observations work in empty scenes ---
+        robot_name = env.scenes[0].robots[0].name
+        cam_name = _camera_sensor_name(env.scenes[0].robots[0])
+        actions = th.stack(
+            [th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)]
+        )
+        obs_list, _, _, _, _ = env.step(actions)
+        for i in range(3):
+            rgb = obs_list[i][robot_name][cam_name]["rgb"]
+            assert rgb.shape == (128, 128, 4) and rgb.dtype == th.uint8
+    finally:
+        og.clear()
+
+
+def test_tiled_rendering_unsupported_modality():
+    """Modalities that cannot be tiled (e.g. pointcloud) must fail at construction with a clear error.
+
+    NOTE: this test must remain LAST in the module. It deliberately leaves a partially-constructed
+    environment behind (og.clear() cannot recover from a failed construction), which is reclaimed
+    at process exit.
+    """
+    with pytest.raises(ValueError, match="Unsupported modality"):
+        _setup_vec_env(num_envs=2, obs_modalities=["rgb", "pointcloud"])


### PR DESCRIPTION
Originally in #1896 . A few different things:
- reset tiled rendering camera: following IsaacLab, when an environment resets, the physics state changes instantly but the cameras don't take a new picture until the next render, so the first observation after a reset would show the old world. Add `num_rerenders_on_reset` to control how many extra renders need to do right after a reset to ensure that observations are correct. The vector branch's reset() already set exactly this value = 3 before this pr
- add new tests/test_tiled_rendering.py
