### PR TITLE
fix setup.sh av version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -450,7 +450,9 @@ if [ "$EVAL" = true ]; then
     TORCH_VERSION=$(pip show torch | grep Version | cut -d " " -f 2)
     pip install torch-cluster -f https://data.pyg.org/whl/torch-${TORCH_VERSION}.html
     # install av and ffmpeg
-    conda install av "numpy<2" -c conda-forge -y
+    # Pin av<16 to stay compatible with lerobot (which requires av>=15,<16); an
+    # unpinned conda install pulls av 17+, which drops av.option and breaks lerobot's import.
+    conda install "av>=15,<16" "numpy<2" -c conda-forge -y
 fi
 
 # Install asset pipeline


### PR DESCRIPTION
Seeing ```Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/stef/Documents/BEHAVIOR-1K/OmniGibson/omnigibson/__init__.py", line 9, in <module>
      from omnigibson.envs import Environment, VectorEnvironment
    File "/home/stef/Documents/BEHAVIOR-1K/OmniGibson/omnigibson/envs/__init__.py", line 3, in <module>
      from omnigibson.envs.lerobot_data_wrapper import LeRobotDataWrapper, LeRobotPlaybackWrapper
    File "/home/stef/Documents/BEHAVIOR-1K/OmniGibson/omnigibson/envs/lerobot_data_wrapper.py", line 6, in <module>
      from lerobot.datasets import LeRobotDataset
  ImportError: cannot import name 'LeRobotDataset' from 'lerobot.datasets' (/home/stef/miniconda3/envs/test_env/lib/python3.11/site-packages/lerobot/datasets/__init__.py) 
``` when running `setup.sh` on main, due to `AttributeError: module 'av' has no attribute 'option'` since the version here was not pinned.
