### PR TITLE
Add constant options for torch threads nums

### DIFF
--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -14,6 +14,14 @@ from av.stream import Stream
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
+TORCH_NUM_THREADS = None
+TORCH_NUM_INTEROP_THREADS = None
+
+if TORCH_NUM_THREADS is not None:
+    th.set_num_threads(TORCH_NUM_THREADS)
+if TORCH_NUM_INTEROP_THREADS is not None:
+    th.set_num_interop_threads(TORCH_NUM_INTEROP_THREADS)
+
 import omnigibson as og
 import omnigibson.utils.transform_utils as T
 from gello.utils.og_teleop_cfg import DISABLED_TRANSITION_RULES
@@ -44,19 +52,11 @@ from omnigibson.eval.utils.light_utils import LightToggleSynchronizer, set_light
 from omnigibson.utils.python_utils import recursively_convert_to_torch
 from omnigibson.utils.ui_utils import create_module_logger
 
-
 LIGHT_EVAL_TASKS = {"turning_out_all_lights_before_sleep"}
 EVAL_BASE_LINK_MASS = 250.0
 EVAL_HEAD_HORIZONTAL_APERTURE = 40.0
 DEFAULT_ROBOT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "r1pro.yaml")
 EVAL_MODES = ("train", "public_test", "hidden_test")
-TORCH_NUM_THREADS = None
-TORCH_NUM_INTEROP_THREADS = None
-
-if TORCH_NUM_THREADS is not None:
-    th.set_num_threads(TORCH_NUM_THREADS)
-if TORCH_NUM_INTEROP_THREADS is not None:
-    th.set_num_interop_threads(TORCH_NUM_INTEROP_THREADS)
 
 gm.USE_GPU_DYNAMICS = False
 gm.ENABLE_TRANSITION_RULES = True

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -50,7 +50,14 @@ EVAL_BASE_LINK_MASS = 250.0
 EVAL_HEAD_HORIZONTAL_APERTURE = 40.0
 DEFAULT_ROBOT_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "r1pro.yaml")
 EVAL_MODES = ("train", "public_test", "hidden_test")
+TORCH_NUM_THREADS = None
+TORCH_NUM_INTEROP_THREADS = None
 
+if TORCH_NUM_THREADS is not None:
+    th.set_num_threads(TORCH_NUM_THREADS)
+if TORCH_NUM_INTEROP_THREADS is not None:
+    th.set_num_interop_threads(TORCH_NUM_INTEROP_THREADS)
+    
 gm.USE_GPU_DYNAMICS = False
 gm.ENABLE_TRANSITION_RULES = True
 

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -57,7 +57,7 @@ if TORCH_NUM_THREADS is not None:
     th.set_num_threads(TORCH_NUM_THREADS)
 if TORCH_NUM_INTEROP_THREADS is not None:
     th.set_num_interop_threads(TORCH_NUM_INTEROP_THREADS)
-    
+
 gm.USE_GPU_DYNAMICS = False
 gm.ENABLE_TRANSITION_RULES = True
 


### PR DESCRIPTION
## Title

Add optional PyTorch thread configuration for evaluation

## Summary

This PR adds optional PyTorch CPU thread settings before importing OmniGibson.

On some systems, PyTorch may use too many CPU threads by default, which can cause low FPS during evaluation due to thread scheduling and synchronization overhead.

```python
TORCH_NUM_THREADS = None
TORCH_NUM_INTEROP_THREADS = None
```

When left as `None`, PyTorch keeps its default settings.
