### PR TITLE
Upgrade to Isaac Sim 6.0 (Python 3.12)

### DIFF
--- a/OmniGibson/omnigibson/eval/wrappers/rgbd_full_res_wrapper.py
+++ b/OmniGibson/omnigibson/eval/wrappers/rgbd_full_res_wrapper.py
@@ -37,6 +37,9 @@ class RGBDFullResWrapper(EnvironmentWrapper):
             else:
                 sensor.image_height = WRIST_RESOLUTION[0]
                 sensor.image_width = WRIST_RESOLUTION[1]
-        # reload observation space
-        env.load_observation_space()
-        logger.info("Reloaded observation space!")
+            # Reload only this sensor's observation space; a full env.load_observation_space()
+            # would also query proprio while physics views are not yet valid.
+            sensor_space = sensor.load_observation_space()
+            if env.observation_space is not None:
+                env.observation_space.spaces[robot.name].spaces[sensor_name] = sensor_space
+        logger.info("Reloaded camera observation spaces!")

--- a/OmniGibson/omnigibson/omnigibson_6_0_0.kit
+++ b/OmniGibson/omnigibson/omnigibson_6_0_0.kit
@@ -1,0 +1,52 @@
+[package]
+description = "A platform for accelerating Embodied AI research"
+title = "OmniGibson"
+version = "3.9.0"
+
+keywords = ["experience", "app", "usd", "isaacsim"] # That makes it browsable in UI with "experience" filter
+
+
+[dependencies]
+"isaacsim.exp.base" = {}
+"omni.flowusd" = {}
+#"omni.kit.xr.profile.vr" = {}
+"omni.physx.supportui" = {}
+#"omni.isaac.physics_inspector" = {}
+
+[settings.app]
+name = "OmniGibson"
+version = "3.9.0"
+settings.persistent = false       # settings reset on each run with this app
+window.title = "OmniGibson"
+vulkan = true # Explicitly enable Vulkan (on by default on Linux, off by default on Windows)
+window.iconPath = "${app}/OmniGibson_logo.png"
+enableDeveloperWarnings = false    # disable developer warnings to reduce log noise
+
+[settings.crashreporter]
+enabled = false           # disable Kit crash reporter
+gatherUserStory = false
+
+[settings.app.livestream]
+proto = "ws"
+allowResize = true
+outDirectory = "${data}"
+
+[settings.app.exts.folders]
+'++' = [
+    "${app}",
+    "${app}/../exts",
+    "${app}/../extscache",
+    "${app}/../extsPhysics",
+    "${app}/../extsUser",
+    "${app}/../extsDeprecated",
+]
+
+[settings.exts."omni.kit.registry.nucleus"]
+registries = [
+	{ name = "kit/default", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/107/shared" },
+	{ name = "kit/sdk", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/sdk/${kit_version_short}/${kit_git_hash}" },
+	{ name = "kit/community", url = "https://dw290v42wisod.cloudfront.net/exts/kit/community" },
+]
+
+[settings.app.extensions]
+pathStatCacheEnabled = false

--- a/OmniGibson/omnigibson/omnigibson_6_0_0_vr.kit
+++ b/OmniGibson/omnigibson/omnigibson_6_0_0_vr.kit
@@ -1,0 +1,52 @@
+[package]
+description = "A platform for accelerating Embodied AI research"
+title = "OmniGibson"
+version = "3.9.0"
+
+keywords = ["experience", "app", "usd", "isaacsim"] # That makes it browsable in UI with "experience" filter
+
+
+[dependencies]
+"isaacsim.exp.base" = {}
+"omni.flowusd" = {}
+"omni.kit.xr.profile.vr" = {}
+"omni.physx.supportui" = {}
+#"omni.isaac.physics_inspector" = {}
+
+[settings.app]
+name = "OmniGibson"
+version = "3.9.0"
+settings.persistent = false       # settings reset on each run with this app
+window.title = "OmniGibson"
+vulkan = true # Explicitly enable Vulkan (on by default on Linux, off by default on Windows)
+window.iconPath = "${app}/OmniGibson_logo.png"
+enableDeveloperWarnings = false    # disable developer warnings to reduce log noise
+
+[settings.crashreporter]
+enabled = false           # disable Kit crash reporter
+gatherUserStory = false
+
+[settings.app.livestream]
+proto = "ws"
+allowResize = true
+outDirectory = "${data}"
+
+[settings.app.exts.folders]
+'++' = [
+    "${app}",
+    "${app}/../exts",
+    "${app}/../extscache",
+    "${app}/../extsPhysics",
+    "${app}/../extsUser",
+    "${app}/../extsDeprecated",
+]
+
+[settings.exts."omni.kit.registry.nucleus"]
+registries = [
+	{ name = "kit/default", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/107/shared" },
+	{ name = "kit/sdk", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/sdk/${kit_version_short}/${kit_git_hash}" },
+	{ name = "kit/community", url = "https://dw290v42wisod.cloudfront.net/exts/kit/community" },
+]
+
+[settings.app.extensions]
+pathStatCacheEnabled = false

--- a/OmniGibson/omnigibson/prims/material_prim.py
+++ b/OmniGibson/omnigibson/prims/material_prim.py
@@ -272,7 +272,7 @@ class MaterialPrim(BasePrim):
         if non_default_inp is not None:
             return non_default_inp
 
-        return self._shader_node.GetInput(inp).GetDefaultValue()
+        return self._shader_node_input(inp).GetDefaultValue()
 
     def set_input(self, inp, val):
         """
@@ -314,7 +314,15 @@ class MaterialPrim(BasePrim):
         Returns:
             set: All the shader input names associated with this material that have default values
         """
+        # USD 25.x (Isaac Sim >= 6.0) renamed GetInputNames -> GetShaderInputNames
+        if hasattr(self._shader_node, "GetShaderInputNames"):
+            return set(self._shader_node.GetShaderInputNames())
         return set(self._shader_node.GetInputNames())
+
+    def _shader_node_input(self, name):
+        # USD 25.x (Isaac Sim >= 6.0) renamed SdrShaderNode.GetInput -> GetShaderInput
+        getter = getattr(self._shader_node, "GetShaderInput", None) or self._shader_node.GetInput
+        return getter(name)
 
     def get_shader_input_names_by_type(self, input_type, include_default=False):
         """
@@ -332,7 +340,7 @@ class MaterialPrim(BasePrim):
         shader_default_input_names = {
             inp_name
             for inp_name in self.shader_default_input_names
-            if self._shader_node.GetInput(inp_name).GetType() == input_type
+            if self._shader_node_input(inp_name).GetType() == input_type
         }
         return shader_input_names | shader_default_input_names
 

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -69,6 +69,7 @@ m.INITIAL_SCENE_PRIM_Z_OFFSET = -100.0
 
 m.KIT_FILES = {
     (5, 1, 0): "omnigibson_5_1_0.kit",
+    (6, 0, 0): "omnigibson_6_0_0.kit",
 }
 
 
@@ -463,19 +464,20 @@ def _launch_simulator(*args, **kwargs):
             # Store other references to variables that will be initialized later
             self._scenes = []
             # The callback will be called right *before* the physics step
-            self._pre_physics_step_callback = self._physics_context._physx_interface.subscribe_physics_on_step_events(
+            physx_interface = lazy.omni.physx.get_physx_interface()
+            self._pre_physics_step_callback = physx_interface.subscribe_physics_on_step_events(
                 lambda _: self._on_pre_physics_step(),
                 pre_step=True,
                 order=0,
             )
             # The callback will be called right *after* the physics step
-            self._post_physics_step_callback = self._physics_context._physx_interface.subscribe_physics_on_step_events(
+            self._post_physics_step_callback = physx_interface.subscribe_physics_on_step_events(
                 lambda _: self._on_post_physics_step(),
                 pre_step=False,
                 order=0,
             )
             self._simulation_event_callback = (
-                self._physics_context._physx_interface.get_simulation_event_stream_v2().create_subscription_to_pop(
+                physx_interface.get_simulation_event_stream_v2().create_subscription_to_pop(
                     self._on_simulation_event
                 )
             )
@@ -1121,11 +1123,11 @@ def _launch_simulator(*args, **kwargs):
 
         @property
         def pi(self):
-            return self._physics_context._physx_interface
+            return lazy.omni.physx.get_physx_interface()
 
         @property
         def psi(self):
-            return self._physics_context._physx_sim_interface
+            return lazy.omni.physx.get_physx_simulation_interface()
 
         @property
         def psqi(self):

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -477,9 +477,7 @@ def _launch_simulator(*args, **kwargs):
                 order=0,
             )
             self._simulation_event_callback = (
-                physx_interface.get_simulation_event_stream_v2().create_subscription_to_pop(
-                    self._on_simulation_event
-                )
+                physx_interface.get_simulation_event_stream_v2().create_subscription_to_pop(self._on_simulation_event)
             )
 
             # List of objects that need to be initialized during whenever the next sim step occurs

--- a/OmniGibson/omnigibson/utils/deprecated_utils.py
+++ b/OmniGibson/omnigibson/utils/deprecated_utils.py
@@ -590,8 +590,13 @@ class ArticulationView(_ArticulationView):
         return
 
     def _invalidate_physics_handle_callback(self, event):
-        # Overwrite super method, add additional de-initialization
-        if event.type == int(omni.timeline.TimelineEventType.STOP):
+        # Overwrite super method, add additional de-initialization.
+        # Isaac Sim 6.0 delivers timeline events via carb.eventdispatcher, whose Event exposes the
+        # type as `.event_type` rather than the `.type` used by 5.1's carb.events.IEvent. Support both.
+        event_type = getattr(event, "type", None)
+        if event_type is None:
+            event_type = getattr(event, "event_type", None)
+        if event_type is not None and int(event_type) == int(omni.timeline.TimelineEventType.STOP):
             self._physics_view = None
             self._invalidate_physics_handle_event = None
             self._is_initialized = False

--- a/OmniGibson/setup.py
+++ b/OmniGibson/setup.py
@@ -42,7 +42,8 @@ setup(
         "imageio-ffmpeg>=0.4.9",
         "termcolor>=2.4.0",
         "progressbar>=2.5",
-        "pymeshlab~=2022.2; platform_machine!='aarch64'",
+        # 2023+ needed for cp312 (Python 3.12 / Isaac Sim 6.0) wheels; 2022.2 has no cp312 build.
+        "pymeshlab>=2023.12; platform_machine!='aarch64'",
         "pymeshlab>=2022.2; platform_machine=='aarch64'",
         "click>=8.1.3",
         "aenum>=3.1.15",

--- a/setup.sh
+++ b/setup.sh
@@ -248,8 +248,8 @@ if [ "$NEW_ENV" = true ]; then
         exit 1
     fi
     
-    # Create environment with Python 3.11 and packaging tools used by this script
-    conda create -n "$NEW_ENV_NAME" python=3.11 pip "setuptools>=71,<81" wheel -c conda-forge -y
+    # Create environment with Python 3.12 (required by Isaac Sim 6.0) and packaging tools used by this script
+    conda create -n "$NEW_ENV_NAME" python=3.12 pip "setuptools>=71,<81" wheel -c conda-forge -y
     conda activate "$NEW_ENV_NAME"
     
     [[ "$CONDA_DEFAULT_ENV" != "$NEW_ENV_NAME" ]] && { echo "ERROR: Failed to activate environment '$NEW_ENV_NAME'"; exit 1; }
@@ -262,7 +262,10 @@ echo "Installing PyTorch with CUDA $CUDA_VERSION support..."
 # Determine the CUDA version string for pip URL (e.g., cu128, cu126, etc.)
 CUDA_VER_SHORT=$(echo "$CUDA_VERSION" | sed 's/\.//g')  # e.g. convert 12.8 to 128
 
-python -m pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 torchcodec==0.5 --index-url https://download.pytorch.org/whl/cu${CUDA_VER_SHORT}
+# Isaac Sim 6.0 requires torch 2.11.0. Install the +cuXXX build so the local-version tag survives
+# Isaac's `torch==2.11.0` dependency (otherwise pip replaces it with a plain build and torch-cluster
+# can't find a matching pyg wheel).
+python -m pip install torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 torchcodec==0.11.1 --index-url https://download.pytorch.org/whl/cu${CUDA_VER_SHORT}
 
 echo "✓ PyTorch installation completed"
 
@@ -282,9 +285,9 @@ if [ "$OMNIGIBSON" = true ]; then
     echo "Installing OmniGibson..."
     [ ! -d "OmniGibson" ] && { echo "ERROR: OmniGibson directory not found"; exit 1; }
     
-    # Check Python version
+    # Check Python version (this script installs Isaac Sim 6.0, which requires Python 3.12)
     PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-    [ "$PYTHON_VERSION" != "3.11" ] && { echo "ERROR: Python 3.11 required, found $PYTHON_VERSION"; exit 1; }
+    [ "$PYTHON_VERSION" != "3.12" ] && { echo "ERROR: This script installs Isaac Sim 6.0, which requires Python 3.12 (found $PYTHON_VERSION). Recreate the environment with Python 3.12 (e.g. via the --new-env flag), or use an earlier BEHAVIOR-1K release for the Isaac Sim 5.1 / Python 3.10 setup."; exit 1; }
     
     # Check for conflicting environment variables
     if [[ -n "$EXP_PATH" || -n "$CARB_APP_PATH" || -n "$ISAAC_PATH" ]]; then
@@ -334,82 +337,15 @@ if [ "$OMNIGIBSON" = true ]; then
     else
         echo "Installing Isaac Sim via pip..."
 
-        # For aarch, do alternative install via direct one-liner
-        if [ "$ARCH" = "aarch64" ]; then
-            python -m pip install isaacsim[all,extscache]==5.1.0 --extra-index-url https://pypi.nvidia.com
-        else
-            # Helper functions
-            check_glibc_old() {
-                ldd --version 2>&1 | grep -qE "2\.(31|32|33|34)"
-            }
-
-            install_isaac_packages() {
-                local temp_dir=$(mktemp -d)
-                local packages=(
-                    "omniverse_kit-107.3.1.206797"
-                    "isaacsim_kernel-5.1.0.0"
-                    "isaacsim_app-5.1.0.0"
-                    "isaacsim_core-5.1.0.0"
-                    "isaacsim_gui-5.1.0.0"
-                    "isaacsim_utils-5.1.0.0"
-                    "isaacsim_storage-5.1.0.0"
-                    "isaacsim_asset-5.1.0.0"
-                    "isaacsim_sensor-5.1.0.0"
-                    "isaacsim_robot_motion-5.1.0.0"
-                    "isaacsim_robot-5.1.0.0"
-                    "isaacsim_benchmark-5.1.0.0"
-                    "isaacsim_code_editor-5.1.0.0"
-                    "isaacsim_ros1-5.1.0.0"
-                    "isaacsim_cortex-5.1.0.0"
-                    "isaacsim_example-5.1.0.0"
-                    "isaacsim_replicator-5.1.0.0"
-                    "isaacsim_rl-5.1.0.0"
-                    "isaacsim_robot_setup-5.1.0.0"
-                    "isaacsim_ros2-5.1.0.0"
-                    "isaacsim_template-5.1.0.0"
-                    "isaacsim_test-5.1.0.0"
-                    "isaacsim-5.1.0.0"
-                    "isaacsim_extscache_physics-5.1.0.0"
-                    "isaacsim_extscache_kit-5.1.0.0"
-                    "isaacsim_extscache_kit_sdk-5.1.0.0"
-                )
-
-                local wheel_files=()
-                for pkg in "${packages[@]}"; do
-                    local pkg_name=${pkg%-*}
-                    local filename="${pkg}-cp311-none-manylinux_2_35_${ARCH}.whl"
-                    local url="https://pypi.nvidia.com/${pkg_name//_/-}/$filename"
-                    local filepath="$temp_dir/$filename"
-
-                    echo "Downloading $pkg..."
-                    if ! curl -sL "$url" -o "$filepath"; then
-                        echo "ERROR: Failed to download $pkg"
-                        rm -rf "$temp_dir"
-                        return 1
-                    fi
-
-                    # Rename for older GLIBC
-                    if check_glibc_old; then
-                        local new_filepath="${filepath/manylinux_2_35/manylinux_2_31}"
-                        mv "$filepath" "$new_filepath"
-                        filepath="$new_filepath"
-                    fi
-
-                    wheel_files+=("$filepath")
-                done
-
-                echo "Installing Isaac Sim packages..."
-                python -m pip install "${wheel_files[@]}"
-                rm -rf "$temp_dir"
-
-                # Verify installation
-                if ! python -c "import isaacsim" 2>/dev/null; then
-                    echo "ERROR: Isaac Sim installation verification failed"
-                    return 1
-                fi
-            }
-
-            install_isaac_packages || { echo "ERROR: Isaac Sim installation failed"; exit 1; }
+        # Isaac Sim 6.0 is distributed as a single metapackage; kit is bundled inside the
+        # isaacsim-extscache-* wheels (no separate omniverse-kit wheel as in 5.1). Some deps
+        # are pre-releases (e.g. tinyobjloader, mujoco-usd-converter) and live only on the
+        # NVIDIA index, so --pre is required to let pip resolve them.
+        python -m pip install --pre "isaacsim[all,extscache]==6.0.0.1" \
+            --extra-index-url https://pypi.nvidia.com \
+            || { echo "ERROR: Isaac Sim installation failed"; exit 1; }
+        if ! python -c "import isaacsim" 2>/dev/null; then
+            echo "ERROR: Isaac Sim installation verification failed"; exit 1
         fi
         
         # Extract ISAAC_PATH from isaacsim module
@@ -422,13 +358,18 @@ if [ "$OMNIGIBSON" = true ]; then
         fi
 
         # Fix packaging conflict - remove conflicting version
-        # There is a conflict where isaacsim enforces 23.0 but omni kit ships with 25.0
-        if [ -d "$CONDA_PREFIX/lib/python3.11/site-packages/isaacsim/extscache/omni.services.pip_archive-0.16.0+107.0.3.lx64.cp311/pip_prebundle/packaging" ]; then
+        # There is a conflict where isaacsim enforces 23.0 but omni kit ships with 25.0.
+        # The pip_archive extscache dir is versioned (differs across Isaac releases), so glob for it.
+        if [ -n "$ISAAC_PATH" ] && [ -d "$ISAAC_PATH/extscache" ]; then
             echo "Fixing packaging conflict..."
-            rm -rf "$CONDA_PREFIX/lib/python3.11/site-packages/isaacsim/extscache/omni.services.pip_archive-0.16.0+107.0.3.lx64.cp311/pip_prebundle/packaging"
+            find "$ISAAC_PATH/extscache" -type d -path "*omni.services.pip_archive*/pip_prebundle/packaging" -exec rm -rf {} + 2>/dev/null || true
         fi
     fi
     
+    # numba (pulled in transitively) imports coverage.types.Tracer, which only exists in coverage>=7.6;
+    # Isaac Sim ships an older coverage, so bump it or `import omnigibson` fails on Python 3.12.
+    # Also realign numba+llvmlite to a compatible pair for Python 3.12 (Isaac ships a stale llvmlite).
+    python -m pip install -U "coverage>=7.6" "numba>=0.60" "llvmlite>=0.43"
     # Force reinstall cffi 1.17.1 to resolve compatibility issues with Isaac Sim extensions
     python -m pip install --force-reinstall cffi==1.17.1
     # Force reinstall websockets >= 15.0.1 because it's been overwritten by Isaac Sim with an older version


### PR DESCRIPTION
## Summary

Upgrades OmniGibson / BEHAVIOR-1K from Isaac Sim 5.1 to **Isaac Sim 6.0.0.1** (and Python 3.11 -> 3.12). Single focused commit, rebased on latest `main`; 8 files, +160/-96.

## Motivation

Two independent reasons this upgrade is worth taking:

1. **Newer NVIDIA driver support (the pressing operational issue).** Under Isaac Sim 5.1, the current NVIDIA driver branch (595.x) crashes -- so users are forced to pin their workloads to nodes running the older 580.x driver. On shared and heterogeneous GPU clusters (which is where most large-scale BEHAVIOR eval/training happens) that pinning is a real bottleneck: it strands otherwise-healthy GPUs and complicates scheduling. **Isaac Sim 6.0 resolves this** -- it runs cleanly on both 580.x and 595.x drivers, so evaluation and training are no longer gated on driver branch and can use any healthy GPU node. As machines get reimaged onto newer drivers over time, this shifts from "nice to have" to "required to run at all" on 5.1.

2. **Staying current with the simulator.** Beyond the driver fix, moving onto NVIDIA's current supported Isaac Sim release brings its physics/rendering/API improvements and keeps OmniGibson from drifting a full generation behind upstream -- which makes each subsequent upgrade smaller and reduces the accumulation of deprecated-API shims.

## Changes

- **`setup.sh`**: Python 3.11 -> 3.12; replace the manual per-wheel Isaac install list with `pip install --pre "isaacsim[all,extscache]==6.0.0.1"`; bump torch stack to 2.11.0 / torchvision 0.26.0 / torchaudio 2.11.0 / (+cu128); glob-based fix for a packaging conflict; add `coverage`/`numba`/`llvmlite` to dependency fixups.
- **`OmniGibson/setup.py`**: `pymeshlab >= 2023.12` (cp312 wheels).
- **`simulator.py`**: register `(6,0,0) -> omnigibson_6_0_0.kit`; add the new `omnigibson_6_0_0{,_vr}.kit` files; migrate the private `PhysicsContext._physx_interface` / `_physx_sim_interface` to the public `omni.physx.get_physx_interface()` / `get_physx_simulation_interface()`.
- **`prims/material_prim.py`**: handle the Sdr API renames (`GetInputNames` -> `GetShaderInputNames`, `GetInput` -> `GetShaderInput`) via a small helper, `hasattr`-guarded so it stays 5.1-compatible.
- **`utils/deprecated_utils.py`**: timeline event `.type` -> `.event_type` fallback (carb eventdispatcher in 6.0).
- **`eval/wrappers/rgbd_full_res_wrapper.py`**: per-sensor observation-space reload.

## Compatibility & testing

- The API-shim changes (material Sdr, timeline event) are `hasattr`-guarded, so they remain compatible with Isaac 5.1.
- Verified end-to-end on Isaac Sim 6.0: a full pi0.5 policy evaluation against the OmniGibson evaluator ran cleanly (e.g. `turning_on_radio`, multiple instances/rollouts, non-trivial `q_score`). 6.0 also resolves the driver-595 crash seen under 5.1, so evals no longer need to be pinned to specific driver branches.

### Test suite results (this branch, Isaac Sim 6.0, a40 GPU)

Ran the OmniGibson CI test matrix (`OMNIGIBSON_HEADLESS=1`, one file per job). ~150 tests pass; full breakdown:

| test file | result |
| --- | --- |
| test_transform_utils | 34 passed |
| test_transition_rules | 28 passed, 2 skipped |
| test_object_states | 29 passed, 6 skipped |
| test_robot_states_flatcache | 18 passed, 3 skipped |
| test_symbolic_primitives | 14 passed, 6 skipped |
| test_multiple_envs | 8 passed, 2 skipped |
| test_controllers | 5 passed |
| test_envs | 5 passed |
| test_dump_load_states | 4 passed |
| test_object_removal | 2 passed |
| test_snapshots | 2 passed |
| test_scene_graph | 1 passed |
| test_systems | 1 passed |
| test_sensors | 1 passed, **1 failed** (see below) |
| test_robot_teleoperation | **error** (see below) |

Two items that are **not** regressions from this PR's changes, but noted for transparency:

- **`test_sensors::test_segmentation_modalities`** fails: under 6.0, semantic segmentation labels some particle systems / derived objects (`stain`, `white_rice`, `diced__apple`) as `unlabelled` where the test expects the fine-grained class. None of the files in this PR touch the segmentation/annotator path -- this looks like an Isaac Sim 6.0 semantic-annotator behavior change and likely needs a small OmniGibson-side follow-up (possibly a missing semantic extension in the new Kit profile). Flagging rather than papering over it.
- **`test_robot_teleoperation`** errors at collection with `ModuleNotFoundError: No module named 'telemoma'` -- a missing optional teleop dependency in the test environment, unrelated to the simulator version.

(A first pass also showed spurious failures in `test_robot_states_flatcache` and a `test_object_states` timeout; both were traced to individual GPU nodes whose RTX renderer failed to initialize / ran pathologically slow, and both pass cleanly on healthy nodes -- numbers above are from clean reruns.)

This is a significant version bump; happy to split it up, add CI coverage, or open a tracking issue first if the maintainers would prefer that workflow.


_Generated with [Claude Code](https://claude.com/claude-code)_