### PR TITLE
Fix custom robot import for Isaac Sim 5.1

### DIFF
--- a/OmniGibson/omnigibson/examples/robots/import_custom_robot.py
+++ b/OmniGibson/omnigibson/examples/robots/import_custom_robot.py
@@ -395,7 +395,7 @@ def add_sensor(stage, root_prim, sensor_type, link_name, parent_link_name=None, 
             stage=stage,
             link_prim_path=link_prim_path,
         )
-        link_prim_xform = lazy.isaacsim.core.prims.xform_prim.XFormPrim(prim_path=link_prim_path)
+        link_prim_xform = lazy.isaacsim.core.prims.xform_prim.XFormPrim(link_prim_path)
 
         # Create fixed joint to connect the two together
         create_joint(
@@ -409,14 +409,22 @@ def add_sensor(stage, root_prim, sensor_type, link_name, parent_link_name=None, 
 
         # Set child prim to the appropriate local pose -- this should be the parent local pose transformed by
         # the additional offset
-        parent_prim_xform = lazy.isaacsim.core.prims.xform_prim.XFormPrim(prim_path=parent_path)
-        parent_pos, parent_quat = parent_prim_xform.get_local_pose()
-        parent_quat = parent_quat[[1, 2, 3, 0]]
-        parent_pose = T.pose2mat((th.tensor(parent_pos), th.tensor(parent_quat)))
+        parent_prim_xform = lazy.isaacsim.core.prims.xform_prim.XFormPrim(parent_path)
+        parent_pos_arr, parent_quat_arr = parent_prim_xform.get_local_poses()
+        # Convert from numpy (w,x,y,z) to torch (x,y,z,w)
+        parent_pos = th.tensor(parent_pos_arr[0])
+        parent_quat = th.tensor(parent_quat_arr[0][[1, 2, 3, 0]])
+        parent_pose = T.pose2mat((parent_pos, parent_quat))
         offset_pose = T.pose2mat((pos_offset, ori_offset))
         child_pose = parent_pose @ offset_pose
         link_pos, link_quat = T.mat2pose(child_pose)
-        link_prim_xform.set_local_pose(link_pos, link_quat[[3, 0, 1, 2]])
+        # Convert back from (x,y,z,w) to scalar-first (w,x,y,z) for Isaac Sim API
+        link_pos_np = link_pos.numpy()
+        link_quat_np = link_quat[[3, 0, 1, 2]].numpy()
+        link_prim_xform.set_local_poses(
+            link_pos_np.reshape(1, 3),
+            link_quat_np.reshape(1, 4),
+        )
 
     else:
         # Otherwise, link prim MUST exist
@@ -688,6 +696,20 @@ def find_all_meshes(root_prim):
     )
 
 
+def shift_prim_local_z(prim, z_offset):
+    translate_attr = prim.GetAttribute("xformOp:translate")
+    if translate_attr.IsValid():
+        local_pos = translate_attr.Get() or lazy.pxr.Gf.Vec3d(0.0, 0.0, 0.0)
+        translate_attr.Set(lazy.pxr.Gf.Vec3d(local_pos[0], local_pos[1], local_pos[2] - z_offset))
+    else:
+        translate_op = lazy.pxr.UsdGeom.Xformable(prim).AddXformOp(
+            lazy.pxr.UsdGeom.XformOp.TypeTranslate,
+            lazy.pxr.UsdGeom.XformOp.PrecisionDouble,
+            "",
+        )
+        translate_op.Set(lazy.pxr.Gf.Vec3d(0.0, 0.0, -z_offset))
+
+
 def create_curobo_cfgs(robot_prim, robot_urdf_path, curobo_cfg, root_link, save_dir, is_holonomic=False):
     """
     Creates a set of curobo configs based on @robot_prim and @curobo_cfg
@@ -845,6 +867,7 @@ def main(config):
     urdf_path, usd_path, prim = import_og_asset_from_urdf(
         category="robot",
         model=cfg.name,
+        dataset_name="custom_dataset",
         urdf_path=cfg.urdf_path,
         collision_method=cfg.collision.decompose_method,
         coacd_links=cfg.collision.coacd_links,
@@ -931,10 +954,7 @@ def main(config):
     # Grab all of the root prim's nested children and joints, and modify their offsets based on AABB z-lower bound
     root_meshes = find_all_meshes(root_prim=articulation_root_prim)
     for mesh in root_meshes:
-        translate_attr = mesh.GetAttribute("xformOp:translate")
-        local_pos = translate_attr.Get()
-        local_pos[2] -= z_offset
-        translate_attr.Set(local_pos)
+        shift_prim_local_z(prim=mesh, z_offset=z_offset)
     root_joints = find_all_joints(root_prim=articulation_root_prim, only_articulated=False)
     root_prim_path = articulation_root_prim.GetPrimPath().pathString
     for joint in root_joints:
@@ -952,10 +972,7 @@ def main(config):
     for link in all_links:
         if link == articulation_root_prim:
             continue
-        translate_attr = link.GetAttribute("xformOp:translate")
-        local_pos = translate_attr.Get()
-        local_pos[2] -= z_offset
-        translate_attr.Set(local_pos)
+        shift_prim_local_z(prim=link, z_offset=z_offset)
 
     # Add holonomic base if requested
     if cfg.base_motion.use_holonomic_joints:

--- a/OmniGibson/omnigibson/examples/robots/robot_control_example.py
+++ b/OmniGibson/omnigibson/examples/robots/robot_control_example.py
@@ -128,9 +128,9 @@ def main(
     elif control_mode is None:
         control_mode = choose_from_options(options=CONTROL_MODES, name="control mode")
     else:
-        assert control_mode in CONTROL_MODES, (
-            f"Unknown control mode '{control_mode}'. Valid options are: {list(CONTROL_MODES)}"
-        )
+        assert (
+            control_mode in CONTROL_MODES
+        ), f"Unknown control mode '{control_mode}'. Valid options are: {list(CONTROL_MODES)}"
 
     # Update the control mode of the robot
     controller_config = {component: {"name": name} for component, name in controller_choices.items()}

--- a/OmniGibson/omnigibson/examples/robots/robot_control_example.py
+++ b/OmniGibson/omnigibson/examples/robots/robot_control_example.py
@@ -60,7 +60,15 @@ def choose_controllers(robot, random_selection=False):
     return controller_choices
 
 
-def main(random_selection=False, headless=False, short_exec=False, quickstart=False):
+def main(
+    random_selection=False,
+    headless=False,
+    short_exec=False,
+    quickstart=False,
+    robot_name=None,
+    scene_model=None,
+    control_mode=None,
+):
     """
     Robot control demo with selection
     Queries the user to select a robot, the controllers, a scene and a type of input (random actions or teleop)
@@ -68,16 +76,22 @@ def main(random_selection=False, headless=False, short_exec=False, quickstart=Fa
     og.log.info(f"Demo {__file__}\n    " + "*" * 80 + "\n    Description:\n" + main.__doc__ + "*" * 80)
 
     # Choose scene to load
-    scene_model = "Rs_int"
-    if not quickstart:
+    if scene_model is None and quickstart:
+        scene_model = "Rs_int"
+    elif scene_model is None:
         scene_model = choose_from_options(options=SCENES, name="scene", random_selection=random_selection)
+    else:
+        assert scene_model in SCENES, f"Unknown scene '{scene_model}'. Valid options are: {list(SCENES)}"
 
     # Choose robot to create
-    robot_name = "fetch"
-    if not quickstart:
+    if robot_name is None and quickstart:
+        robot_name = "fetch"
+    elif robot_name is None:
         robot_name = choose_from_options(
             options=list(sorted(REGISTERED_ROBOTS)), name="robot", random_selection=random_selection
         )
+    else:
+        assert robot_name in REGISTERED_ROBOTS, f"{robot_name} is not a registered robot."
 
     scene_cfg = dict()
     if scene_model == "empty":
@@ -101,22 +115,22 @@ def main(random_selection=False, headless=False, short_exec=False, quickstart=Fa
 
     # Choose robot controller to use
     robot = env.robots[0]
-    controller_choices = {
-        "base": "DifferentialDriveController",
-        "arm_0": "InverseKinematicsController",
-        "gripper_0": "MultiFingerGripperController",
-        "camera": "JointController",
-    }
-    if not quickstart:
+    if quickstart or (robot_name is not None and scene_model is not None and control_mode is not None):
+        controller_choices = {component: robot._default_controllers[component] for component in robot.controller_order}
+    else:
         controller_choices = choose_controllers(robot=robot, random_selection=random_selection)
 
     # Choose control mode
     if random_selection:
         control_mode = "random"
     elif quickstart:
-        control_mode = "teleop"
-    else:
+        control_mode = control_mode or "teleop"
+    elif control_mode is None:
         control_mode = choose_from_options(options=CONTROL_MODES, name="control mode")
+    else:
+        assert control_mode in CONTROL_MODES, (
+            f"Unknown control mode '{control_mode}'. Valid options are: {list(CONTROL_MODES)}"
+        )
 
     # Update the control mode of the robot
     controller_config = {component: {"name": name} for component, name in controller_choices.items()}
@@ -138,6 +152,8 @@ def main(random_selection=False, headless=False, short_exec=False, quickstart=Fa
 
     # Create teleop controller
     action_generator = KeyboardRobotController(robot=robot)
+    if len(action_generator.ik_arms) > 0:
+        print(f"Detected IK arms: {action_generator.ik_arms}. Use 3/4 or Z/X to switch active arm.")
 
     # Register custom binding to reset the environment
     action_generator.register_custom_keymapping(
@@ -154,12 +170,18 @@ def main(random_selection=False, headless=False, short_exec=False, quickstart=Fa
     print("Running demo.")
     print("Press ESC to quit")
 
+    if not og.sim.is_playing():
+        og.sim.play()
+
     # Loop control until user quits
     max_steps = -1 if not short_exec else 100
     step = 0
 
     random_action = None
     while step != max_steps:
+        if not og.sim.is_playing():
+            og.sim.play()
+
         if control_mode == "random":
             # Sample new random action every 30 steps
             if step % 30 == 0:
@@ -185,5 +207,33 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether the example should be loaded with default settings for a quick start.",
     )
+    parser.add_argument(
+        "--robot",
+        default=None,
+        help="Robot model to load. If omitted, the example prompts for a robot unless --quickstart is used.",
+    )
+    parser.add_argument(
+        "--scene",
+        default=None,
+        choices=sorted(SCENES),
+        help="Scene to load. If omitted, the example prompts for a scene unless --quickstart is used.",
+    )
+    parser.add_argument(
+        "--control-mode",
+        default=None,
+        choices=sorted(CONTROL_MODES),
+        help="Control mode to use. If omitted, the example prompts for a mode unless --quickstart is used.",
+    )
+    parser.add_argument(
+        "--short-exec",
+        action="store_true",
+        help="Run only a short fixed-length rollout, useful for smoke testing.",
+    )
     args = parser.parse_args()
-    main(quickstart=args.quickstart)
+    main(
+        quickstart=args.quickstart,
+        short_exec=args.short_exec,
+        robot_name=args.robot,
+        scene_model=args.scene,
+        control_mode=args.control_mode,
+    )

--- a/OmniGibson/omnigibson/utils/asset_conversion_utils.py
+++ b/OmniGibson/omnigibson/utils/asset_conversion_utils.py
@@ -1146,19 +1146,79 @@ def convert_urdf_to_usd(
     links = list(visuals_prim.GetChildren()) + list(colliders_prim.GetChildren())
     wrappers = [wrapper for link in links for wrapper in link.GetChildren()]
 
+    geom_types = {"Sphere", "Cube", "Cone", "Cylinder", "Mesh"}
+
+    def _ensure_geom_xform_ops(prim):
+        if prim.GetTypeName() not in geom_types:
+            return
+
+        prop_names = prim.GetPropertyNames()
+        xformable = lazy.pxr.UsdGeom.Xformable(prim)
+
+        if "xformOp:translate" in prop_names:
+            xform_op_translate = lazy.pxr.UsdGeom.XformOp(prim.GetAttribute("xformOp:translate"))
+            if prim.GetAttribute("xformOp:translate").Get() is None:
+                xform_op_translate.Set(lazy.pxr.Gf.Vec3d([0.0, 0.0, 0.0]))
+        else:
+            xform_op_translate = xformable.AddXformOp(
+                lazy.pxr.UsdGeom.XformOp.TypeTranslate, lazy.pxr.UsdGeom.XformOp.PrecisionDouble, ""
+            )
+            xform_op_translate.Set(lazy.pxr.Gf.Vec3d([0.0, 0.0, 0.0]))
+
+        if "xformOp:orient" in prop_names:
+            xform_op_orient = lazy.pxr.UsdGeom.XformOp(prim.GetAttribute("xformOp:orient"))
+            if prim.GetAttribute("xformOp:orient").Get() is None:
+                xform_op_orient.Set(lazy.pxr.Gf.Quatd(1.0, lazy.pxr.Gf.Vec3d([0.0, 0.0, 0.0])))
+        else:
+            xform_op_orient = xformable.AddXformOp(
+                lazy.pxr.UsdGeom.XformOp.TypeOrient, lazy.pxr.UsdGeom.XformOp.PrecisionDouble, ""
+            )
+            xform_op_orient.Set(lazy.pxr.Gf.Quatd(1.0, lazy.pxr.Gf.Vec3d([0.0, 0.0, 0.0])))
+
+        if "xformOp:scale" in prop_names:
+            xform_op_scale = lazy.pxr.UsdGeom.XformOp(prim.GetAttribute("xformOp:scale"))
+            if prim.GetAttribute("xformOp:scale").Get() is None:
+                xform_op_scale.Set(lazy.pxr.Gf.Vec3d([1.0, 1.0, 1.0]))
+        else:
+            xform_op_scale = xformable.AddXformOp(
+                lazy.pxr.UsdGeom.XformOp.TypeScale, lazy.pxr.UsdGeom.XformOp.PrecisionDouble, ""
+            )
+            xform_op_scale.Set(lazy.pxr.Gf.Vec3d([1.0, 1.0, 1.0]))
+
+        xformable.SetXformOpOrder([xform_op_translate, xform_op_orient, xform_op_scale])
+
     for parent_prim in wrappers:
         parent_path = parent_prim.GetPath()
         grandparent_path = parent_path.GetParentPath()
 
-        # Find the child prim - it's actually away at a reference. There should be exactly one.
+        # Find the child prim - it is usually away at a reference. Isaac Sim 5.1
+        # may also emit direct primitive colliders here, which should be kept as-is.
         references = parent_prim.GetPrimStack()[0].referenceList.prependedItems
-        assert len(references) == 1, f"{parent_path} is not a reference!"
+        if not references:
+            for child_prim in lazy.pxr.Usd.PrimRange(parent_prim):
+                _ensure_geom_xform_ops(child_prim)
+            continue
+        assert len(references) == 1, f"Expected exactly one reference for {parent_path}, got {len(references)}"
         referenced_wrapper_path_str = str(references[0].primPath)
         referenced_wrapper_prim = side_stage.GetPrimAtPath(referenced_wrapper_path_str)
         assert referenced_wrapper_prim.IsValid()
 
-        child_prim = referenced_wrapper_prim.GetChild("World").GetChild("mesh")
-        assert child_prim.IsValid()
+        # Older importer output stores the authored geometry under World/mesh.
+        # Isaac Sim 5.1 can emit a whole /meshes/<name> prim instead, so promote
+        # that entire subtree while leaving the source around for material migration.
+        world_prim = referenced_wrapper_prim.GetChild("World")
+        if world_prim.IsValid() and world_prim.GetChild("mesh").IsValid():
+            child_prim = world_prim.GetChild("mesh")
+            delete_child_source = True
+        elif referenced_wrapper_prim.GetTypeName() in geom_types or referenced_wrapper_prim.GetChildren():
+            child_prim = referenced_wrapper_prim
+            delete_child_source = False
+        else:
+            # No mesh for this link — remove the wrapper prim and continue
+            del side_stage.GetRootLayer().GetPrimAtPath(grandparent_path).nameChildren[parent_path.name]
+            continue
+        for prim_to_update in lazy.pxr.Usd.PrimRange(child_prim):
+            _ensure_geom_xform_ops(prim_to_update)
         child_path = child_prim.GetPath()
 
         # Duplicate the properties on the parent prim onto the child.
@@ -1181,8 +1241,11 @@ def convert_urdf_to_usd(
         # Move the child prim to the parent's path.
         assert lazy.pxr.Sdf.CopySpec(side_stage.GetRootLayer(), child_path, side_stage.GetRootLayer(), parent_path)
 
-        # Delete the child's original path
-        del side_stage.GetRootLayer().GetPrimAtPath(child_path.GetParentPath()).nameChildren[child_path.name]
+        # Delete the child's original path when materials live outside it. For
+        # copied /meshes/<name> subtrees, keep the source until material bindings
+        # are migrated, then /meshes is removed wholesale below.
+        if delete_child_source:
+            del side_stage.GetRootLayer().GetPrimAtPath(child_path.GetParentPath()).nameChildren[child_path.name]
 
     # Migrate materials from /meshes to /Looks before deleting the meshes hierarchy
     # This is necessary for IsaacSim 5.1+ where materials are now placed under /meshes


### PR DESCRIPTION

## Summary

Thank you for maintaining BEHAVIOR-1K and the custom robot import workflow.

While testing the custom robot import tutorial on the current `main` branch with Isaac Sim 5.1, I ran into compatibility issues in `import_custom_robot.py`. The baseline quickstart works with the current 5.1 setup, but the custom robot import path fails on the Stretch tutorial config.

The first failure happens because `import_og_asset_from_urdf()` now requires `dataset_name`. After addressing that, a few additional updates were needed for Isaac Sim 5.1's URDF importer USD output and local pose APIs.

This PR proposes a small compatibility update for the custom robot import path:
- Pass `dataset_name="custom_dataset"` when importing custom robot URDFs.
- Update `XFormPrim` and local pose API usage for Isaac Sim 5.1.
- Handle quaternion convention conversion between Isaac Sim and OmniGibson utilities.
- Make USD post-processing compatible with Isaac Sim 5.1 geometry outputs.
- Add non-interactive smoke-test options to `robot_control_example.py`.

## Testing

- Current `main` quickstart with Isaac Sim 5.1: PASS
- Current `main` Stretch import: fails before this fix
  - `TypeError: import_og_asset_from_urdf() missing 1 required positional argument: 'dataset_name'`
- PR branch Stretch import: PASS
  - Generated `stretch_test.usda`
- PR branch imported Stretch control smoke test: PASS
  - `robot_control_example.py --robot stretch_test --scene empty --control-mode random --short-exec`
- Static checks:
  - `git diff --check origin/main..HEAD`
  - `py_compile` on changed Python files
  - grep check for local path or project-specific leftovers