### PR TITLE
BDDL flammable heatsource ability check

### DIFF
--- a/OmniGibson/omnigibson/objects/usd_object.py
+++ b/OmniGibson/omnigibson/objects/usd_object.py
@@ -545,31 +545,14 @@ class USDObject(EntityPrim, Registerable, metaclass=ABCMeta):
                 if compatible:
                     params = self._abilities[ability]
                     for state_type, state_params in get_states_and_params_for_ability(ability, params):
-                        if state_type in states_info:
-                            # An object carries at most one instance of a given state, so two
-                            # abilities requesting the same state must be reconciled. The only
-                            # supported overlap is HeatSourceOrSink: an explicit heat/cold source
-                            # ability and `flammable` both request it (flammable pairs OnFire with
-                            # a requires_on_fire heat source). The explicit source owns the single
-                            # instance — its toggled heating is the object's task-relevant behavior
-                            # — and `flammable` then contributes only its OnFire detector. Any other
-                            # overlap is unsupported and fails loudly.
-                            # (charcoal_grill and space_heater are both heatSource + flammable.)
-                            prev_ability = states_info[state_type]["ability"]
-                            conflict = {prev_ability, ability}
-                            is_source_vs_flammable = (
-                                state_type is HeatSourceOrSink
-                                and "flammable" in conflict
-                                and bool(conflict & {"heatSource", "coldSource"})
-                            )
-                            assert is_source_vs_flammable, (
-                                f"Object {self.name}: state {state_type.__name__} is requested by multiple abilities "
-                                f"({prev_ability} and {ability}); this is not supported."
-                            )
-                            # `flammable` yields the heat source to the explicit source, whether the
-                            # explicit source was registered already or overwrites flammable below.
-                            if ability == "flammable":
-                                continue
+                        # Fail loudly instead of silently letting the last ability's params win —
+                        # a single state instance can't serve two abilities (e.g. an object that
+                        # is both a heatSource and flammable is not supported; the BDDL data
+                        # generation sanity checks enforce this at the synset level).
+                        assert state_type not in states_info, (
+                            f"Object {self.name}: state {state_type.__name__} is requested by multiple abilities "
+                            f"({states_info[state_type]['ability']} and {ability}); this is not supported."
+                        )
                         states_info[state_type] = {
                             "ability": ability,
                             "params": state_type.postprocess_ability_params(state_params, self.scene),

--- a/OmniGibson/omnigibson/objects/usd_object.py
+++ b/OmniGibson/omnigibson/objects/usd_object.py
@@ -548,11 +548,13 @@ class USDObject(EntityPrim, Registerable, metaclass=ABCMeta):
                         # Fail loudly instead of silently letting the last ability's params win —
                         # a single state instance can't serve two abilities (e.g. an object that
                         # is both a heatSource and flammable is not supported; the BDDL data
-                        # generation sanity checks enforce this at the synset level).
-                        assert state_type not in states_info, (
-                            f"Object {self.name}: state {state_type.__name__} is requested by multiple abilities "
-                            f"({states_info[state_type]['ability']} and {ability}); this is not supported."
-                        )
+                        # generation sanity checks enforce this at the synset level). Raised
+                        # unconditionally (not an assert) so python -O cannot skip it.
+                        if state_type in states_info:
+                            raise ValueError(
+                                f"Object {self.name}: state {state_type.__name__} is requested by multiple abilities "
+                                f"({states_info[state_type]['ability']} and {ability}); this is not supported."
+                            )
                         states_info[state_type] = {
                             "ability": ability,
                             "params": state_type.postprocess_ability_params(state_params, self.scene),

--- a/bddl3/bddl/data_generation/sanity_check.py
+++ b/bddl3/bddl/data_generation/sanity_check.py
@@ -55,6 +55,21 @@ def sanity_check_object_hierarchy(object_taxonomy):
                                 ), f"In ParticleModifier annotation, {condition[1]} is not a leaf substance synset."
 
 
+def sanity_check_no_flammable_heat_sources(object_taxonomy):
+    # flammable and heatSource/coldSource each require the object's single
+    # HeatSourceOrSink state in OmniGibson (flammable via OnFire's flame heat
+    # source), so no synset may be annotated with both.
+    for synset in object_taxonomy.get_descendants("entity.n.01"):
+        abilities = object_taxonomy.get_abilities(synset)
+        if "flammable" not in abilities:
+            continue
+        conflicting = {"heatSource", "coldSource"} & set(abilities)
+        assert not conflicting, (
+            f"Synset {synset} is annotated as both flammable and {sorted(conflicting)}; "
+            "these abilities conflict because both claim the object's HeatSourceOrSink state."
+        )
+
+
 def sanity_check_transition_rules(object_taxonomy):
     leaf_synsets = object_taxonomy.get_leaf_descendants("entity.n.01")
     valid_keys = set()
@@ -108,6 +123,7 @@ def sanity_check():
     # Needs to refresh to use the latest version of the taxonomy
     object_taxonomy.refresh_hierarchy_file()
     sanity_check_object_hierarchy(object_taxonomy)
+    sanity_check_no_flammable_heat_sources(object_taxonomy)
     sanity_check_transition_rules(object_taxonomy)
     sanity_check_transition_rules_washer(object_taxonomy)
 

--- a/bddl3/bddl/data_generation/sanity_check.py
+++ b/bddl3/bddl/data_generation/sanity_check.py
@@ -64,10 +64,12 @@ def sanity_check_no_flammable_heat_sources(object_taxonomy):
         if "flammable" not in abilities:
             continue
         conflicting = {"heatSource", "coldSource"} & set(abilities)
-        assert not conflicting, (
-            f"Synset {synset} is annotated as both flammable and {sorted(conflicting)}; "
-            "these abilities conflict because both claim the object's HeatSourceOrSink state."
-        )
+        # Raise instead of assert so the check also runs under python -O.
+        if conflicting:
+            raise ValueError(
+                f"Synset {synset} is annotated as both flammable and {sorted(conflicting)}; "
+                "these abilities conflict because both claim the object's HeatSourceOrSink state."
+            )
 
 
 def sanity_check_transition_rules(object_taxonomy):


### PR DESCRIPTION
After #2267 we should not let an object to have both `flammable` and `heatsourceorsink`. Add checks. The synset google sheet are also modified.