### PR TITLE
Parallel eval

### DIFF
--- a/OmniGibson/omnigibson/envs/env_base.py
+++ b/OmniGibson/omnigibson/envs/env_base.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from collections.abc import Iterable
 from copy import deepcopy
+import os
 
 import gymnasium as gym
 import torch as th
@@ -496,13 +497,17 @@ class Environment(gym.Env, GymObservable, Recreatable):
         # Build sensor registry for get_obs()
         self._build_sensor_registry()
 
-        # Robot camera observations come from the tiled render product in multi-env mode, so hide the
-        # per-sensor viewports (their individual render products are unused for obs).
-        if self._tiled_sensor is not None:
-            for sensors in self._robot_sensor_map.values():
-                for sensor in sensors:
-                    if isinstance(sensor, VisionSensor):
-                        sensor.viewer_visibility = False
+        # Robot camera observations come from the tiled render product in multi-env mode. Pause the
+        # individual render products: hiding their UI viewports is a no-op in headless mode and leaves
+        # those unused products rendering every frame alongside the tiled product.
+        keep_individual_render_products = os.getenv("OMNIGIBSON_KEEP_INDIVIDUAL_RENDER_PRODUCTS", "0") == "1"
+        if self._tiled_sensor is not None and not keep_individual_render_products:
+            with og.sim.editing_usd():
+                for sensors in self._robot_sensor_map.values():
+                    for sensor in sensors:
+                        if isinstance(sensor, VisionSensor):
+                            sensor.viewer_visibility = False
+                            sensor.render_product.hydra_texture.updates_enabled = False
 
         self.reset()
 
@@ -708,7 +713,7 @@ class Environment(gym.Env, GymObservable, Recreatable):
             return action
         return action
 
-    def step(self, action, n_render_iterations=1, render=True):
+    def step(self, action, n_render_iterations=1):
         """
         Apply robot's action and return the next state, reward, done and info,
         following OpenAI Gym's convention
@@ -719,13 +724,6 @@ class Environment(gym.Env, GymObservable, Recreatable):
                 concatenated set of actions. For multi-env, should be (num_envs, action_dim) shaped for tensors,
                 or a list of dicts (one per env) for dict actions.
             n_render_iterations (int): Number of rendering iterations to use before returning observations
-            render (bool): If False, step physics (and non-physics/object-state updates) WITHOUT rendering
-                the cameras this step. Vision sensors keep their previous frame, so callers must be reusing
-                stale image observations (e.g. mid action-chunk, when the policy is replaying and not looking
-                at fresh pixels). Proprioception is still fresh (it comes from physics, not rendering).
-                Rendering is the dominant per-step cost, so skipping it on non-observation steps is the main
-                eval speedup. Default True (unchanged behavior).
-
         Returns:
             5-tuple:
                 - list[dict]: states, i.e. next observations per env
@@ -759,17 +757,11 @@ class Environment(gym.Env, GymObservable, Recreatable):
                     robot.apply_action(action_dict[robot.name])
 
         # Step simulation
-        if render:
-            og.sim.step()
+        og.sim.step()
 
-            # Render any additional times requested
-            for _ in range(n_render_iterations - 1):
-                og.sim.render()
-        else:
-            # Skip rendering this step: physics + non-physics/object-state updates only. The cameras
-            # retain their last rendered frame, so downstream obs will carry stale images.
-            with og.sim.render_on_step(False):
-                og.sim.step()
+        # Render any additional times requested
+        for _ in range(n_render_iterations - 1):
+            og.sim.render()
 
         # Grab observations
         obs_list, obs_info_list = self.get_obs()

--- a/OmniGibson/omnigibson/envs/env_base.py
+++ b/OmniGibson/omnigibson/envs/env_base.py
@@ -708,7 +708,7 @@ class Environment(gym.Env, GymObservable, Recreatable):
             return action
         return action
 
-    def step(self, action, n_render_iterations=1):
+    def step(self, action, n_render_iterations=1, render=True):
         """
         Apply robot's action and return the next state, reward, done and info,
         following OpenAI Gym's convention
@@ -719,6 +719,12 @@ class Environment(gym.Env, GymObservable, Recreatable):
                 concatenated set of actions. For multi-env, should be (num_envs, action_dim) shaped for tensors,
                 or a list of dicts (one per env) for dict actions.
             n_render_iterations (int): Number of rendering iterations to use before returning observations
+            render (bool): If False, step physics (and non-physics/object-state updates) WITHOUT rendering
+                the cameras this step. Vision sensors keep their previous frame, so callers must be reusing
+                stale image observations (e.g. mid action-chunk, when the policy is replaying and not looking
+                at fresh pixels). Proprioception is still fresh (it comes from physics, not rendering).
+                Rendering is the dominant per-step cost, so skipping it on non-observation steps is the main
+                eval speedup. Default True (unchanged behavior).
 
         Returns:
             5-tuple:
@@ -753,11 +759,17 @@ class Environment(gym.Env, GymObservable, Recreatable):
                     robot.apply_action(action_dict[robot.name])
 
         # Step simulation
-        og.sim.step()
+        if render:
+            og.sim.step()
 
-        # Render any additional times requested
-        for _ in range(n_render_iterations - 1):
-            og.sim.render()
+            # Render any additional times requested
+            for _ in range(n_render_iterations - 1):
+                og.sim.render()
+        else:
+            # Skip rendering this step: physics + non-physics/object-state updates only. The cameras
+            # retain their last rendered frame, so downstream obs will carry stale images.
+            with og.sim.render_on_step(False):
+                og.sim.step()
 
         # Grab observations
         obs_list, obs_info_list = self.get_obs()

--- a/OmniGibson/omnigibson/envs/env_wrapper.py
+++ b/OmniGibson/omnigibson/envs/env_wrapper.py
@@ -46,13 +46,15 @@ class EnvironmentWrapper(Wrapper, Registerable):
         # Run super
         super().__init__(obj=env)
 
-    def step(self, action, n_render_iterations=1):
+    def step(self, action, n_render_iterations=1, render=True):
         """
         By default, run the normal environment step() function
 
         Args:
             action (th.tensor): action to take in environment
             n_render_iterations (int): Number of rendering iterations to use before returning observations
+            render (bool): If False, step physics without rendering the cameras this step (see
+                Environment.step). Forwarded to the wrapped environment.
 
         Returns:
             4-tuple:
@@ -62,7 +64,7 @@ class EnvironmentWrapper(Wrapper, Registerable):
                 - (bool) whether the current episode is truncated
                 - (dict) misc information
         """
-        return self.env.step(action, n_render_iterations=n_render_iterations)
+        return self.env.step(action, n_render_iterations=n_render_iterations, render=render)
 
     def reset(self, **kwargs):
         """

--- a/OmniGibson/omnigibson/envs/env_wrapper.py
+++ b/OmniGibson/omnigibson/envs/env_wrapper.py
@@ -64,14 +64,16 @@ class EnvironmentWrapper(Wrapper, Registerable):
         """
         return self.env.step(action, n_render_iterations=n_render_iterations)
 
-    def reset(self):
+    def reset(self, **kwargs):
         """
-        By default, run the normal environment reset() function
+        By default, run the normal environment reset() function. Keyword arguments (e.g. ``env_indices``
+        for vectorized per-env reset, ``seed``, ``options``) are forwarded to the wrapped environment so
+        the wrapper stays transparent to reset.
 
         Returns:
             dict: Environment observation space after reset occurs
         """
-        return self.env.reset()
+        return self.env.reset(**kwargs)
 
     def observation_spec(self):
         """

--- a/OmniGibson/omnigibson/envs/env_wrapper.py
+++ b/OmniGibson/omnigibson/envs/env_wrapper.py
@@ -46,16 +46,13 @@ class EnvironmentWrapper(Wrapper, Registerable):
         # Run super
         super().__init__(obj=env)
 
-    def step(self, action, n_render_iterations=1, render=True):
+    def step(self, action, n_render_iterations=1):
         """
         By default, run the normal environment step() function
 
         Args:
             action (th.tensor): action to take in environment
             n_render_iterations (int): Number of rendering iterations to use before returning observations
-            render (bool): If False, step physics without rendering the cameras this step (see
-                Environment.step). Forwarded to the wrapped environment.
-
         Returns:
             4-tuple:
                 - (dict) observations from the environment
@@ -64,7 +61,7 @@ class EnvironmentWrapper(Wrapper, Registerable):
                 - (bool) whether the current episode is truncated
                 - (dict) misc information
         """
-        return self.env.step(action, n_render_iterations=n_render_iterations, render=render)
+        return self.env.step(action, n_render_iterations=n_render_iterations)
 
     def reset(self, **kwargs):
         """

--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -71,6 +71,17 @@ def parse_args() -> argparse.Namespace:
         help="Number of parallel env slots; instances are evaluated this many at a time.",
     )
     parser.add_argument(
+        "--render-every",
+        type=int,
+        default=1,
+        help=(
+            "Render (and feed the policy fresh camera images) every N steps; step physics-only in "
+            "between. Set to the policy's action horizon K for chunked policies (skip-render mode) to "
+            "skip drawing on steps the policy replays. 1 = render every step (for policies that look "
+            "every step, e.g. temporal_ensemble). Ignored while writing video."
+        ),
+    )
+    parser.add_argument(
         "--max-steps",
         type=int,
         default=None,
@@ -142,6 +153,7 @@ def main() -> None:
             "mode": args.mode,
             "seed": seed,
             "num_envs": args.num_envs,
+            "render_every": args.render_every,
             "task": {"name": args.task_name},
             "robot": robot_config,
         }

--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -17,7 +17,6 @@ Example:
 """
 
 import argparse
-import json
 import logging
 import os
 from pathlib import Path
@@ -65,6 +64,12 @@ def parse_args() -> argparse.Namespace:
         help="Instance split to evaluate. Default: public_test.",
     )
     parser.add_argument("--num-rollouts", type=int, default=1, help="Rollouts per instance.")
+    parser.add_argument(
+        "--num-envs",
+        type=int,
+        default=1,
+        help="Number of parallel env slots; instances are evaluated this many at a time.",
+    )
     parser.add_argument(
         "--max-steps",
         type=int,
@@ -136,6 +141,7 @@ def main() -> None:
             "write_video": args.write_video,
             "mode": args.mode,
             "seed": seed,
+            "num_envs": args.num_envs,
             "task": {"name": args.task_name},
             "robot": robot_config,
         }
@@ -149,54 +155,18 @@ def main() -> None:
 
     results = []
     with Evaluator(cfg) as evaluator:
-        for instance_id in instance_ids:
-            try:
-                evaluator.reset()
-                evaluator.load_task_instance(int(instance_id))
-            except Exception:
-                logger.exception(f"Failed to load task instance {instance_id}.")
-                raise
-            for rollout_id in range(args.num_rollouts):
-                video_path = os.path.join(video_dir, f"{args.task_name}_{instance_id}_{rollout_id}.mp4")
-                try:
-                    evaluator.reset()
-                    if args.write_video:
-                        evaluator.start_recording(video_path, rate=args.video_fps)
-                    terminated = truncated = False
-                    steps = 0
-                    while not (terminated or truncated):
-                        terminated, truncated = evaluator.step()
-                        steps += 1
-
-                    success = bool(evaluator.env.task.success)
-                    metrics = {}
-                    for metric in evaluator.metrics:
-                        metrics.update(metric.aggregate(evaluator.env))
-
-                    result = {
-                        "task": args.task_name,
-                        "instance_id": int(instance_id),
-                        "rollout_id": rollout_id,
-                        "steps": steps,
-                        "success": success,
-                        **metrics,
-                    }
-                    out_path = os.path.join(json_dir, f"{args.task_name}_{instance_id}_{rollout_id}.json")
-                    with open(out_path, "w") as f:
-                        json.dump(result, f, indent=2, default=float)
-                    q_score = metrics.get("q_score", {}).get("final")
-                    video_msg = f" | video -> {video_path}" if args.write_video else ""
-                    logger.info(
-                        f"Result: instance={instance_id} rollout={rollout_id} steps={steps} "
-                        f"success={success} q_score={q_score} -> {out_path}{video_msg}"
-                    )
-                    results.append(result)
-                except Exception:
-                    logger.exception(f"Instance {instance_id} rollout {rollout_id} failed.")
-                    raise
-                finally:
-                    if args.write_video:
-                        evaluator.stop_recording()
+        # Each run() pass evaluates every instance once, num_envs at a time (the slot batching lives in
+        # evaluator.run -> evaluate_instances_batched). Outer loop repeats for additional rollouts.
+        for rollout_id in range(args.num_rollouts):
+            rollout_results = evaluator.run(
+                [int(i) for i in instance_ids],
+                write_video=args.write_video,
+                video_path=video_dir,
+                metrics_dir=json_dir,
+                rollout_id=rollout_id,
+                video_fps=args.video_fps,
+            )
+            results.extend(rollout_results.values())
 
     n = len(results)
     n_success = sum(r["success"] for r in results)

--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -71,14 +71,12 @@ def parse_args() -> argparse.Namespace:
         help="Number of parallel env slots; instances are evaluated this many at a time.",
     )
     parser.add_argument(
-        "--render-every",
+        "--replay-action-chunk-size",
         type=int,
-        default=1,
+        default=0,
         help=(
-            "Render (and feed the policy fresh camera images) every N steps; step physics-only in "
-            "between. Set to the policy's action horizon K for chunked policies (skip-render mode) to "
-            "skip drawing on steps the policy replays. 1 = render every step (for policies that look "
-            "every step, e.g. temporal_ensemble). Ignored while writing video."
+            "Opt in to exact client-side replay of a complete server-returned action chunk. "
+            "Use the receding-horizon length (for example 16); 0 keeps one websocket request per step."
         ),
     )
     parser.add_argument(
@@ -119,6 +117,12 @@ def main() -> None:
     args = parse_args()
 
     gm.HEADLESS = args.headless
+    # Headless evaluation consumes robot-camera observations through VisionSensor / TiledVisionSensor render
+    # products, not the separate 1280x720 debug viewport. Avoid constructing that unused viewer product: at
+    # N=10 it accounts for two of five RTX tile passes while policy camera shapes and traces remain unchanged.
+    # The environment override restores the old path only for controlled performance A/B runs.
+    if args.headless and os.getenv("OMNIGIBSON_KEEP_VIEWER_CAMERA", "0") != "1":
+        gm.RENDER_VIEWER_CAMERA = False
 
     seed = seed_everything(DEFAULT_EVAL_SEED)
     logger.info(f"Seeded Python, NumPy, and Torch with seed={seed}")
@@ -137,6 +141,7 @@ def main() -> None:
             "_target_": "omnigibson.eval.policies.WebsocketPolicy",
             "host": args.host,
             "port": args.port,
+            "action_chunk_size": args.replay_action_chunk_size,
         }
     else:
         model_cfg = {"_target_": "omnigibson.eval.policies.LocalPolicy", "action_dim": None}
@@ -153,7 +158,6 @@ def main() -> None:
             "mode": args.mode,
             "seed": seed,
             "num_envs": args.num_envs,
-            "render_every": args.render_every,
             "task": {"name": args.task_name},
             "robot": robot_config,
         }

--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -68,7 +68,7 @@ def parse_args() -> argparse.Namespace:
         "--num-envs",
         type=int,
         default=1,
-        help="Number of parallel env slots; instances are evaluated this many at a time.",
+        help="Number of parallel env slots. Must equal the number of selected instance indices.",
     )
     parser.add_argument(
         "--replay-action-chunk-size",
@@ -129,6 +129,11 @@ def main() -> None:
 
     instance_ids = resolve_instance_ids(args.task_name, args.instance_indices, mode=args.mode)
     logger.info(f"Resolved {args.mode} instance ids for {args.task_name}: {instance_ids}")
+    if len(instance_ids) != args.num_envs:
+        raise ValueError(
+            "Evaluation requires exactly one instance per environment slot: "
+            f"got {len(instance_ids)} instance indices and --num-envs={args.num_envs}."
+        )
 
     robot_config = None
     if args.robot_config is not None:
@@ -171,8 +176,8 @@ def main() -> None:
 
     results = []
     with Evaluator(cfg) as evaluator:
-        # Each run() pass evaluates every instance once, num_envs at a time (the slot batching lives in
-        # evaluator.run -> evaluate_instances_batched). Outer loop repeats for additional rollouts.
+        # Each run() pass evaluates the selected instances together in one parallel batch. The outer
+        # loop repeats that same batch for additional rollouts.
         for rollout_id in range(args.num_rollouts):
             rollout_results = evaluator.run(
                 [int(i) for i in instance_ids],

--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -1,6 +1,6 @@
 """Websocket evaluation runner for the BEHAVIOR-1K challenge.
 
-Drives the OmniGibson ``Evaluator`` against a policy served over a websocket
+Drives the OmniGibson ``BatchedEvaluator`` against a policy served over a websocket
 (e.g. the openpi or GR00T ``scripts/b1k/serve_b1k.py`` server). For each test instance of a
 task it runs a rollout and writes a per-rollout result JSON compatible with
 ``omnigibson/eval/utils/score_utils.py`` (``q_score``, ``time``,
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from omegaconf import OmegaConf
 
-from omnigibson.eval.evaluator import Evaluator, resolve_instance_ids
+from omnigibson.eval.evaluator import BatchedEvaluator, resolve_instance_ids
 from omnigibson.eval.utils.eval_utils import DEFAULT_EVAL_SEED, seed_everything
 from omnigibson.macros import gm
 from omnigibson.utils.ui_utils import create_module_logger
@@ -68,7 +68,7 @@ def parse_args() -> argparse.Namespace:
         "--num-envs",
         type=int,
         default=1,
-        help="Number of parallel env slots. Must equal the number of selected instance indices.",
+        help="Number of logical environments in the evaluation batch. Must equal the number of instance indices.",
     )
     parser.add_argument(
         "--replay-action-chunk-size",
@@ -131,7 +131,7 @@ def main() -> None:
     logger.info(f"Resolved {args.mode} instance ids for {args.task_name}: {instance_ids}")
     if len(instance_ids) != args.num_envs:
         raise ValueError(
-            "Evaluation requires exactly one instance per environment slot: "
+            "Evaluation requires exactly one instance per logical environment: "
             f"got {len(instance_ids)} instance indices and --num-envs={args.num_envs}."
         )
 
@@ -175,7 +175,7 @@ def main() -> None:
         os.makedirs(video_dir, exist_ok=True)
 
     results = []
-    with Evaluator(cfg) as evaluator:
+    with BatchedEvaluator(cfg) as evaluator:
         # Each run() pass evaluates the selected instances together in one parallel batch. The outer
         # loop repeats that same batch for additional rollouts.
         for rollout_id in range(args.num_rollouts):

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -166,11 +166,17 @@ class Evaluator:
         self.robot_camera_names = get_robot_camera_names(self.robots[0].name, self.robot_eval_config)
         self._validate_robot_eval_config()
         self._apply_robot_eval_settings()
-        self.policies = self.load_policies()
+        self.policy = self.load_policy()
         self.metrics = self.load_metrics()
         self.obs = [None] * self.num_envs
         self._video_writers = [None] * self.num_envs
         self.light_synchronizers = [None] * self.num_envs
+        # Render cadence. Render (and feed the policy fresh camera images) every ``render_every`` steps;
+        # step physics-only in between, reusing the last frame -- valid because a chunked policy replays
+        # its plan and only looks at images when it re-infers (every K steps). 1 = render every step
+        # (safe default / policies that look every step). Rendering is the dominant per-step cost.
+        self.render_every = max(1, int(cfg.get("render_every", 1)))
+        self._rollout_step = 0
 
         # Initialize the physics views so the first reset()/load can read/restore robot joint state.
         og.sim.update_handles()
@@ -308,20 +314,19 @@ class Evaluator:
                 if head_sensor_name in robot.sensors:
                     robot.sensors[head_sensor_name].horizontal_aperture = EVAL_HEAD_HORIZONTAL_APERTURE
 
-    def load_policies(self) -> List[Any]:
-        # One independent (possibly stateful) policy instance per env slot.
-        policies = []
-        for _ in range(self.num_envs):
-            policy = instantiate(self.cfg.model)
-            if hasattr(policy, "set_action_dim"):
-                policy.set_action_dim(self.robots[0].action_dim)
-            policies.append(policy)
+    def load_policy(self) -> Any:
+        # A SINGLE policy that serves all env slots in one batched call (num_envs robots at once),
+        # instead of one policy per slot. The policy accepts a batched obs (leading num_envs dim) and
+        # returns batched actions; it keeps per-env internal state indexed by position.
+        policy = instantiate(self.cfg.model)
+        if hasattr(policy, "set_action_dim"):
+            policy.set_action_dim(self.robots[0].action_dim)
         logger.info("")
         logger.info("=" * 50)
-        logger.info(f"Loaded {self.num_envs} policy instance(s): {self.cfg.policy_name}")
+        logger.info(f"Loaded {self.num_envs} policy instance(s) (batched): {self.cfg.policy_name}")
         logger.info("=" * 50)
         logger.info("")
-        return policies
+        return policy
 
     def load_metrics(self) -> List[List[MetricBase]]:
         return [
@@ -329,15 +334,16 @@ class Evaluator:
             for i in range(self.num_envs)
         ]
 
-    def _apply_actions(self, actions: th.Tensor, active_slots: List[int]):
+    def _apply_actions(self, actions: th.Tensor, active_slots: List[int], render: bool = True):
         """
         Step all env slots one step with the given ``(num_envs, action_dim)`` actions, then update the
         observations and metrics for the @active_slots only (frozen slots are still stepped by the
-        shared simulator but their obs/metrics are not advanced). Returns ``(terminated, truncated,
-        info)`` straight from the env (``terminated``/``truncated`` are ``(num_envs,)`` tensors, ``info``
-        a per-slot list).
+        shared simulator but their obs/metrics are not advanced). If ``render`` is False, physics steps
+        without drawing the cameras (images stay stale, proprio is still fresh) -- the render cadence
+        uses this to skip drawing on steps the policy is not looking. Returns ``(terminated, truncated,
+        info)`` straight from the env.
         """
-        obs_list, _, terminated, truncated, info = self.env.step(actions, n_render_iterations=1)
+        obs_list, _, terminated, truncated, info = self.env.step(actions, n_render_iterations=1, render=render)
         if self.should_sync_lights:
             # Re-derive visual light state (toggles drive lights that aren't directly serialized) for
             # the active slots, then re-read obs so the recorded frame matches the synced lights.
@@ -361,16 +367,33 @@ class Evaluator:
                 )
         return terminated, truncated, info
 
+    def _batch_obs(self) -> dict:
+        """
+        Stack every env slot's preprocessed obs into one ``(num_envs, ...)`` batch for a SINGLE policy
+        call. All slots share the same keys. Frozen/finished slots keep their last obs and ride along so
+        the batch size stays ``num_envs`` (the policy indexes its per-env buffers by position).
+        """
+        keys = self.obs[0].keys()
+        return {k: th.stack([self.obs[slot][k] for slot in range(self.num_envs)], dim=0) for k in keys}
+
     def _step_fn(self, active_slots: List[int]) -> Tuple[th.Tensor, th.Tensor]:
         """
-        ``step_fn`` consumed by :func:`evaluate_instances_batched`: drive active slots with their own
-        policies (frozen slots get a zero action but are still stepped by the shared simulator).
+        ``step_fn`` consumed by :func:`evaluate_instances_batched`: query the policy ONCE with all env
+        slots batched together, then step. Renders only every ``render_every`` steps (physics-only in
+        between). Frozen slots get a zero action but are still stepped by the shared simulator.
         """
         action_dim = self.robots[0].action_dim
+        batched_action = self.policy.forward(obs=self._batch_obs())  # (num_envs, action_dim)
+        if batched_action.ndim == 1:
+            batched_action = batched_action.unsqueeze(0)
         actions = th.zeros((self.num_envs, action_dim), dtype=th.float32)
         for slot in active_slots:
-            actions[slot] = self.policies[slot].forward(obs=self.obs[slot])
-        terminated, truncated, _ = self._apply_actions(actions, active_slots)
+            actions[slot] = batched_action[slot].to(actions.dtype)
+        # Render on the step whose fresh obs the NEXT policy query will consume, so re-inference steps
+        # get fresh images. render_every == 1 => render every step (unchanged behavior).
+        render = ((self._rollout_step + 1) % self.render_every) == 0
+        terminated, truncated, _ = self._apply_actions(actions, active_slots, render=render)
+        self._rollout_step += 1
         return terminated, truncated
 
     def _set_video_writer(self, env_idx: int, video_writer) -> None:
@@ -494,9 +517,12 @@ class Evaluator:
                 og.sim.render()
             obs_list, _ = self.env.get_obs(env_indices=th.tensor(ordered_slots, dtype=th.long))
         task_name = self.cfg.task.name
+        # One batched policy for all slots: reset its per-env state once, and restart the render-cadence
+        # counter for this group (the step-0 obs below is freshly rendered by env.reset above).
+        self.policy.reset()
+        self._rollout_step = 0
         for i, slot in enumerate(ordered_slots):
             self.obs[slot] = self._preprocess_obs(obs_list[i], env_idx=slot)
-            self.policies[slot].reset()
             for metric in self.metrics[slot]:
                 metric.reset(self.env)
             if write_video:
@@ -562,11 +588,12 @@ class Evaluator:
             for _ in range(3):
                 og.sim.render()
             obs_list, _ = self.env.get_obs()
+        self.policy.reset()
+        self._rollout_step = 0
         for env_idx in range(self.num_envs):
             self.obs[env_idx] = self._preprocess_obs(obs_list[env_idx], env_idx=env_idx)
             for metric in self.metrics[env_idx]:
                 metric.reset(self.env)
-            self.policies[env_idx].reset()
         self.n_success_trials, self.n_trials = 0, 0
 
     def run(
@@ -623,13 +650,20 @@ class Evaluator:
             )
             return result
 
-        return evaluate_instances_batched(
-            list(instances_to_run),
-            self.num_envs,
-            load_fn=load_fn,
-            step_fn=step_fn,
-            record_fn=record_fn,
-        )
+        # Video needs a rendered frame every step, so disable render-skipping while recording.
+        saved_render_every = self.render_every
+        if write_video:
+            self.render_every = 1
+        try:
+            return evaluate_instances_batched(
+                list(instances_to_run),
+                self.num_envs,
+                load_fn=load_fn,
+                step_fn=step_fn,
+                record_fn=record_fn,
+            )
+        finally:
+            self.render_every = saved_render_every
 
     def __enter__(self):
         signal(SIGINT, self._sigint_handler)

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -90,45 +90,45 @@ def evaluate_instances_batched(
     max_steps: Optional[int] = None,
 ) -> "Dict[object, object]":
     """
-    Drive evaluation of @instances in groups of @num_envs. Pure orchestration: all sim work is
-    delegated to the injected load_fn / step_fn / record_fn, and a slot that finishes early is dropped
-    from the active list (frozen) until the whole group is done -- loading an instance settles physics
-    for ALL scenes at once, so refilling one slot mid-group would disturb the slots still running.
-    Returns {instance id -> record_fn's return}.
+    Drive one parallel evaluation batch with exactly one instance per environment slot. Pure
+    orchestration: all sim work is delegated to the injected load_fn / step_fn / record_fn, and a slot
+    that finishes early is dropped from the active list (frozen) until the whole batch is done. Returns
+    {instance id -> record_fn's return}.
     """
     if num_envs < 1:
         raise ValueError(f"num_envs must be >= 1, got {num_envs}")
 
+    instances = list(instances)
+    if len(instances) != num_envs:
+        raise ValueError(
+            f"Evaluation requires exactly one instance per environment slot: "
+            f"got {len(instances)} instances and num_envs={num_envs}."
+        )
+
     results: Dict[object, object] = {}
-    pending = list(instances)
+    slot_to_instance: Dict[int, object] = {slot: inst for slot, inst in enumerate(instances)}
+    load_fn(dict(slot_to_instance))
 
-    while pending:
-        batch = pending[:num_envs]
-        pending = pending[num_envs:]
+    active = {slot: True for slot in slot_to_instance}
+    step = 0
+    while any(active.values()):
+        active_slots = sorted(slot for slot, is_active in active.items() if is_active)
+        terminated, truncated = step_fn(active_slots)
+        step += 1
 
-        slot_to_instance: Dict[int, object] = {slot: inst for slot, inst in enumerate(batch)}
-        load_fn(dict(slot_to_instance))
-
-        active = {slot: True for slot in slot_to_instance}
-        step = 0
-        while any(active.values()):
-            active_slots = sorted(slot for slot, is_active in active.items() if is_active)
-            terminated, truncated = step_fn(active_slots)
-            step += 1
-
-            hit_cap = max_steps is not None and step >= max_steps
-            for slot in active_slots:
-                term = bool(terminated[slot])
-                trunc = bool(truncated[slot]) or hit_cap
-                if term or trunc:
-                    results[slot_to_instance[slot]] = record_fn(
-                        slot=slot,
-                        instance=slot_to_instance[slot],
-                        step=step,
-                        terminated=term,
-                        truncated=trunc,
-                    )
-                    active[slot] = False
+        hit_cap = max_steps is not None and step >= max_steps
+        for slot in active_slots:
+            term = bool(terminated[slot])
+            trunc = bool(truncated[slot]) or hit_cap
+            if term or trunc:
+                results[slot_to_instance[slot]] = record_fn(
+                    slot=slot,
+                    instance=slot_to_instance[slot],
+                    step=step,
+                    terminated=term,
+                    truncated=trunc,
+                )
+                active[slot] = False
 
     return results
 
@@ -586,11 +586,10 @@ class Evaluator:
         video_fps: int = 30,
     ) -> dict:
         """
-        Offline driver: evaluate every instance in @instances_to_run, processing them ``num_envs`` at a
-        time. The whole group finishes before the next group loads, and an early-finishing slot waits
-        idle rather than getting a new instance. Writes one result JSON per instance to @metrics_dir if
-        given. Returns {instance id -> result dict} (result is score_utils-compatible: q_score/time/
-        agent_distance plus task/instance/success/steps).
+        Offline driver for one batch containing exactly ``num_envs`` instances. An early-finishing slot
+        waits idle rather than getting a new instance. Writes one result JSON per instance to
+        @metrics_dir if given. Returns {instance id -> result dict} (result is score_utils-compatible:
+        q_score/time/agent_distance plus task/instance/success/steps).
         """
         task_name = self.cfg.task.name
 

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import traceback
+from dataclasses import dataclass, field
 from signal import SIGINT, signal
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -90,10 +91,10 @@ def evaluate_instances_batched(
     max_steps: Optional[int] = None,
 ) -> "Dict[object, object]":
     """
-    Drive one parallel evaluation batch with exactly one instance per environment slot. Pure
-    orchestration: all sim work is delegated to the injected load_fn / step_fn / record_fn, and a slot
-    that finishes early is dropped from the active list (frozen) until the whole batch is done. Returns
-    {instance id -> record_fn's return}.
+    Drive one parallel evaluation batch with exactly one instance per logical environment. Pure
+    orchestration: all sim work is delegated to the injected load_fn / step_fn / record_fn. When an
+    instance finishes, its environment is removed from the active list and remains frozen until the
+    complete batch finishes. Returns {instance id -> record_fn's return}.
     """
     if num_envs < 1:
         raise ValueError(f"num_envs must be >= 1, got {num_envs}")
@@ -101,45 +102,90 @@ def evaluate_instances_batched(
     instances = list(instances)
     if len(instances) != num_envs:
         raise ValueError(
-            f"Evaluation requires exactly one instance per environment slot: "
+            f"Evaluation requires exactly one instance per logical environment: "
             f"got {len(instances)} instances and num_envs={num_envs}."
         )
 
     results: Dict[object, object] = {}
-    slot_to_instance: Dict[int, object] = {slot: inst for slot, inst in enumerate(instances)}
-    load_fn(dict(slot_to_instance))
+    env_idx_to_instance: Dict[int, object] = {env_idx: instance for env_idx, instance in enumerate(instances)}
+    load_fn(dict(env_idx_to_instance))
 
-    active = {slot: True for slot in slot_to_instance}
+    active = {env_idx: True for env_idx in env_idx_to_instance}
     step = 0
     while any(active.values()):
-        active_slots = sorted(slot for slot, is_active in active.items() if is_active)
-        terminated, truncated = step_fn(active_slots)
+        active_env_indices = sorted(env_idx for env_idx, is_active in active.items() if is_active)
+        terminated, truncated = step_fn(active_env_indices)
         step += 1
 
         hit_cap = max_steps is not None and step >= max_steps
-        for slot in active_slots:
-            term = bool(terminated[slot])
-            trunc = bool(truncated[slot]) or hit_cap
+        for env_idx in active_env_indices:
+            term = bool(terminated[env_idx])
+            trunc = bool(truncated[env_idx]) or hit_cap
             if term or trunc:
-                results[slot_to_instance[slot]] = record_fn(
-                    slot=slot,
-                    instance=slot_to_instance[slot],
+                results[env_idx_to_instance[env_idx]] = record_fn(
+                    env_idx=env_idx,
+                    instance=env_idx_to_instance[env_idx],
                     step=step,
                     terminated=term,
                     truncated=trunc,
                 )
-                active[slot] = False
+                active[env_idx] = False
 
     return results
 
 
-class Evaluator:
+@dataclass(frozen=True)
+class InstanceEnvAccessor:
+    """Read-only access to one logical environment inside a shared vectorized environment."""
+
+    shared_env: EnvironmentWrapper
+    env_idx: int
+
+    @property
+    def scene(self):
+        return self.shared_env.scenes[self.env_idx]
+
+    @property
+    def robot(self) -> Robot:
+        robots = self.scene.robots
+        assert len(robots) == 1, f"Evaluation assumes one robot per environment, got {len(robots)}."
+        return robots[0]
+
+    @property
+    def object_scope(self):
+        return self.shared_env.task.object_scope[self.env_idx]
+
+    @property
+    def success(self) -> bool:
+        return bool(self.shared_env.task.success[self.env_idx])
+
+    def get_goal_option_satisfaction(self):
+        return self.shared_env.task.get_goal_option_satisfaction(self.env_idx)
+
+
+@dataclass
+class InstanceEvaluationState:
+    """Mutable rollout state for one task instance assigned to one logical environment."""
+
+    env_accessor: InstanceEnvAccessor
+    metrics: List[MetricBase] = field(default_factory=list)
+    instance_id: Optional[int] = None
+    obs: Optional[dict] = None
+    video_writer: Any = None
+    light_synchronizer: Optional[LightToggleSynchronizer] = None
+    active: bool = False
+
+    @property
+    def env_idx(self) -> int:
+        return self.env_accessor.env_idx
+
+
+class BatchedEvaluator:
     """
-    Vectorized evaluator engine for BEHAVIOR tasks. Holds a single OmniGibson environment with
-    ``num_envs`` parallel scene slots (one task instance per slot) and per-slot robots, policies,
-    metrics, observations and video writers (index everything by ``env_idx``). ``num_envs=1``
-    reproduces single-env evaluation. All sim interaction lives here; the offline driver (:meth:`run`)
-    is a thin layer on top of :func:`evaluate_instances_batched`.
+    Batched evaluator engine for BEHAVIOR tasks. Owns one shared vectorized OmniGibson environment and
+    one batched policy. Each batch entry is represented by an :class:`InstanceEvaluationState`,
+    which binds one task instance to one logical environment through an
+    :class:`InstanceEnvAccessor`. ``num_envs=1`` reproduces single-environment evaluation.
     """
 
     def __init__(self, cfg: DictConfig) -> None:
@@ -152,25 +198,24 @@ class Evaluator:
         self.robot_eval_config = {}
         self.robot_camera_names = {}
 
-        # Number of parallel env slots (instances evaluated concurrently). Defaults to 1.
+        # Number of logical environments evaluated concurrently. Defaults to 1.
         self.num_envs = int(cfg.get("num_envs", 1))
         self.env = self.load_env(env_wrapper=self.cfg.env_wrapper)
         assert (
             self.env.num_envs == self.num_envs
-        ), f"Env created with num_envs={self.env.num_envs} but Evaluator expected {self.num_envs}."
+        ), f"Env created with num_envs={self.env.num_envs} but BatchedEvaluator expected {self.num_envs}."
 
-        # Per-slot robots / policies / metrics / observations / video writers / light synchronizers.
-        self.robots = self.load_robots()
-        # All slots share the same robot config, so resolve eval camera names once (from slot 0) and
+        self.instance_eval_states = self._create_instance_eval_states()
+        # All environments share the same robot config, so resolve eval camera names once and
         # validate that the configured camera sensors exist on the robot.
-        self.robot_camera_names = get_robot_camera_names(self.robots[0].name, self.robot_eval_config)
+        self.robot_camera_names = get_robot_camera_names(
+            self.instance_eval_states[0].env_accessor.robot.name, self.robot_eval_config
+        )
         self._validate_robot_eval_config()
         self._apply_robot_eval_settings()
         self.policy = self.load_policy()
-        self.metrics = self.load_metrics()
-        self.obs = [None] * self.num_envs
-        self._video_writers = [None] * self.num_envs
-        self.light_synchronizers = [None] * self.num_envs
+        for instance_eval_state in self.instance_eval_states:
+            instance_eval_state.metrics = self.load_metrics(instance_eval_state.env_accessor)
 
         # Initialize the physics views so the first reset()/load can read/restore robot joint state.
         og.sim.update_handles()
@@ -180,13 +225,13 @@ class Evaluator:
     def should_sync_lights(self) -> bool:
         return self.env.task.activity_name in LIGHT_EVAL_TASKS
 
-    def _reset_light_synchronizer(self, env_idx: int) -> None:
+    def _reset_light_synchronizer(self, instance_eval_state: InstanceEvaluationState) -> None:
         if self.should_sync_lights:
-            synchronizer = LightToggleSynchronizer(self.env.scenes[env_idx])
+            synchronizer = LightToggleSynchronizer(instance_eval_state.env_accessor.scene)
             synchronizer.reset_from_current_state()
-            self.light_synchronizers[env_idx] = synchronizer
+            instance_eval_state.light_synchronizer = synchronizer
         else:
-            self.light_synchronizers[env_idx] = None
+            instance_eval_state.light_synchronizer = None
 
     def load_env(self, env_wrapper: DictConfig) -> EnvironmentWrapper:
         for rule in DISABLED_TRANSITION_RULES:
@@ -238,7 +283,7 @@ class Evaluator:
             cfg["task"]["termination_config"]["max_steps"] = self.cfg.max_steps
         cfg["task"]["include_obs"] = False
 
-        # Run num_envs instances of the same scene model + task in parallel slots.
+        # Run num_envs instances of the same scene model + task in parallel environments.
         cfg.setdefault("env", {})
         cfg["env"]["num_envs"] = self.num_envs
 
@@ -246,19 +291,17 @@ class Evaluator:
         env._eval_robot_config = self.robot_eval_config
         return instantiate(env_wrapper, env=env)
 
-    def load_robots(self) -> List[Robot]:
-        # env.robots is list[list[Robot]] (one inner list per scene). The eval pipeline assumes a single
-        # robot per scene (load_env configures exactly one robot; _preprocess_obs uses its name) --
-        # assert it so a multi-robot config fails loudly instead of silently using robot 0.
-        for scene_robots in self.env.robots:
-            assert len(scene_robots) == 1, f"Eval assumes one robot per scene, got {len(scene_robots)}."
-        return [scene_robots[0] for scene_robots in self.env.robots]
+    def _create_instance_eval_states(self) -> List[InstanceEvaluationState]:
+        return [
+            InstanceEvaluationState(env_accessor=InstanceEnvAccessor(shared_env=self.env, env_idx=env_idx))
+            for env_idx in range(self.num_envs)
+        ]
 
     def _validate_robot_eval_config(self) -> None:
         missing_camera_sensors = []
         for camera_id, camera_name in self.robot_camera_names.items():
             sensor_name = camera_name.split("::", 1)[1]
-            if sensor_name not in self.robots[0].sensors:
+            if sensor_name not in self.instance_eval_states[0].env_accessor.robot.sensors:
                 missing_camera_sensors.append(f"{camera_id}: {sensor_name}")
         if missing_camera_sensors:
             raise ValueError(
@@ -294,9 +337,10 @@ class Evaluator:
     def _apply_robot_eval_settings(self) -> None:
         # Heavier base so contact with the (heavy) world does not shove the robot around during eval.
         # base mass writes require the sim stopped; do all robots inside a single stop/play (global op).
-        if any(robot.model in ("r1", "r1pro") for robot in self.robots):
+        robots = [instance_eval_state.env_accessor.robot for instance_eval_state in self.instance_eval_states]
+        if any(robot.model in ("r1", "r1pro") for robot in robots):
             og.sim.stop()
-            for robot in self.robots:
+            for robot in robots:
                 if robot.model in ("r1", "r1pro"):
                     robot.base_footprint_link.mass = EVAL_BASE_LINK_MASS
             og.sim.play()
@@ -304,17 +348,16 @@ class Evaluator:
         head_camera_name = self.robot_camera_names.get("head")
         if head_camera_name is not None:
             head_sensor_name = head_camera_name.split("::")[1]
-            for robot in self.robots:
+            for robot in robots:
                 if head_sensor_name in robot.sensors:
                     robot.sensors[head_sensor_name].horizontal_aperture = EVAL_HEAD_HORIZONTAL_APERTURE
 
     def load_policy(self) -> Any:
-        # A SINGLE policy that serves all env slots in one batched call (num_envs robots at once),
-        # instead of one policy per slot. The policy accepts a batched obs (leading num_envs dim) and
-        # returns batched actions; it keeps per-env internal state indexed by position.
+        # A single policy serves all logical environments in one batched call. It accepts observations
+        # with a leading num_envs dimension and keeps per-environment state positionally aligned.
         policy = instantiate(self.cfg.model)
         if hasattr(policy, "set_action_dim"):
-            policy.set_action_dim(self.robots[0].action_dim)
+            policy.set_action_dim(self.instance_eval_states[0].env_accessor.robot.action_dim)
         logger.info("")
         logger.info("=" * 50)
         logger.info(f"Loaded {self.num_envs} policy instance(s) (batched): {self.cfg.policy_name}")
@@ -322,85 +365,90 @@ class Evaluator:
         logger.info("")
         return policy
 
-    def load_metrics(self) -> List[List[MetricBase]]:
+    def load_metrics(self, env_accessor: InstanceEnvAccessor) -> List[MetricBase]:
         return [
-            [AgentMetric(self.human_stats, env_idx=i), TaskMetric(self.human_stats, env_idx=i)]
-            for i in range(self.num_envs)
+            AgentMetric(self.human_stats, env_accessor=env_accessor),
+            TaskMetric(self.human_stats, env_accessor=env_accessor),
         ]
 
-    def _apply_actions(self, actions: th.Tensor, active_slots: List[int]):
+    def _apply_actions(self, actions: th.Tensor, active_env_indices: List[int]):
         """
-        Step all env slots one step with the given ``(num_envs, action_dim)`` actions, then update the
-        observations and metrics for the @active_slots only (frozen slots are still stepped by the
-        shared simulator but their obs/metrics are not advanced). Returns ``(terminated, truncated,
-        info)`` straight from the env.
+        Step the complete environment batch with the given ``(num_envs, action_dim)`` actions, then
+        update observations and metrics only for @active_env_indices. Finished environments are still
+        advanced by the shared simulator, but their evaluation state is frozen.
         """
         obs_list, _, terminated, truncated, info = self.env.step(actions, n_render_iterations=1)
         if self.should_sync_lights:
             # Re-derive visual light state (toggles drive lights that aren't directly serialized) for
-            # the active slots, then re-read obs so the recorded frame matches the synced lights.
-            for slot in active_slots:
-                if self.light_synchronizers[slot] is not None:
-                    self.light_synchronizers[slot].sync_from_current_state()
+            # active environments, then re-read obs so recorded frames match the synced lights.
+            for env_idx in active_env_indices:
+                light_synchronizer = self.instance_eval_states[env_idx].light_synchronizer
+                if light_synchronizer is not None:
+                    light_synchronizer.sync_from_current_state()
             for _ in range(3):
                 og.sim.render()
             obs_list, _ = self.env.get_obs()
-        for slot in active_slots:
-            self.obs[slot] = self._preprocess_obs(obs_list[slot], env_idx=slot)
-            for metric in self.metrics[slot]:
+        for env_idx in active_env_indices:
+            instance_eval_state = self.instance_eval_states[env_idx]
+            instance_eval_state.obs = self._preprocess_obs(obs_list[env_idx], instance_eval_state)
+            for metric in instance_eval_state.metrics:
                 metric.step(
-                    self.env,
-                    actions[slot],
-                    obs_list[slot],
-                    0.0,
-                    bool(terminated[slot]),
-                    bool(truncated[slot]),
-                    info[slot],
+                    action=actions[env_idx],
+                    obs=obs_list[env_idx],
+                    reward=0.0,
+                    terminated=bool(terminated[env_idx]),
+                    truncated=bool(truncated[env_idx]),
+                    info=info[env_idx],
                 )
         return terminated, truncated, info
 
     def _batch_obs(self) -> dict:
         """
-        Stack every env slot's preprocessed obs into one ``(num_envs, ...)`` batch for a SINGLE policy
-        call. All slots share the same keys. Frozen/finished slots keep their last obs and ride along so
-        the batch size stays ``num_envs`` (the policy indexes its per-env buffers by position).
+        Stack every instance's preprocessed observation into one ``(num_envs, ...)`` batch for a
+        single policy call. Finished instances keep their last observation so the batch size remains
+        fixed and the policy's per-environment state remains positionally aligned.
         """
-        keys = self.obs[0].keys()
-        return {k: th.stack([self.obs[slot][k] for slot in range(self.num_envs)], dim=0) for k in keys}
+        keys = self.instance_eval_states[0].obs.keys()
+        return {
+            key: th.stack([instance_eval_state.obs[key] for instance_eval_state in self.instance_eval_states], dim=0)
+            for key in keys
+        }
 
-    def _step_fn(self, active_slots: List[int]) -> Tuple[th.Tensor, th.Tensor]:
+    def _step_fn(self, active_env_indices: List[int]) -> Tuple[th.Tensor, th.Tensor]:
         """
-        ``step_fn`` consumed by :func:`evaluate_instances_batched`: query the policy ONCE with all env
-        slots batched together, then step. Frozen slots get a zero action but are still stepped by the
-        shared simulator.
+        ``step_fn`` consumed by :func:`evaluate_instances_batched`: query the policy once with all
+        logical environments batched together, then step. Finished environments get a zero action but are
+        still advanced by the shared simulator.
         """
-        action_dim = self.robots[0].action_dim
+        action_dim = self.instance_eval_states[0].env_accessor.robot.action_dim
         batched_action = self.policy.forward(obs=self._batch_obs())  # (num_envs, action_dim)
         if batched_action.ndim == 1:
             batched_action = batched_action.unsqueeze(0)
         actions = th.zeros((self.num_envs, action_dim), dtype=th.float32)
-        for slot in active_slots:
-            actions[slot] = batched_action[slot].to(actions.dtype)
-        terminated, truncated, _ = self._apply_actions(actions, active_slots)
+        for env_idx in active_env_indices:
+            actions[env_idx] = batched_action[env_idx].to(actions.dtype)
+        terminated, truncated, _ = self._apply_actions(actions, active_env_indices)
         return terminated, truncated
 
-    def _set_video_writer(self, env_idx: int, video_writer) -> None:
-        existing = self._video_writers[env_idx]
+    def _set_video_writer(self, instance_eval_state: InstanceEvaluationState, video_writer) -> None:
+        existing = instance_eval_state.video_writer
         if existing is not None:
             container, stream = existing
             for packet in stream.encode():
                 container.mux(packet)
             container.close()
-        self._video_writers[env_idx] = video_writer
+        instance_eval_state.video_writer = video_writer
 
-    def _load_instance_state(self, instance_id: int, env_idx: int) -> None:
+    def _load_instance_state(self, instance_id: int, instance_eval_state: InstanceEvaluationState) -> None:
         """
-        Load a task instance's object/robot state into slot @env_idx. Does NOT settle physics or
+        Load a task instance into its assigned logical environment. Does NOT settle physics or
         finalize the scene -- that happens once for the whole batch in :meth:`_settle_and_finalize` so
-        settling does not disturb already-loaded sibling slots.
+        settling does not disturb the other logical environments.
         """
-        robot = self.robots[env_idx]
-        scene = self.env.scenes[env_idx]
+        env_accessor = instance_eval_state.env_accessor
+        env_idx = env_accessor.env_idx
+        robot = env_accessor.robot
+        scene = env_accessor.scene
         # Start every instance from a CLEAN robot: reset joints / controllers / velocities (and release
         # grasp) to the default config -- the instance TRO only restores the robot's base pose below.
         # 2285 got this for free from evaluator.reset() (env.reset) before each load_task_instance; in
@@ -438,7 +486,7 @@ class Evaluator:
                     available_poses = presampled_robot_poses[robot.model]
                 else:
                     raise KeyError(f"No generic or model-specific presampled robot pose found for {robot.model}!")
-                # Presampled poses are scene-relative; frame="scene" puts slot N's robot in its own
+                # Presampled poses are scene-relative; frame="scene" puts environment N's robot in its own
                 # scene rather than env 0's geometry (cf. #2257).
                 robot.set_position_orientation(
                     available_poses[0]["position"], available_poses[0]["orientation"], frame="scene"
@@ -449,19 +497,19 @@ class Evaluator:
                 # scene-relative (env 0) coordinates. For multi envs (env_idx != 0) the scene prim is
                 # shifted by its world offset, so add that offset to the root-link position up front --
                 # load_state then places the object correctly in a single write.
-                obj = self.env.task.object_scope[env_idx][tro_key]
+                obj = env_accessor.object_scope[tro_key]
                 if env_idx != 0 and isinstance(tro_state, dict) and "root_link" in tro_state:
                     scene_offset = scene._scene_prim.get_position_orientation()[0]
                     tro_state["root_link"]["pos"] = tro_state["root_link"]["pos"] + scene_offset
                 obj.load_state(tro_state, serialized=False)
 
         if self.should_sync_lights:
-            set_light_control_toggles(self.env.task.object_scope[env_idx].values(), True)
+            set_light_control_toggles(env_accessor.object_scope.values(), True)
         og.sim.update_handles()
 
-    def _settle_and_finalize(self, slots: List[int]) -> None:
+    def _settle_and_finalize(self, env_indices: List[int]) -> None:
         """
-        Settle physics for all freshly-loaded @slots together and finalize each one's scene. Loading
+        Settle physics for all freshly-loaded environments together and finalize each scene. Loading
         state can introduce jitter, so keep all loaded task-relevant entities (including the robot,
         which _load_instance_state just reset to a clean config) still for a few sub-steps before
         snapshotting each scene's initial state -- otherwise the robot drifts under gravity before the
@@ -469,57 +517,61 @@ class Evaluator:
         """
         for _ in range(25):
             og.sim.step_physics()
-            for slot in slots:
-                for inst, entity in self.env.task.object_scope[slot].items():
+            for env_idx in env_indices:
+                for inst, entity in self.instance_eval_states[env_idx].env_accessor.object_scope.items():
                     if not is_system_bddl_inst(inst) and entity is not None:
                         entity.keep_still()
-        for slot in slots:
-            self.env.scenes[slot].update_initial_file()
+        for env_idx in env_indices:
+            self.instance_eval_states[env_idx].env_accessor.scene.update_initial_file()
         # load_batch immediately calls env.reset(), whose task reset restores every selected scene
         # from this initial file. Avoid doing the same hard restore and physics step twice.
 
     def load_batch(
         self,
-        slot_to_instance: dict,
+        env_idx_to_instance: dict,
         write_video: bool = False,
         video_path: str = None,
         rollout_id: int = 0,
         video_fps: int = 30,
     ) -> None:
         """
-        Load a batch of instances (one per slot) into their slots, settle the whole batch together,
-        then refresh observations and reset per-slot policy / metrics / light synchronizers (and video
-        writers). Consumed by :meth:`run` via :func:`evaluate_instances_batched`.
+        Load one instance per logical environment, settle the complete batch, refresh observations,
+        and reset policy, metrics, light synchronizers, and video writers.
         """
-        ordered_slots = sorted(slot_to_instance)
-        for slot in ordered_slots:
-            self._load_instance_state(slot_to_instance[slot], env_idx=slot)
-        self._settle_and_finalize(ordered_slots)
-        obs_list, _ = self.env.reset(env_indices=th.tensor(ordered_slots, dtype=th.long))
-        for slot in ordered_slots:
-            self._reset_light_synchronizer(slot)
+        env_indices = sorted(env_idx_to_instance)
+        for env_idx in env_indices:
+            instance_eval_state = self.instance_eval_states[env_idx]
+            instance_eval_state.instance_id = int(env_idx_to_instance[env_idx])
+            instance_eval_state.active = True
+            self._load_instance_state(instance_eval_state.instance_id, instance_eval_state)
+        self._settle_and_finalize(env_indices)
+        obs_list, _ = self.env.reset(env_indices=th.tensor(env_indices, dtype=th.long))
+        for env_idx in env_indices:
+            self._reset_light_synchronizer(self.instance_eval_states[env_idx])
         # Light toggles change visibility after the reset obs was captured; re-render + re-fetch so the
         # first obs reflects the synced lights (mirrors single-env _sync_lights_and_get_obs). No-op for
         # non-light tasks.
         if self.should_sync_lights:
             for _ in range(3):
                 og.sim.render()
-            obs_list, _ = self.env.get_obs(env_indices=th.tensor(ordered_slots, dtype=th.long))
+            obs_list, _ = self.env.get_obs(env_indices=th.tensor(env_indices, dtype=th.long))
         task_name = self.cfg.task.name
-        # One batched policy for all slots: reset its per-env state once.
+        # One batched policy for the complete batch: reset its per-environment state once.
         self.policy.reset()
-        for i, slot in enumerate(ordered_slots):
-            self.obs[slot] = self._preprocess_obs(obs_list[i], env_idx=slot)
-            for metric in self.metrics[slot]:
-                metric.reset(self.env)
+        for obs_idx, env_idx in enumerate(env_indices):
+            instance_eval_state = self.instance_eval_states[env_idx]
+            instance_eval_state.obs = self._preprocess_obs(obs_list[obs_idx], instance_eval_state)
+            for metric in instance_eval_state.metrics:
+                metric.reset()
             if write_video:
-                video_name = os.path.join(video_path, f"{task_name}_{slot_to_instance[slot]}_{rollout_id}.mp4")
+                video_name = os.path.join(video_path, f"{task_name}_{instance_eval_state.instance_id}_{rollout_id}.mp4")
                 self._set_video_writer(
-                    slot, create_video_writer(fpath=video_name, resolution=(448, 672), rate=video_fps)
+                    instance_eval_state,
+                    create_video_writer(fpath=video_name, resolution=(448, 672), rate=video_fps),
                 )
 
-    def _preprocess_obs(self, obs: dict, env_idx: int = 0) -> dict:
-        robot = self.robots[env_idx]
+    def _preprocess_obs(self, obs: dict, instance_eval_state: InstanceEvaluationState) -> dict:
+        robot = instance_eval_state.env_accessor.robot
         obs = flatten_obs_dict(obs)
         base_pose = robot.get_position_orientation()
         cam_rel_poses = []
@@ -536,8 +588,8 @@ class Evaluator:
         obs["task_id"] = th.tensor([TASK_NAMES_TO_INDICES[self.cfg.task.name]], dtype=th.int64)
         return obs
 
-    def _write_video(self, env_idx: int) -> None:
-        obs = self.obs[env_idx]
+    def _write_video(self, instance_eval_state: InstanceEvaluationState) -> None:
+        obs = instance_eval_state.obs
         required_camera_ids = ("left_wrist", "right_wrist", "head")
         if not all(camera_id in self.robot_camera_names for camera_id in required_camera_ids):
             return
@@ -554,26 +606,28 @@ class Evaluator:
         head_rgb = cv2.resize(obs[self.robot_camera_names["head"] + "::rgb"].detach().cpu().numpy(), (448, 448))
         write_video(
             np.expand_dims(np.hstack([np.vstack([left_wrist_rgb, right_wrist_rgb]), head_rgb]), 0),
-            video_writer=self._video_writers[env_idx],
+            video_writer=instance_eval_state.video_writer,
             batch_size=1,
             mode="rgb",
         )
 
     def reset(self) -> None:
-        """Generic reset of all slots to the currently-loaded (seed) instance + reset policies/metrics."""
+        """Reset all logical environments to their loaded instances and reset policy and metrics."""
         obs_list, _ = self.env.reset()
-        for env_idx in range(self.num_envs):
-            self._reset_light_synchronizer(env_idx)
+        for instance_eval_state in self.instance_eval_states:
+            self._reset_light_synchronizer(instance_eval_state)
         # Refresh obs after light visibility changes so the first obs is in sync (see load_batch).
         if self.should_sync_lights:
             for _ in range(3):
                 og.sim.render()
             obs_list, _ = self.env.get_obs()
         self.policy.reset()
-        for env_idx in range(self.num_envs):
-            self.obs[env_idx] = self._preprocess_obs(obs_list[env_idx], env_idx=env_idx)
-            for metric in self.metrics[env_idx]:
-                metric.reset(self.env)
+        for instance_eval_state in self.instance_eval_states:
+            env_idx = instance_eval_state.env_idx
+            instance_eval_state.obs = self._preprocess_obs(obs_list[env_idx], instance_eval_state)
+            instance_eval_state.active = True
+            for metric in instance_eval_state.metrics:
+                metric.reset()
         self.n_success_trials, self.n_trials = 0, 0
 
     def run(
@@ -586,46 +640,48 @@ class Evaluator:
         video_fps: int = 30,
     ) -> dict:
         """
-        Offline driver for one batch containing exactly ``num_envs`` instances. An early-finishing slot
-        waits idle rather than getting a new instance. Writes one result JSON per instance to
+        Offline driver for one batch containing exactly ``num_envs`` instances. An environment whose
+        instance finishes early waits idle rather than receiving a new instance. Writes one result JSON per instance to
         @metrics_dir if given. Returns {instance id -> result dict} (result is score_utils-compatible:
         q_score/time/agent_distance plus task/instance/success/steps).
         """
         task_name = self.cfg.task.name
 
-        def load_fn(slot_to_instance):
+        def load_fn(env_idx_to_instance):
             self.load_batch(
-                slot_to_instance,
+                env_idx_to_instance,
                 write_video=write_video,
                 video_path=video_path,
                 rollout_id=rollout_id,
                 video_fps=video_fps,
             )
 
-        def step_fn(active_slots):
-            terminated, truncated = self._step_fn(active_slots)
+        def step_fn(active_env_indices):
+            terminated, truncated = self._step_fn(active_env_indices)
             if write_video:
-                for slot in active_slots:
-                    self._write_video(slot)
+                for env_idx in active_env_indices:
+                    self._write_video(self.instance_eval_states[env_idx])
             return terminated, truncated
 
-        def record_fn(slot, instance, step, terminated, truncated):
+        def record_fn(env_idx, instance, step, terminated, truncated):
+            instance_eval_state = self.instance_eval_states[env_idx]
+            instance_eval_state.active = False
             self.n_trials += 1
-            success = bool(self.env.task.success[slot])
+            success = instance_eval_state.env_accessor.success
             if success:
                 self.n_success_trials += 1
             result = {"task": task_name, "instance_id": int(instance), "rollout_id": rollout_id, "steps": step}
             result["success"] = success
-            for metric in self.metrics[slot]:
-                result.update(metric.aggregate(self.env))
+            for metric in instance_eval_state.metrics:
+                result.update(metric.aggregate())
             if metrics_dir is not None:
                 with open(os.path.join(metrics_dir, f"{task_name}_{instance}_{rollout_id}.json"), "w") as f:
                     json.dump(result, f, indent=2, default=float)
             if write_video:
-                self._set_video_writer(slot, None)
+                self._set_video_writer(instance_eval_state, None)
             q_score = result.get("q_score", {}).get("final")
             logger.info(
-                f"Instance {instance} (slot {slot}) finished at step {step}: success={success} q_score={q_score}"
+                f"Instance {instance} (env {env_idx}) finished at step {step}: success={success} q_score={q_score}"
             )
             return result
 
@@ -652,8 +708,8 @@ class Evaluator:
         logger.info("")
         if exc_type is not None:
             traceback.print_exception(exc_type, exc_value, exc_tb)
-        for env_idx in range(self.num_envs):
-            self._set_video_writer(env_idx, None)
+        for instance_eval_state in self.instance_eval_states:
+            self._set_video_writer(instance_eval_state, None)
         self.env.close()
         og.shutdown()
 
@@ -663,4 +719,15 @@ class Evaluator:
         sys.exit(0)
 
 
-__all__ = ["Evaluator", "resolve_instance_ids", "evaluate_instances_batched"]
+# Backward-compatible alias for callers that imported the original class name.
+Evaluator = BatchedEvaluator
+
+
+__all__ = [
+    "BatchedEvaluator",
+    "Evaluator",
+    "InstanceEnvAccessor",
+    "InstanceEvaluationState",
+    "resolve_instance_ids",
+    "evaluate_instances_batched",
+]

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -171,12 +171,6 @@ class Evaluator:
         self.obs = [None] * self.num_envs
         self._video_writers = [None] * self.num_envs
         self.light_synchronizers = [None] * self.num_envs
-        # Render cadence. Render (and feed the policy fresh camera images) every ``render_every`` steps;
-        # step physics-only in between, reusing the last frame -- valid because a chunked policy replays
-        # its plan and only looks at images when it re-infers (every K steps). 1 = render every step
-        # (safe default / policies that look every step). Rendering is the dominant per-step cost.
-        self.render_every = max(1, int(cfg.get("render_every", 1)))
-        self._rollout_step = 0
 
         # Initialize the physics views so the first reset()/load can read/restore robot joint state.
         og.sim.update_handles()
@@ -334,16 +328,14 @@ class Evaluator:
             for i in range(self.num_envs)
         ]
 
-    def _apply_actions(self, actions: th.Tensor, active_slots: List[int], render: bool = True):
+    def _apply_actions(self, actions: th.Tensor, active_slots: List[int]):
         """
         Step all env slots one step with the given ``(num_envs, action_dim)`` actions, then update the
         observations and metrics for the @active_slots only (frozen slots are still stepped by the
-        shared simulator but their obs/metrics are not advanced). If ``render`` is False, physics steps
-        without drawing the cameras (images stay stale, proprio is still fresh) -- the render cadence
-        uses this to skip drawing on steps the policy is not looking. Returns ``(terminated, truncated,
+        shared simulator but their obs/metrics are not advanced). Returns ``(terminated, truncated,
         info)`` straight from the env.
         """
-        obs_list, _, terminated, truncated, info = self.env.step(actions, n_render_iterations=1, render=render)
+        obs_list, _, terminated, truncated, info = self.env.step(actions, n_render_iterations=1)
         if self.should_sync_lights:
             # Re-derive visual light state (toggles drive lights that aren't directly serialized) for
             # the active slots, then re-read obs so the recorded frame matches the synced lights.
@@ -379,8 +371,8 @@ class Evaluator:
     def _step_fn(self, active_slots: List[int]) -> Tuple[th.Tensor, th.Tensor]:
         """
         ``step_fn`` consumed by :func:`evaluate_instances_batched`: query the policy ONCE with all env
-        slots batched together, then step. Renders only every ``render_every`` steps (physics-only in
-        between). Frozen slots get a zero action but are still stepped by the shared simulator.
+        slots batched together, then step. Frozen slots get a zero action but are still stepped by the
+        shared simulator.
         """
         action_dim = self.robots[0].action_dim
         batched_action = self.policy.forward(obs=self._batch_obs())  # (num_envs, action_dim)
@@ -389,11 +381,7 @@ class Evaluator:
         actions = th.zeros((self.num_envs, action_dim), dtype=th.float32)
         for slot in active_slots:
             actions[slot] = batched_action[slot].to(actions.dtype)
-        # Render on the step whose fresh obs the NEXT policy query will consume, so re-inference steps
-        # get fresh images. render_every == 1 => render every step (unchanged behavior).
-        render = ((self._rollout_step + 1) % self.render_every) == 0
-        terminated, truncated, _ = self._apply_actions(actions, active_slots, render=render)
-        self._rollout_step += 1
+        terminated, truncated, _ = self._apply_actions(actions, active_slots)
         return terminated, truncated
 
     def _set_video_writer(self, env_idx: int, video_writer) -> None:
@@ -487,7 +475,8 @@ class Evaluator:
                         entity.keep_still()
         for slot in slots:
             self.env.scenes[slot].update_initial_file()
-            self.env.scenes[slot].reset()
+        # load_batch immediately calls env.reset(), whose task reset restores every selected scene
+        # from this initial file. Avoid doing the same hard restore and physics step twice.
 
     def load_batch(
         self,
@@ -517,10 +506,8 @@ class Evaluator:
                 og.sim.render()
             obs_list, _ = self.env.get_obs(env_indices=th.tensor(ordered_slots, dtype=th.long))
         task_name = self.cfg.task.name
-        # One batched policy for all slots: reset its per-env state once, and restart the render-cadence
-        # counter for this group (the step-0 obs below is freshly rendered by env.reset above).
+        # One batched policy for all slots: reset its per-env state once.
         self.policy.reset()
-        self._rollout_step = 0
         for i, slot in enumerate(ordered_slots):
             self.obs[slot] = self._preprocess_obs(obs_list[i], env_idx=slot)
             for metric in self.metrics[slot]:
@@ -536,20 +523,14 @@ class Evaluator:
         obs = flatten_obs_dict(obs)
         base_pose = robot.get_position_orientation()
         cam_rel_poses = []
-        # The first camera-parameter query returns zeros; fall back to get_position_orientation() then.
+        # Camera extrinsics come directly from the sensor prim. Querying camera_parameters just for
+        # cameraViewTransform lazily creates an annotator and forces global renders per camera.
         for camera_name in self.robot_camera_names.values():
             sensor_name = camera_name.split("::")[1]
             if sensor_name not in robot.sensors:
                 continue
             camera = robot.sensors[sensor_name]
-            direct_cam_pose = camera.camera_parameters["cameraViewTransform"]
-            if np.allclose(direct_cam_pose, np.zeros(16)):
-                cam_rel_poses.append(
-                    th.cat(T.relative_pose_transform(*(camera.get_position_orientation()), *base_pose))
-                )
-            else:
-                cam_pose = T.mat2pose(th.tensor(np.linalg.inv(np.reshape(direct_cam_pose, [4, 4]).T), dtype=th.float32))
-                cam_rel_poses.append(th.cat(T.relative_pose_transform(*cam_pose, *base_pose)))
+            cam_rel_poses.append(th.cat(T.relative_pose_transform(*(camera.get_position_orientation()), *base_pose)))
         if cam_rel_poses:
             obs[f"{robot.name}::cam_rel_poses"] = th.cat(cam_rel_poses, axis=-1)
         obs["task_id"] = th.tensor([TASK_NAMES_TO_INDICES[self.cfg.task.name]], dtype=th.int64)
@@ -589,7 +570,6 @@ class Evaluator:
                 og.sim.render()
             obs_list, _ = self.env.get_obs()
         self.policy.reset()
-        self._rollout_step = 0
         for env_idx in range(self.num_envs):
             self.obs[env_idx] = self._preprocess_obs(obs_list[env_idx], env_idx=env_idx)
             for metric in self.metrics[env_idx]:
@@ -650,20 +630,13 @@ class Evaluator:
             )
             return result
 
-        # Video needs a rendered frame every step, so disable render-skipping while recording.
-        saved_render_every = self.render_every
-        if write_video:
-            self.render_every = 1
-        try:
-            return evaluate_instances_batched(
-                list(instances_to_run),
-                self.num_envs,
-                load_fn=load_fn,
-                step_fn=step_fn,
-                record_fn=record_fn,
-            )
-        finally:
-            self.render_every = saved_render_every
+        return evaluate_instances_batched(
+            list(instances_to_run),
+            self.num_envs,
+            load_fn=load_fn,
+            step_fn=step_fn,
+            record_fn=record_fn,
+        )
 
     def __enter__(self):
         signal(SIGINT, self._sigint_handler)

--- a/OmniGibson/omnigibson/eval/evaluator.py
+++ b/OmniGibson/omnigibson/eval/evaluator.py
@@ -5,13 +5,11 @@ import os
 import sys
 import traceback
 from signal import SIGINT, signal
-from typing import Any, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import torch as th
-from av.container import Container
-from av.stream import Stream
-from hydra.utils import instantiate
+from hydra.utils import get_class, instantiate
 from omegaconf import DictConfig, OmegaConf
 
 import omnigibson as og
@@ -33,6 +31,7 @@ from omnigibson.eval.utils.eval_utils import (
     generate_basic_environment_config,
     get_robot_camera_names,
 )
+from omnigibson.eval.utils.light_utils import LightToggleSynchronizer, set_light_control_toggles
 from omnigibson.eval.utils.obs_utils import create_video_writer, write_video
 from omnigibson.eval.utils.score_utils import load_human_stats
 from omnigibson.macros import gm
@@ -40,7 +39,6 @@ from omnigibson.metrics import AgentMetric, MetricBase, TaskMetric
 from omnigibson.robots import Robot
 from omnigibson.utils.asset_utils import get_task_instance_path
 from omnigibson.utils.bddl_utils import is_system_bddl_inst
-from omnigibson.eval.utils.light_utils import LightToggleSynchronizer, set_light_control_toggles
 from omnigibson.utils.python_utils import recursively_convert_to_torch
 from omnigibson.utils.ui_utils import create_module_logger
 
@@ -83,60 +81,112 @@ def resolve_instance_ids(task_name: str, instance_indices: list[int], mode: str 
     return [int(test_instances[i]) for i in instance_indices]
 
 
+def evaluate_instances_batched(
+    instances: Sequence,
+    num_envs: int,
+    load_fn: Callable[[Dict[int, object]], None],
+    step_fn: Callable[[List[int]], "tuple[Sequence[bool], Sequence[bool]]"],
+    record_fn: Callable[..., object],
+    max_steps: Optional[int] = None,
+) -> "Dict[object, object]":
+    """
+    Drive evaluation of @instances in groups of @num_envs. Pure orchestration: all sim work is
+    delegated to the injected load_fn / step_fn / record_fn, and a slot that finishes early is dropped
+    from the active list (frozen) until the whole group is done -- loading an instance settles physics
+    for ALL scenes at once, so refilling one slot mid-group would disturb the slots still running.
+    Returns {instance id -> record_fn's return}.
+    """
+    if num_envs < 1:
+        raise ValueError(f"num_envs must be >= 1, got {num_envs}")
+
+    results: Dict[object, object] = {}
+    pending = list(instances)
+
+    while pending:
+        batch = pending[:num_envs]
+        pending = pending[num_envs:]
+
+        slot_to_instance: Dict[int, object] = {slot: inst for slot, inst in enumerate(batch)}
+        load_fn(dict(slot_to_instance))
+
+        active = {slot: True for slot in slot_to_instance}
+        step = 0
+        while any(active.values()):
+            active_slots = sorted(slot for slot, is_active in active.items() if is_active)
+            terminated, truncated = step_fn(active_slots)
+            step += 1
+
+            hit_cap = max_steps is not None and step >= max_steps
+            for slot in active_slots:
+                term = bool(terminated[slot])
+                trunc = bool(truncated[slot]) or hit_cap
+                if term or trunc:
+                    results[slot_to_instance[slot]] = record_fn(
+                        slot=slot,
+                        instance=slot_to_instance[slot],
+                        step=step,
+                        terminated=term,
+                        truncated=trunc,
+                    )
+                    active[slot] = False
+
+    return results
+
+
 class Evaluator:
+    """
+    Vectorized evaluator engine for BEHAVIOR tasks. Holds a single OmniGibson environment with
+    ``num_envs`` parallel scene slots (one task instance per slot) and per-slot robots, policies,
+    metrics, observations and video writers (index everything by ``env_idx``). ``num_envs=1``
+    reproduces single-env evaluation. All sim interaction lives here; the offline driver (:meth:`run`)
+    is a thin layer on top of :func:`evaluate_instances_batched`.
+    """
+
     def __init__(self, cfg: DictConfig) -> None:
         self.cfg = cfg
 
         self.n_trials = 0
         self.n_success_trials = 0
         self.total_time = 0
-        self.robot_action = dict()
         self.robot_name = None
         self.robot_eval_config = {}
         self.robot_camera_names = {}
 
+        # Number of parallel env slots (instances evaluated concurrently). Defaults to 1.
+        self.num_envs = int(cfg.get("num_envs", 1))
         self.env = self.load_env(env_wrapper=self.cfg.env_wrapper)
-        self.robot = self.load_robot()
-        self.robot_camera_names = get_robot_camera_names(self.robot.name, self.robot_eval_config)
+        assert (
+            self.env.num_envs == self.num_envs
+        ), f"Env created with num_envs={self.env.num_envs} but Evaluator expected {self.num_envs}."
+
+        # Per-slot robots / policies / metrics / observations / video writers / light synchronizers.
+        self.robots = self.load_robots()
+        # All slots share the same robot config, so resolve eval camera names once (from slot 0) and
+        # validate that the configured camera sensors exist on the robot.
+        self.robot_camera_names = get_robot_camera_names(self.robots[0].name, self.robot_eval_config)
         self._validate_robot_eval_config()
         self._apply_robot_eval_settings()
-        self.policy = self.load_policy()
+        self.policies = self.load_policies()
         self.metrics = self.load_metrics()
-        self.obs = None
-        self.light_synchronizer = None
+        self.obs = [None] * self.num_envs
+        self._video_writers = [None] * self.num_envs
+        self.light_synchronizers = [None] * self.num_envs
 
-        # Initialize the physics views so the first reset() (which eval.py issues before the first
-        # load_task_instance) can read/restore robot joint state.
+        # Initialize the physics views so the first reset()/load can read/restore robot joint state.
         og.sim.update_handles()
-
         self.env._current_episode = 0
-        self._video_writer = None
-        self._video_path = None
-        self._video_rate = 30
 
     @property
     def should_sync_lights(self) -> bool:
         return self.env.task.activity_name in LIGHT_EVAL_TASKS
 
-    def _reset_light_synchronizer(self) -> None:
+    def _reset_light_synchronizer(self, env_idx: int) -> None:
         if self.should_sync_lights:
-            self.light_synchronizer = LightToggleSynchronizer(self.env.scene)
-            self.light_synchronizer.reset_from_current_state()
+            synchronizer = LightToggleSynchronizer(self.env.scenes[env_idx])
+            synchronizer.reset_from_current_state()
+            self.light_synchronizers[env_idx] = synchronizer
         else:
-            self.light_synchronizer = None
-
-    def _sync_lights_and_get_obs(self, obs: dict | None = None) -> dict:
-        if not self.should_sync_lights:
-            return obs
-
-        if self.light_synchronizer is None:
-            self._reset_light_synchronizer()
-        else:
-            self.light_synchronizer.sync_from_current_state()
-        for _ in range(3):
-            og.sim.render()
-        obs, _ = self.env.get_obs()
-        return obs
+            self.light_synchronizers[env_idx] = None
 
     def load_env(self, env_wrapper: DictConfig) -> EnvironmentWrapper:
         for rule in DISABLED_TRANSITION_RULES:
@@ -159,6 +209,24 @@ class Evaluator:
         self.robot_name = robot_cfg["name"]
         cfg["robots"] = [robot_cfg]
 
+        # Camera resolution + modalities are decided by the chosen eval wrapper and baked into the
+        # robot config HERE, before env creation. This is required (not just cleaner) because in
+        # multi-env mode robot cameras are batched into a single TiledVisionSensor whose resolution is
+        # fixed at creation -- a post-hoc per-sensor resize in the wrapper would be silently ignored.
+        # Resolve the wrapper class (without instantiating it -- that needs the env) to read its spec.
+        camera_spec = get_class(env_wrapper["_target_"]).camera_spec()
+        cfg["robots"][0]["obs_modalities"] = ["proprio", *camera_spec["modalities"]]
+        # Per-camera resolution via per-link sensor_config overrides. The link key is "<link>:Camera:0"
+        # (see robots/robot.py), which takes precedence over the class-level VisionSensor default. Map
+        # each eval camera role to its robot sensor via the (config-driven) eval.camera_sensor_names.
+        sensor_config = cfg["robots"][0].setdefault("sensor_config", {})
+        for camera_id, sensor_name in self.robot_eval_config.get("camera_sensor_names", {}).items():
+            if camera_id not in camera_spec["resolution"]:
+                continue
+            link_key = sensor_name.split(":", 1)[1]
+            height, width = camera_spec["resolution"][camera_id]
+            sensor_config[link_key] = {"sensor_kwargs": {"image_height": height, "image_width": width}}
+
         if self.cfg.max_steps is None:
             max_steps = int(self.human_stats["length"] * EVAL_TIMEOUT_MULTIPLIER)
             logger.info(
@@ -170,20 +238,27 @@ class Evaluator:
             cfg["task"]["termination_config"]["max_steps"] = self.cfg.max_steps
         cfg["task"]["include_obs"] = False
 
+        # Run num_envs instances of the same scene model + task in parallel slots.
+        cfg.setdefault("env", {})
+        cfg["env"]["num_envs"] = self.num_envs
+
         env = og.Environment(configs=cfg)
         env._eval_robot_config = self.robot_eval_config
         return instantiate(env_wrapper, env=env)
 
-    def load_robot(self) -> Robot:
-        if self.robot_name is not None:
-            return self.env.scene.object_registry("name", self.robot_name)
-        return self.env.robots[0]
+    def load_robots(self) -> List[Robot]:
+        # env.robots is list[list[Robot]] (one inner list per scene). The eval pipeline assumes a single
+        # robot per scene (load_env configures exactly one robot; _preprocess_obs uses its name) --
+        # assert it so a multi-robot config fails loudly instead of silently using robot 0.
+        for scene_robots in self.env.robots:
+            assert len(scene_robots) == 1, f"Eval assumes one robot per scene, got {len(scene_robots)}."
+        return [scene_robots[0] for scene_robots in self.env.robots]
 
     def _validate_robot_eval_config(self) -> None:
         missing_camera_sensors = []
         for camera_id, camera_name in self.robot_camera_names.items():
             sensor_name = camera_name.split("::", 1)[1]
-            if sensor_name not in self.robot.sensors:
+            if sensor_name not in self.robots[0].sensors:
                 missing_camera_sensors.append(f"{camera_id}: {sensor_name}")
         if missing_camera_sensors:
             raise ValueError(
@@ -217,63 +292,110 @@ class Evaluator:
         return robot_cfg
 
     def _apply_robot_eval_settings(self) -> None:
-        if self.robot.model in ("r1", "r1pro"):
+        # Heavier base so contact with the (heavy) world does not shove the robot around during eval.
+        # base mass writes require the sim stopped; do all robots inside a single stop/play (global op).
+        if any(robot.model in ("r1", "r1pro") for robot in self.robots):
             og.sim.stop()
-            self.robot.base_footprint_link.mass = EVAL_BASE_LINK_MASS
+            for robot in self.robots:
+                if robot.model in ("r1", "r1pro"):
+                    robot.base_footprint_link.mass = EVAL_BASE_LINK_MASS
             og.sim.play()
 
         head_camera_name = self.robot_camera_names.get("head")
         if head_camera_name is not None:
             head_sensor_name = head_camera_name.split("::")[1]
-            if head_sensor_name in self.robot.sensors:
-                self.robot.sensors[head_sensor_name].horizontal_aperture = EVAL_HEAD_HORIZONTAL_APERTURE
+            for robot in self.robots:
+                if head_sensor_name in robot.sensors:
+                    robot.sensors[head_sensor_name].horizontal_aperture = EVAL_HEAD_HORIZONTAL_APERTURE
 
-    def load_policy(self) -> Any:
-        policy = instantiate(self.cfg.model)
-        if hasattr(policy, "set_action_dim"):
-            policy.set_action_dim(self.robot.action_dim)
+    def load_policies(self) -> List[Any]:
+        # One independent (possibly stateful) policy instance per env slot.
+        policies = []
+        for _ in range(self.num_envs):
+            policy = instantiate(self.cfg.model)
+            if hasattr(policy, "set_action_dim"):
+                policy.set_action_dim(self.robots[0].action_dim)
+            policies.append(policy)
         logger.info("")
         logger.info("=" * 50)
-        logger.info(f"Loaded policy: {self.cfg.policy_name}")
+        logger.info(f"Loaded {self.num_envs} policy instance(s): {self.cfg.policy_name}")
         logger.info("=" * 50)
         logger.info("")
-        return policy
+        return policies
 
-    def load_metrics(self) -> List[MetricBase]:
-        return [AgentMetric(self.human_stats), TaskMetric(self.human_stats)]
+    def load_metrics(self) -> List[List[MetricBase]]:
+        return [
+            [AgentMetric(self.human_stats, env_idx=i), TaskMetric(self.human_stats, env_idx=i)]
+            for i in range(self.num_envs)
+        ]
 
-    def step(self) -> Tuple[bool, bool]:
-        self.robot_action = self.policy.forward(obs=self.obs)
-        obs, _, terminated, truncated, info = self.env.step(self.robot_action, n_render_iterations=1)
-        obs = self._sync_lights_and_get_obs(obs)
-        self.obs = self._preprocess_obs(obs)
+    def _apply_actions(self, actions: th.Tensor, active_slots: List[int]):
+        """
+        Step all env slots one step with the given ``(num_envs, action_dim)`` actions, then update the
+        observations and metrics for the @active_slots only (frozen slots are still stepped by the
+        shared simulator but their obs/metrics are not advanced). Returns ``(terminated, truncated,
+        info)`` straight from the env (``terminated``/``truncated`` are ``(num_envs,)`` tensors, ``info``
+        a per-slot list).
+        """
+        obs_list, _, terminated, truncated, info = self.env.step(actions, n_render_iterations=1)
+        if self.should_sync_lights:
+            # Re-derive visual light state (toggles drive lights that aren't directly serialized) for
+            # the active slots, then re-read obs so the recorded frame matches the synced lights.
+            for slot in active_slots:
+                if self.light_synchronizers[slot] is not None:
+                    self.light_synchronizers[slot].sync_from_current_state()
+            for _ in range(3):
+                og.sim.render()
+            obs_list, _ = self.env.get_obs()
+        for slot in active_slots:
+            self.obs[slot] = self._preprocess_obs(obs_list[slot], env_idx=slot)
+            for metric in self.metrics[slot]:
+                metric.step(
+                    self.env,
+                    actions[slot],
+                    obs_list[slot],
+                    0.0,
+                    bool(terminated[slot]),
+                    bool(truncated[slot]),
+                    info[slot],
+                )
+        return terminated, truncated, info
 
-        if self._video_path is not None:
-            self._write_video()
-
-        if terminated or truncated:
-            self.n_trials += 1
-            if info["done"]["success"]:
-                self.n_success_trials += 1
-
-        for metric in self.metrics:
-            metric.step(self.env, self.robot_action, obs, 0.0, terminated, truncated, info)
+    def _step_fn(self, active_slots: List[int]) -> Tuple[th.Tensor, th.Tensor]:
+        """
+        ``step_fn`` consumed by :func:`evaluate_instances_batched`: drive active slots with their own
+        policies (frozen slots get a zero action but are still stepped by the shared simulator).
+        """
+        action_dim = self.robots[0].action_dim
+        actions = th.zeros((self.num_envs, action_dim), dtype=th.float32)
+        for slot in active_slots:
+            actions[slot] = self.policies[slot].forward(obs=self.obs[slot])
+        terminated, truncated, _ = self._apply_actions(actions, active_slots)
         return terminated, truncated
 
-    @property
-    def video_writer(self) -> Tuple[Container, Stream]:
-        return self._video_writer
-
-    @video_writer.setter
-    def video_writer(self, video_writer: Tuple[Container, Stream]) -> None:
-        if self._video_writer is not None:
-            container, stream = self._video_writer
+    def _set_video_writer(self, env_idx: int, video_writer) -> None:
+        existing = self._video_writers[env_idx]
+        if existing is not None:
+            container, stream = existing
             for packet in stream.encode():
                 container.mux(packet)
             container.close()
-        self._video_writer = video_writer
+        self._video_writers[env_idx] = video_writer
 
-    def load_task_instance(self, instance_id: int) -> None:
+    def _load_instance_state(self, instance_id: int, env_idx: int) -> None:
+        """
+        Load a task instance's object/robot state into slot @env_idx. Does NOT settle physics or
+        finalize the scene -- that happens once for the whole batch in :meth:`_settle_and_finalize` so
+        settling does not disturb already-loaded sibling slots.
+        """
+        robot = self.robots[env_idx]
+        scene = self.env.scenes[env_idx]
+        # Start every instance from a CLEAN robot: reset joints / controllers / velocities (and release
+        # grasp) to the default config -- the instance TRO only restores the robot's base pose below.
+        # 2285 got this for free from evaluator.reset() (env.reset) before each load_task_instance; in
+        # the batched path we must do it explicitly, otherwise the previous episode's/batch's robot
+        # joint+grasp state carries into the snapshot taken in _settle_and_finalize.
+        robot.reset()
         scene_model = self.env.task.scene_name
         tro_filename = self.env.task.get_cached_activity_scene_filename(
             scene_model=scene_model,
@@ -300,42 +422,100 @@ class Evaluator:
                 presampled_robot_poses = {key.lower(): value for key, value in tro_state.items()}
                 if "robot" in presampled_robot_poses:
                     available_poses = presampled_robot_poses["robot"]
-                elif self.robot.model in presampled_robot_poses:
+                elif robot.model in presampled_robot_poses:
                     logger.info("No generic presampled robot pose found, using robot-specific pose.")
-                    available_poses = presampled_robot_poses[self.robot.model]
+                    available_poses = presampled_robot_poses[robot.model]
                 else:
-                    raise KeyError(f"No generic or model-specific presampled robot pose found for {self.robot.model}!")
-                self.robot.set_position_orientation(available_poses[0]["position"], available_poses[0]["orientation"])
-                self.env.scene.write_task_metadata(key=tro_key, data=tro_state)
+                    raise KeyError(f"No generic or model-specific presampled robot pose found for {robot.model}!")
+                # Presampled poses are scene-relative; frame="scene" puts slot N's robot in its own
+                # scene rather than env 0's geometry (cf. #2257).
+                robot.set_position_orientation(
+                    available_poses[0]["position"], available_poses[0]["orientation"], frame="scene"
+                )
+                scene.write_task_metadata(key=tro_key, data=tro_state)
             else:
-                self.env.task.object_scope[tro_key].load_state(tro_state, serialized=False)
+                # load_state applies the TRO root-link pose in WORLD frame, but the TRO is authored in
+                # scene-relative (env 0) coordinates. For multi envs (env_idx != 0) the scene prim is
+                # shifted by its world offset, so add that offset to the root-link position up front --
+                # load_state then places the object correctly in a single write.
+                obj = self.env.task.object_scope[env_idx][tro_key]
+                if env_idx != 0 and isinstance(tro_state, dict) and "root_link" in tro_state:
+                    scene_offset = scene._scene_prim.get_position_orientation()[0]
+                    tro_state["root_link"]["pos"] = tro_state["root_link"]["pos"] + scene_offset
+                obj.load_state(tro_state, serialized=False)
 
         if self.should_sync_lights:
-            set_light_control_toggles(self.env.task.object_scope.values(), True)
-
-        # Keep all task-relevant entities (including the robot/agent) still while the scene settles,
-        # so the snapshotted per-instance initial state is stable. The robot must already be in a clean
-        # configuration when this is called -- eval.py resets before load_task_instance for this reason.
+            set_light_control_toggles(self.env.task.object_scope[env_idx].values(), True)
         og.sim.update_handles()
+
+    def _settle_and_finalize(self, slots: List[int]) -> None:
+        """
+        Settle physics for all freshly-loaded @slots together and finalize each one's scene. Loading
+        state can introduce jitter, so keep all loaded task-relevant entities (including the robot,
+        which _load_instance_state just reset to a clean config) still for a few sub-steps before
+        snapshotting each scene's initial state -- otherwise the robot drifts under gravity before the
+        snapshot.
+        """
         for _ in range(25):
             og.sim.step_physics()
-            for inst, entity in self.env.task.object_scope.items():
-                if not is_system_bddl_inst(inst) and entity is not None:
-                    entity.keep_still()
+            for slot in slots:
+                for inst, entity in self.env.task.object_scope[slot].items():
+                    if not is_system_bddl_inst(inst) and entity is not None:
+                        entity.keep_still()
+        for slot in slots:
+            self.env.scenes[slot].update_initial_file()
+            self.env.scenes[slot].reset()
 
-        self.env.scene.update_initial_file()
-        self.env.scene.reset()
-        self._reset_light_synchronizer()
+    def load_batch(
+        self,
+        slot_to_instance: dict,
+        write_video: bool = False,
+        video_path: str = None,
+        rollout_id: int = 0,
+        video_fps: int = 30,
+    ) -> None:
+        """
+        Load a batch of instances (one per slot) into their slots, settle the whole batch together,
+        then refresh observations and reset per-slot policy / metrics / light synchronizers (and video
+        writers). Consumed by :meth:`run` via :func:`evaluate_instances_batched`.
+        """
+        ordered_slots = sorted(slot_to_instance)
+        for slot in ordered_slots:
+            self._load_instance_state(slot_to_instance[slot], env_idx=slot)
+        self._settle_and_finalize(ordered_slots)
+        obs_list, _ = self.env.reset(env_indices=th.tensor(ordered_slots, dtype=th.long))
+        for slot in ordered_slots:
+            self._reset_light_synchronizer(slot)
+        # Light toggles change visibility after the reset obs was captured; re-render + re-fetch so the
+        # first obs reflects the synced lights (mirrors single-env _sync_lights_and_get_obs). No-op for
+        # non-light tasks.
+        if self.should_sync_lights:
+            for _ in range(3):
+                og.sim.render()
+            obs_list, _ = self.env.get_obs(env_indices=th.tensor(ordered_slots, dtype=th.long))
+        task_name = self.cfg.task.name
+        for i, slot in enumerate(ordered_slots):
+            self.obs[slot] = self._preprocess_obs(obs_list[i], env_idx=slot)
+            self.policies[slot].reset()
+            for metric in self.metrics[slot]:
+                metric.reset(self.env)
+            if write_video:
+                video_name = os.path.join(video_path, f"{task_name}_{slot_to_instance[slot]}_{rollout_id}.mp4")
+                self._set_video_writer(
+                    slot, create_video_writer(fpath=video_name, resolution=(448, 672), rate=video_fps)
+                )
 
-    def _preprocess_obs(self, obs: dict) -> dict:
+    def _preprocess_obs(self, obs: dict, env_idx: int = 0) -> dict:
+        robot = self.robots[env_idx]
         obs = flatten_obs_dict(obs)
-        base_pose = self.robot.get_position_orientation()
+        base_pose = robot.get_position_orientation()
         cam_rel_poses = []
+        # The first camera-parameter query returns zeros; fall back to get_position_orientation() then.
         for camera_name in self.robot_camera_names.values():
             sensor_name = camera_name.split("::")[1]
-            if sensor_name not in self.robot.sensors:
+            if sensor_name not in robot.sensors:
                 continue
-            camera = self.robot.sensors[sensor_name]
+            camera = robot.sensors[sensor_name]
             direct_cam_pose = camera.camera_parameters["cameraViewTransform"]
             if np.allclose(direct_cam_pose, np.zeros(16)):
                 cam_rel_poses.append(
@@ -345,55 +525,111 @@ class Evaluator:
                 cam_pose = T.mat2pose(th.tensor(np.linalg.inv(np.reshape(direct_cam_pose, [4, 4]).T), dtype=th.float32))
                 cam_rel_poses.append(th.cat(T.relative_pose_transform(*cam_pose, *base_pose)))
         if cam_rel_poses:
-            obs[f"{self.robot.name}::cam_rel_poses"] = th.cat(cam_rel_poses, axis=-1)
+            obs[f"{robot.name}::cam_rel_poses"] = th.cat(cam_rel_poses, axis=-1)
         obs["task_id"] = th.tensor([TASK_NAMES_TO_INDICES[self.cfg.task.name]], dtype=th.int64)
         return obs
 
-    def _write_video(self) -> None:
+    def _write_video(self, env_idx: int) -> None:
+        obs = self.obs[env_idx]
         required_camera_ids = ("left_wrist", "right_wrist", "head")
         if not all(camera_id in self.robot_camera_names for camera_id in required_camera_ids):
             return
-        if self.robot_camera_names["head"] + "::rgb" not in self.obs:
+        if obs is None or self.robot_camera_names["head"] + "::rgb" not in obs:
             return
+        # .detach().cpu() is required for num_envs>1: robot cameras come from the TiledVisionSensor,
+        # whose obs are CUDA tensors (a plain .numpy() would raise). No-op for single-env CPU tensors.
         left_wrist_rgb = cv2.resize(
-            self.obs[self.robot_camera_names["left_wrist"] + "::rgb"].numpy(),
-            (224, 224),
+            obs[self.robot_camera_names["left_wrist"] + "::rgb"].detach().cpu().numpy(), (224, 224)
         )
         right_wrist_rgb = cv2.resize(
-            self.obs[self.robot_camera_names["right_wrist"] + "::rgb"].numpy(),
-            (224, 224),
+            obs[self.robot_camera_names["right_wrist"] + "::rgb"].detach().cpu().numpy(), (224, 224)
         )
-        head_rgb = cv2.resize(
-            self.obs[self.robot_camera_names["head"] + "::rgb"].numpy(),
-            (448, 448),
+        head_rgb = cv2.resize(obs[self.robot_camera_names["head"] + "::rgb"].detach().cpu().numpy(), (448, 448))
+        write_video(
+            np.expand_dims(np.hstack([np.vstack([left_wrist_rgb, right_wrist_rgb]), head_rgb]), 0),
+            video_writer=self._video_writers[env_idx],
+            batch_size=1,
+            mode="rgb",
         )
-        frame = np.expand_dims(np.hstack([np.vstack([left_wrist_rgb, right_wrist_rgb]), head_rgb]), 0)
-        if self._video_writer is None:
-            # Writer is created lazily so its resolution matches the composite (H, W) frame above.
-            self.video_writer = create_video_writer(
-                self._video_path, resolution=frame.shape[1:3], rate=self._video_rate
-            )
-        write_video(frame, video_writer=self.video_writer, batch_size=1, mode="rgb")
-
-    def start_recording(self, fpath: str, rate: int = 30) -> None:
-        # Finalize any in-progress recording, then arm a new one (writer is created on the first frame).
-        self.video_writer = None
-        self._video_path = fpath
-        self._video_rate = rate
-
-    def stop_recording(self) -> None:
-        self.video_writer = None
-        self._video_path = None
 
     def reset(self) -> None:
-        obs = self.env.reset()[0]
-        self._reset_light_synchronizer()
-        obs = self._sync_lights_and_get_obs(obs)
-        self.obs = self._preprocess_obs(obs)
-        for metric in self.metrics:
-            metric.reset(self.env)
-        self.policy.reset()
+        """Generic reset of all slots to the currently-loaded (seed) instance + reset policies/metrics."""
+        obs_list, _ = self.env.reset()
+        for env_idx in range(self.num_envs):
+            self._reset_light_synchronizer(env_idx)
+        # Refresh obs after light visibility changes so the first obs is in sync (see load_batch).
+        if self.should_sync_lights:
+            for _ in range(3):
+                og.sim.render()
+            obs_list, _ = self.env.get_obs()
+        for env_idx in range(self.num_envs):
+            self.obs[env_idx] = self._preprocess_obs(obs_list[env_idx], env_idx=env_idx)
+            for metric in self.metrics[env_idx]:
+                metric.reset(self.env)
+            self.policies[env_idx].reset()
         self.n_success_trials, self.n_trials = 0, 0
+
+    def run(
+        self,
+        instances_to_run: List[int],
+        write_video: bool = False,
+        video_path: str = None,
+        metrics_dir: str = None,
+        rollout_id: int = 0,
+        video_fps: int = 30,
+    ) -> dict:
+        """
+        Offline driver: evaluate every instance in @instances_to_run, processing them ``num_envs`` at a
+        time. The whole group finishes before the next group loads, and an early-finishing slot waits
+        idle rather than getting a new instance. Writes one result JSON per instance to @metrics_dir if
+        given. Returns {instance id -> result dict} (result is score_utils-compatible: q_score/time/
+        agent_distance plus task/instance/success/steps).
+        """
+        task_name = self.cfg.task.name
+
+        def load_fn(slot_to_instance):
+            self.load_batch(
+                slot_to_instance,
+                write_video=write_video,
+                video_path=video_path,
+                rollout_id=rollout_id,
+                video_fps=video_fps,
+            )
+
+        def step_fn(active_slots):
+            terminated, truncated = self._step_fn(active_slots)
+            if write_video:
+                for slot in active_slots:
+                    self._write_video(slot)
+            return terminated, truncated
+
+        def record_fn(slot, instance, step, terminated, truncated):
+            self.n_trials += 1
+            success = bool(self.env.task.success[slot])
+            if success:
+                self.n_success_trials += 1
+            result = {"task": task_name, "instance_id": int(instance), "rollout_id": rollout_id, "steps": step}
+            result["success"] = success
+            for metric in self.metrics[slot]:
+                result.update(metric.aggregate(self.env))
+            if metrics_dir is not None:
+                with open(os.path.join(metrics_dir, f"{task_name}_{instance}_{rollout_id}.json"), "w") as f:
+                    json.dump(result, f, indent=2, default=float)
+            if write_video:
+                self._set_video_writer(slot, None)
+            q_score = result.get("q_score", {}).get("final")
+            logger.info(
+                f"Instance {instance} (slot {slot}) finished at step {step}: success={success} q_score={q_score}"
+            )
+            return result
+
+        return evaluate_instances_batched(
+            list(instances_to_run),
+            self.num_envs,
+            load_fn=load_fn,
+            step_fn=step_fn,
+            record_fn=record_fn,
+        )
 
     def __enter__(self):
         signal(SIGINT, self._sigint_handler)
@@ -410,7 +646,8 @@ class Evaluator:
         logger.info("")
         if exc_type is not None:
             traceback.print_exception(exc_type, exc_value, exc_tb)
-        self.video_writer = None
+        for env_idx in range(self.num_envs):
+            self._set_video_writer(env_idx, None)
         self.env.close()
         og.shutdown()
 
@@ -420,4 +657,4 @@ class Evaluator:
         sys.exit(0)
 
 
-__all__ = ["Evaluator", "resolve_instance_ids"]
+__all__ = ["Evaluator", "resolve_instance_ids", "evaluate_instances_batched"]

--- a/OmniGibson/omnigibson/eval/policies.py
+++ b/OmniGibson/omnigibson/eval/policies.py
@@ -34,7 +34,13 @@ class LocalPolicy:
             return self.policy.act(obs).detach().cpu()
         else:
             assert self.action_dim is not None
-            return th.zeros(self.action_dim, dtype=th.float32)
+            batch_size = None
+            if obs:
+                first_obs = next(iter(obs.values()))
+                if isinstance(first_obs, th.Tensor) and first_obs.ndim > 0:
+                    batch_size = first_obs.shape[0]
+            shape = (self.action_dim,) if batch_size is None else (batch_size, self.action_dim)
+            return th.zeros(shape, dtype=th.float32)
 
     def reset(self) -> None:
         if self.policy is not None:
@@ -52,17 +58,29 @@ class WebsocketPolicy:
         host: Optional[str] = None,
         port: Optional[int] = None,
         allow_reconnect: bool = False,
+        action_chunk_size: int = 0,
         **kwargs,
     ) -> None:
         logging.info(f"Creating websocket client policy with host: {host}, port: {port}")
         self.last_action = None
         self.policy = None
         self._allow_reconnect = allow_reconnect
+        self._action_chunk_size = action_chunk_size
         if host is not None or port is not None:
-            self.policy = WebsocketClientPolicy(host=host, port=port, allow_reconnect=allow_reconnect)
+            self.policy = WebsocketClientPolicy(
+                host=host,
+                port=port,
+                allow_reconnect=allow_reconnect,
+                action_chunk_size=action_chunk_size,
+            )
 
     def update_host(self, host: str, port: int) -> None:
-        self.policy = WebsocketClientPolicy(host=host, port=port, allow_reconnect=self._allow_reconnect)
+        self.policy = WebsocketClientPolicy(
+            host=host,
+            port=port,
+            allow_reconnect=self._allow_reconnect,
+            action_chunk_size=self._action_chunk_size,
+        )
 
     def forward(self, obs: dict, *args, **kwargs) -> th.Tensor:
         if "need_new_action" in obs and not obs["need_new_action"] and self.last_action is not None:

--- a/OmniGibson/omnigibson/eval/policies.py
+++ b/OmniGibson/omnigibson/eval/policies.py
@@ -49,7 +49,10 @@ class LocalPolicy:
 
 class WebsocketPolicy:
     """
-    Websocket policy for controlling the robot over a websocket connection.
+    Websocket policy for controlling the robot over a websocket connection. ``action_chunk_size`` opts
+    into the action-chunk protocol documented in ``docs/challenge/evaluation.md``; it is disabled by
+    default because replaying a chunk is correct only for servers that return actions intended for
+    open-loop execution from one observation.
     """
 
     def __init__(

--- a/OmniGibson/omnigibson/eval/utils/eval_utils.py
+++ b/OmniGibson/omnigibson/eval/utils/eval_utils.py
@@ -9,6 +9,10 @@ from omnigibson.macros import gm
 
 HEAD_RESOLUTION = (720, 720)
 WRIST_RESOLUTION = (480, 480)
+# Standard eval camera roles. Eval wrappers key their camera_spec() resolution by these roles; the
+# Evaluator maps each role to a concrete robot sensor via the robot config's
+# eval.camera_sensor_names (see get_robot_camera_names) when baking resolution at env creation.
+EVAL_CAMERA_ROLES = ("left_wrist", "right_wrist", "head")
 DEFAULT_EVAL_SEED = 0
 EVAL_TIMEOUT_MULTIPLIER = 1.5
 NUM_TEST_INSTANCES = 40

--- a/OmniGibson/omnigibson/eval/utils/network_utils.py
+++ b/OmniGibson/omnigibson/eval/utils/network_utils.py
@@ -26,6 +26,8 @@ logger.setLevel(logging.INFO)
 
 __all__ = ["WebsocketClientPolicy", "WebsocketPolicyServer"]
 
+ACTION_CHUNK_REQUEST_KEY = "__action_chunk_size__"
+
 
 class WebsocketClientPolicy:
     """Implements the Policy interface by communicating with a server over websocket.
@@ -40,6 +42,7 @@ class WebsocketClientPolicy:
         scheme: str = "ws",
         api_key: Optional[str] = None,
         allow_reconnect: bool = False,
+        action_chunk_size: int = 0,
     ) -> None:
         """
         Initializes the websocket client policy.
@@ -58,6 +61,10 @@ class WebsocketClientPolicy:
         self._api_key = api_key
         self._ws, self._server_metadata = None, None
         self._allow_reconnect = allow_reconnect
+        self._action_chunk_size = max(0, int(action_chunk_size))
+        self._action_chunk = None
+        self._action_chunk_index = 0
+        self._chunk_requests_supported = self._action_chunk_size > 1
 
     def get_server_metadata(self) -> Dict:
         return self._server_metadata
@@ -101,10 +108,19 @@ class WebsocketClientPolicy:
                 time.sleep(5)
 
     def act(self, obs: Dict) -> th.Tensor:
+        if self._action_chunk is not None and self._action_chunk_index < self._action_chunk.shape[-2]:
+            action = self._action_chunk[..., self._action_chunk_index, :].clone()
+            self._action_chunk_index += 1
+            return action
+
         if self._ws is None:
             self._ws, self._server_metadata = self._wait_for_server()
 
-        data = self._packer.pack(obs)
+        request = obs
+        if self._chunk_requests_supported:
+            request = dict(obs)
+            request[ACTION_CHUNK_REQUEST_KEY] = self._action_chunk_size
+        data = self._packer.pack(request)
         max_retries = 2
         response = None
 
@@ -124,6 +140,23 @@ class WebsocketClientPolicy:
                         continue
                     raise RuntimeError(f"Server response missing 'action' key: {action_dict}")
                 action = th.from_numpy(deepcopy(action_dict["action"])).to(th.float32)
+                if self._chunk_requests_supported:
+                    if "action_chunk" in action_dict:
+                        chunk = th.from_numpy(deepcopy(action_dict["action_chunk"])).to(th.float32)
+                        expected_shape = (*action.shape[:-1], self._action_chunk_size, action.shape[-1])
+                        if chunk.shape != expected_shape:
+                            raise RuntimeError(
+                                f"Server returned action_chunk shape {tuple(chunk.shape)}, expected {expected_shape}."
+                            )
+                        if not th.equal(chunk[..., 0, :], action):
+                            raise RuntimeError("Server action must exactly equal action_chunk[..., 0, :].")
+                        self._action_chunk = chunk
+                        self._action_chunk_index = 1
+                    else:
+                        logger.warning(
+                            "Policy server does not support action chunks; falling back to one request per step."
+                        )
+                        self._chunk_requests_supported = False
                 return action
 
             except websockets.exceptions.ConnectionClosedError as e:
@@ -134,6 +167,8 @@ class WebsocketClientPolicy:
                 raise RuntimeError(f"Websocket connection error: {e}")
 
     def reset(self) -> None:
+        self._action_chunk = None
+        self._action_chunk_index = 0
         if self._ws is None:
             self._ws, self._server_metadata = self._wait_for_server()
 

--- a/OmniGibson/omnigibson/eval/utils/network_utils.py
+++ b/OmniGibson/omnigibson/eval/utils/network_utils.py
@@ -55,6 +55,9 @@ class WebsocketClientPolicy:
             allow_reconnect (bool): Whether to allow automatic reconnection if the websocket connection is lost.
                 If False, the client will raise an error if the connection is lost.
                 If True, the client will attempt to reconnect indefinitely with a delay between attempts.
+            action_chunk_size (int): Number of server-returned actions to execute before requesting a new
+                observation-conditioned action. Values <= 1 disable chunk requests. Only enable this when the
+                server returns an exact open-loop action sequence produced from the current observation.
         """
         self._uri = f"{scheme}://{host}:{port}"
         self._packer = Packer()

--- a/OmniGibson/omnigibson/eval/wrappers/default_wrapper.py
+++ b/OmniGibson/omnigibson/eval/wrappers/default_wrapper.py
@@ -9,7 +9,8 @@ class DefaultWrapper(EnvironmentWrapper):
     Default eval wrapper: low-resolution (224x224) RGB observations.
 
     Camera resolution and modalities are declared via :meth:`camera_spec` and baked into the robot
-    config at env CREATION by the Evaluator (see ``omnigibson.eval.evaluator.Evaluator.load_env``),
+    config at env CREATION by the BatchedEvaluator
+    (see ``omnigibson.eval.evaluator.BatchedEvaluator.load_env``),
     not changed at runtime. This is required because in multi-env mode robot cameras are batched into
     a single ``TiledVisionSensor`` whose resolution is fixed at creation, so a post-hoc per-sensor
     resize would be silently ignored.

--- a/OmniGibson/omnigibson/eval/wrappers/default_wrapper.py
+++ b/OmniGibson/omnigibson/eval/wrappers/default_wrapper.py
@@ -1,29 +1,30 @@
 from omnigibson.envs import Environment, EnvironmentWrapper
-from omnigibson.eval.utils.eval_utils import set_sensor_modalities
-from omnigibson.utils.ui_utils import create_module_logger
+from omnigibson.eval.utils.eval_utils import EVAL_CAMERA_ROLES
 
-
-logger = create_module_logger(module_name=__name__)
+EVAL_LOW_RES = (224, 224)  # (H, W)
 
 
 class DefaultWrapper(EnvironmentWrapper):
     """
-    Default eval wrapper: low-resolution RGB observations.
+    Default eval wrapper: low-resolution (224x224) RGB observations.
+
+    Camera resolution and modalities are declared via :meth:`camera_spec` and baked into the robot
+    config at env CREATION by the Evaluator (see ``omnigibson.eval.evaluator.Evaluator.load_env``),
+    not changed at runtime. This is required because in multi-env mode robot cameras are batched into
+    a single ``TiledVisionSensor`` whose resolution is fixed at creation, so a post-hoc per-sensor
+    resize would be silently ignored.
 
     Args:
         env (og.Environment): The environment to wrap.
     """
 
+    @classmethod
+    def camera_spec(cls) -> dict:
+        """Returns {"modalities": [...], "resolution": {camera_role: (H, W)}} for this eval profile."""
+        return {
+            "modalities": ["rgb"],
+            "resolution": {role: EVAL_LOW_RES for role in EVAL_CAMERA_ROLES},
+        }
+
     def __init__(self, env: Environment):
         super().__init__(env=env)
-        robot = env.robots[0]
-        for sensor_name, sensor in robot.sensors.items():
-            if not hasattr(sensor, "image_height") or not hasattr(sensor, "image_width"):
-                continue
-            set_sensor_modalities(sensor, {"rgb"})
-            sensor.image_height = 224
-            sensor.image_width = 224
-            sensor_space = sensor.load_observation_space()
-            if env.observation_space is not None:
-                env.observation_space.spaces[robot.name].spaces[sensor_name] = sensor_space
-        logger.info("Reloaded camera observation spaces!")

--- a/OmniGibson/omnigibson/eval/wrappers/rgbd_full_res_wrapper.py
+++ b/OmniGibson/omnigibson/eval/wrappers/rgbd_full_res_wrapper.py
@@ -1,42 +1,25 @@
-from omnigibson.envs import EnvironmentWrapper, Environment
-from omnigibson.utils.ui_utils import create_module_logger
-from omnigibson.eval.utils.eval_utils import (
-    HEAD_RESOLUTION,
-    WRIST_RESOLUTION,
-    get_robot_camera_names,
-    set_sensor_modalities,
-)
-
-logger = create_module_logger(module_name=__name__)
+from omnigibson.envs import Environment, EnvironmentWrapper
+from omnigibson.eval.utils.eval_utils import EVAL_CAMERA_ROLES, HEAD_RESOLUTION, WRIST_RESOLUTION
 
 
 class RGBDFullResWrapper(EnvironmentWrapper):
     """
+    Eval wrapper: full-resolution RGB-D observations (head at HEAD_RESOLUTION, wrists at
+    WRIST_RESOLUTION) matching the data-collection cameras, plus a depth modality.
+
+    As with :class:`~omnigibson.eval.wrappers.default_wrapper.DefaultWrapper`, camera resolution and
+    modalities are declared via :meth:`camera_spec` and baked into the robot config at env CREATION
+    (multi-env tiled rendering fixes resolution at creation, so a runtime resize would not apply).
+
     Args:
         env (og.Environment): The environment to wrap.
     """
 
+    @classmethod
+    def camera_spec(cls) -> dict:
+        """Returns {"modalities": [...], "resolution": {camera_role: (H, W)}} for this eval profile."""
+        resolution = {role: (HEAD_RESOLUTION if role == "head" else WRIST_RESOLUTION) for role in EVAL_CAMERA_ROLES}
+        return {"modalities": ["rgb", "depth_linear"], "resolution": resolution}
+
     def __init__(self, env: Environment):
         super().__init__(env=env)
-        # Note that from eval.py we only set rgb modality, here we include depth.
-        # Here, we change the camera resolution to match the one we used in data collection
-        robot = env.robots[0]
-        robot_eval_config = getattr(env, "_eval_robot_config", {})
-        camera_roles_by_sensor_name = {
-            camera_name.split("::")[1]: camera_id
-            for camera_id, camera_name in get_robot_camera_names(robot.name, robot_eval_config).items()
-        }
-        for sensor_name, sensor in robot.sensors.items():
-            if not hasattr(sensor, "image_height") or not hasattr(sensor, "image_width"):
-                continue
-            set_sensor_modalities(sensor, {"rgb", "depth_linear"})
-            camera_id = camera_roles_by_sensor_name.get(sensor_name)
-            if camera_id == "head":
-                sensor.image_height = HEAD_RESOLUTION[0]
-                sensor.image_width = HEAD_RESOLUTION[1]
-            else:
-                sensor.image_height = WRIST_RESOLUTION[0]
-                sensor.image_width = WRIST_RESOLUTION[1]
-        # reload observation space
-        env.load_observation_space()
-        logger.info("Reloaded observation space!")

--- a/OmniGibson/omnigibson/metrics/agent_metric.py
+++ b/OmniGibson/omnigibson/metrics/agent_metric.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 
 class AgentMetric(MetricBase):
-    def __init__(self, human_stats: Optional[dict] = None, env_idx: int = 0):
-        super().__init__(env_idx=env_idx)
+    def __init__(self, human_stats: Optional[dict] = None, env_idx: int = 0, env_accessor=None):
+        super().__init__(env_idx=env_idx, env_accessor=env_accessor)
         self.initialized = False
         self.human_stats = human_stats
         if human_stats is None:
@@ -18,13 +18,12 @@ class AgentMetric(MetricBase):
                 "right": self.human_stats["right_eef_displacement"],
             }
 
-    def reset(self, env):
-        # Tracks env.scenes[env_idx] and its single robot. Per-env for vectorized evaluation.
+    def reset(self, env=None):
         self.state[self._scene(env)] = dict()
         self.initialized = False
 
     def _compute_step_metrics(self, env, action, obs, reward, terminated, truncated, info):
-        robot = self._scene(env).robots[0]
+        robot = env.robot if env is self.env_accessor else self._scene(env).robots[0]
         self.next_state_cache = {
             "base": {"position": robot.get_position_orientation()[0]},
             **{arm: {"position": robot.get_eef_position(arm)} for arm in robot.arm_names},

--- a/OmniGibson/omnigibson/metrics/agent_metric.py
+++ b/OmniGibson/omnigibson/metrics/agent_metric.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 
 class AgentMetric(MetricBase):
-    def __init__(self, human_stats: Optional[dict] = None):
-        super().__init__()
+    def __init__(self, human_stats: Optional[dict] = None, env_idx: int = 0):
+        super().__init__(env_idx=env_idx)
         self.initialized = False
         self.human_stats = human_stats
         if human_stats is None:
@@ -19,13 +19,12 @@ class AgentMetric(MetricBase):
             }
 
     def reset(self, env):
-        # Single-env metric: env.scene and env.scene.robots[0] reads below assume one env / one robot.
-        assert env.num_envs == 1, f"AgentMetric is single-env only; got num_envs={env.num_envs}."
-        self.state[env.scene] = dict()
+        # Tracks env.scenes[env_idx] and its single robot. Per-env for vectorized evaluation.
+        self.state[self._scene(env)] = dict()
         self.initialized = False
 
     def _compute_step_metrics(self, env, action, obs, reward, terminated, truncated, info):
-        robot = env.scene.robots[0]
+        robot = self._scene(env).robots[0]
         self.next_state_cache = {
             "base": {"position": robot.get_position_orientation()[0]},
             **{arm: {"position": robot.get_eef_position(arm)} for arm in robot.arm_names},

--- a/OmniGibson/omnigibson/metrics/metric_base.py
+++ b/OmniGibson/omnigibson/metrics/metric_base.py
@@ -4,8 +4,16 @@ class MetricBase:
     each environment episode
     """
 
-    def __init__(self):
+    def __init__(self, env_idx=0):
+        # env_idx selects which environment (scene) this metric instance tracks. Defaults to 0 so
+        # single-env usage is unchanged; vectorized evaluation instantiates one metric per env slot.
+        self.env_idx = env_idx
         self.state = dict()
+
+    def _scene(self, env):
+        """The scene this metric tracks. Uses ``env.scenes[env_idx]`` so it works for any num_envs
+        (``env.scene`` asserts a single scene and would raise for num_envs > 1)."""
+        return env.scenes[self.env_idx]
 
     @classmethod
     def is_compatible(cls, env):
@@ -50,10 +58,11 @@ class MetricBase:
             info (dict): info, i.e. dictionary with any useful information
         """
         step_metrics = self._compute_step_metrics(env, action, obs, reward, terminated, truncated, info)
+        scene = self._scene(env)
         assert (
-            env.scene in self.state
-        ), f"Environment {env} is not being tracked, please call 'self.reset(env)' to track!"
-        state = self.state[env.scene]
+            scene in self.state
+        ), f"Environment {env} (env_idx={self.env_idx}) is not being tracked, please call 'self.reset(env)' to track!"
+        state = self.state[scene]
         for k, v in step_metrics.items():
             if k not in state:
                 state[k] = []
@@ -102,11 +111,12 @@ class MetricBase:
         Returns:
             dict: Any relevant aggregated metric information
         """
-        if env.scene in self.state:
-            if self.state[env.scene] == dict():
+        scene = self._scene(env)
+        if scene in self.state:
+            if self.state[scene] == dict():
                 return dict()
             else:
-                return self._compute_episode_metrics(env=env, episode_info=self.state[env.scene])
+                return self._compute_episode_metrics(env=env, episode_info=self.state[scene])
         else:
             print("Environment not yet tracked, skipping metric aggregation!")
             return dict()
@@ -118,4 +128,4 @@ class MetricBase:
         Args:
             env (EnvironmentWrapper): Environment being tracked
         """
-        self.state[env.scene] = dict()
+        self.state[self._scene(env)] = dict()

--- a/OmniGibson/omnigibson/metrics/metric_base.py
+++ b/OmniGibson/omnigibson/metrics/metric_base.py
@@ -4,16 +4,24 @@ class MetricBase:
     each environment episode
     """
 
-    def __init__(self, env_idx=0):
-        # env_idx selects which environment (scene) this metric instance tracks. Defaults to 0 so
-        # single-env usage is unchanged; vectorized evaluation instantiates one metric per env slot.
+    def __init__(self, env_idx=0, env_accessor=None):
+        # Batched evaluation binds a metric to an accessor, which owns the mapping into the shared
+        # environment. env_idx remains as a compatibility path for MetricsWrapper and external users.
         self.env_idx = env_idx
+        self.env_accessor = env_accessor
         self.state = dict()
 
-    def _scene(self, env):
-        """The scene this metric tracks. Uses ``env.scenes[env_idx]`` so it works for any num_envs
-        (``env.scene`` asserts a single scene and would raise for num_envs > 1)."""
-        return env.scenes[self.env_idx]
+    def _resolve_env(self, env):
+        if env is not None:
+            return env
+        if self.env_accessor is None:
+            raise ValueError("Metric is not bound to an environment accessor; pass env explicitly.")
+        return self.env_accessor
+
+    def _scene(self, env=None):
+        """Return the scene tracked by this metric for bound and legacy callers."""
+        env = self._resolve_env(env)
+        return env.scene if env is self.env_accessor else env.scenes[self.env_idx]
 
     @classmethod
     def is_compatible(cls, env):
@@ -44,12 +52,11 @@ class MetricBase:
         """
         raise NotImplementedError
 
-    def step(self, env, action, obs, reward, terminated, truncated, info):
+    def step(self, env=None, action=None, obs=None, reward=None, terminated=None, truncated=None, info=None):
         """
         Steps this metric, updating any internal values being tracked.
 
         Args:
-            env (EnvironmentWrapper): Environment being tracked
             action (th.Tensor): action deployed resulting in @obs
             obs (dict): state, i.e. observation
             reward (float): reward, i.e. reward at this current timestep
@@ -57,11 +64,10 @@ class MetricBase:
             truncated (bool): truncated, i.e. whether this episode ended due to a time limit etc.
             info (dict): info, i.e. dictionary with any useful information
         """
+        env = self._resolve_env(env)
         step_metrics = self._compute_step_metrics(env, action, obs, reward, terminated, truncated, info)
         scene = self._scene(env)
-        assert (
-            scene in self.state
-        ), f"Environment {env} (env_idx={self.env_idx}) is not being tracked, please call 'self.reset(env)' to track!"
+        assert scene in self.state, f"Environment {scene} is not being tracked, please call 'self.reset()' to track!"
         state = self.state[scene]
         for k, v in step_metrics.items():
             if k not in state:
@@ -73,7 +79,6 @@ class MetricBase:
         Compute any step-wise metrics at the current environment step that just occurred
 
         Args:
-            env (EnvironmentWrapper): Environment being tracked
             action (th.Tensor): action deployed resulting in @obs
             obs (dict): state, i.e. observation
             reward (float): reward, i.e. reward at this current timestep
@@ -91,7 +96,6 @@ class MetricBase:
         Computes the aggregated metrics over the current trajectory episode in @env
 
         Args:
-            env (EnvironmentWrapper): Environment being tracked
             episode_info (dict): Internal information that was tracked using @_compute_episode metrics. This
                 information is is the same key-mapped dict as @_compute_step_metrics mapped to the
                 list of values aggregated over the current trajectory episode
@@ -101,16 +105,14 @@ class MetricBase:
         """
         raise NotImplementedError
 
-    def aggregate(self, env):
+    def aggregate(self, env=None):
         """
-        Aggregates information over the current trajectory being tracked in @env
-
-        Args:
-            env (EnvironmentWrapper): Environment being tracked
+        Aggregates information over the current trajectory tracked by this metric.
 
         Returns:
             dict: Any relevant aggregated metric information
         """
+        env = self._resolve_env(env)
         scene = self._scene(env)
         if scene in self.state:
             if self.state[scene] == dict():
@@ -121,11 +123,8 @@ class MetricBase:
             print("Environment not yet tracked, skipping metric aggregation!")
             return dict()
 
-    def reset(self, env):
+    def reset(self, env=None):
         """
-        Resets this metric with respect to @env
-
-        Args:
-            env (EnvironmentWrapper): Environment being tracked
+        Resets this metric for its bound logical environment.
         """
         self.state[self._scene(env)] = dict()

--- a/OmniGibson/omnigibson/metrics/task_metric.py
+++ b/OmniGibson/omnigibson/metrics/task_metric.py
@@ -1,11 +1,36 @@
 import omnigibson as og
 from omnigibson.metrics.metric_base import MetricBase
-from typing import Optional
+from typing import Optional, Sequence
+
+
+def compute_q_score(
+    success: bool,
+    now_satisfied_options: Sequence[Sequence[bool]],
+    initial_satisfied_options: Sequence[Sequence[bool]],
+) -> float:
+    """
+    Partial-success (Q-score) for one episode/env: a full success scores 1.0; otherwise the fraction
+    of goal predicates that were NOT satisfied at episode start but ARE satisfied now, maximized over
+    the alternative goal-state options. Mirrors the pre-refactor inline formula (lives here next to its
+    only caller, TaskMetric). Empty options/no options return 0.0 instead of raising.
+    """
+    if success:
+        return 1.0
+    if not now_satisfied_options:
+        return 0.0
+    option_scores = []
+    for now_opt, init_opt in zip(now_satisfied_options, initial_satisfied_options):
+        if len(now_opt) == 0:
+            option_scores.append(0.0)
+            continue
+        newly_satisfied = sum(int((not init) and now) for now, init in zip(now_opt, init_opt))
+        option_scores.append(newly_satisfied / len(now_opt))
+    return max(option_scores) if option_scores else 0.0
 
 
 class TaskMetric(MetricBase):
-    def __init__(self, human_stats: Optional[dict] = None):
-        super().__init__()
+    def __init__(self, human_stats: Optional[dict] = None, env_idx: int = 0):
+        super().__init__(env_idx=env_idx)
         self.timesteps = 0
         self.human_stats = human_stats
         if human_stats is None:
@@ -16,17 +41,13 @@ class TaskMetric(MetricBase):
             }
 
     def reset(self, env):
-        # Single-env metric (used by eval.py / eval_with_jobqueue.py): scene index 0.
-        # _compute_step_metrics' scalar reward/terminated/truncated params and the
-        # env.task.success[0] read assume one env.
-        assert env.num_envs == 1, f"TaskMetric is single-env only; got num_envs={env.num_envs}."
-        self.state[env.scene] = dict()
+        # Tracks env.scenes[env_idx]. Partial-success (Q-score) is computed via the env-aware
+        # BehaviorTask.get_goal_option_satisfaction(env_idx) so each env reports its OWN goal state;
+        # reading ground_goal_state_options[*].evaluate() would bind the shared scope (env 0).
+        self.state[self._scene(env)] = dict()
         self.timesteps = 0
         self.render_timestep = og.sim.get_rendering_dt()
-        self.initial_predicate_states = [
-            [pred.evaluate(env.task._evaluate_predicate) for pred in option]
-            for option in env.task.ground_goal_state_options
-        ]
+        self.initial_predicate_states = env.task.get_goal_option_satisfaction(self.env_idx)
 
     def _compute_step_metrics(self, env, action, obs, reward, terminated, truncated, info):
         self.timesteps += 1
@@ -36,20 +57,13 @@ class TaskMetric(MetricBase):
         # Use the accumulated state from episode_info
         timesteps = episode_info.get("timesteps", [])[-1] if episode_info.get("timesteps") else self.timesteps
 
-        # task.success is a (num_envs,) bool tensor post-#2001; single-env eval reads scene 0
-        if bool(env.task.success[0]):
-            final_q_score = 1.0
-        else:
-            final_q_score = max(
-                sum(
-                    int(not initially_true and pred.evaluate(env.task._evaluate_predicate))
-                    for pred, initially_true in zip(option, option_previous_state)
-                )
-                / len(option)
-                for option, option_previous_state in zip(
-                    env.task.ground_goal_state_options, self.initial_predicate_states
-                )
-            )
+        # task.success is a (num_envs,) bool tensor; read THIS env's slot. Partial credit (when not a
+        # full success) counts newly-satisfied goal predicates per option, max over options.
+        final_q_score = compute_q_score(
+            success=bool(env.task.success[self.env_idx]),
+            now_satisfied_options=env.task.get_goal_option_satisfaction(self.env_idx),
+            initial_satisfied_options=self.initial_predicate_states,
+        )
 
         return {
             "q_score": {"final": final_q_score},

--- a/OmniGibson/omnigibson/metrics/task_metric.py
+++ b/OmniGibson/omnigibson/metrics/task_metric.py
@@ -29,8 +29,8 @@ def compute_q_score(
 
 
 class TaskMetric(MetricBase):
-    def __init__(self, human_stats: Optional[dict] = None, env_idx: int = 0):
-        super().__init__(env_idx=env_idx)
+    def __init__(self, human_stats: Optional[dict] = None, env_idx: int = 0, env_accessor=None):
+        super().__init__(env_idx=env_idx, env_accessor=env_accessor)
         self.timesteps = 0
         self.human_stats = human_stats
         if human_stats is None:
@@ -40,14 +40,16 @@ class TaskMetric(MetricBase):
                 "steps": self.human_stats["length"],
             }
 
-    def reset(self, env):
-        # Tracks env.scenes[env_idx]. Partial-success (Q-score) is computed via the env-aware
-        # BehaviorTask.get_goal_option_satisfaction(env_idx) so each env reports its OWN goal state;
-        # reading ground_goal_state_options[*].evaluate() would bind the shared scope (env 0).
+    def reset(self, env=None):
+        env = self._resolve_env(env)
         self.state[self._scene(env)] = dict()
         self.timesteps = 0
         self.render_timestep = og.sim.get_rendering_dt()
-        self.initial_predicate_states = env.task.get_goal_option_satisfaction(self.env_idx)
+        self.initial_predicate_states = (
+            env.get_goal_option_satisfaction()
+            if env is self.env_accessor
+            else env.task.get_goal_option_satisfaction(self.env_idx)
+        )
 
     def _compute_step_metrics(self, env, action, obs, reward, terminated, truncated, info):
         self.timesteps += 1
@@ -60,8 +62,12 @@ class TaskMetric(MetricBase):
         # task.success is a (num_envs,) bool tensor; read THIS env's slot. Partial credit (when not a
         # full success) counts newly-satisfied goal predicates per option, max over options.
         final_q_score = compute_q_score(
-            success=bool(env.task.success[self.env_idx]),
-            now_satisfied_options=env.task.get_goal_option_satisfaction(self.env_idx),
+            success=env.success if env is self.env_accessor else bool(env.task.success[self.env_idx]),
+            now_satisfied_options=(
+                env.get_goal_option_satisfaction()
+                if env is self.env_accessor
+                else env.task.get_goal_option_satisfaction(self.env_idx)
+            ),
             initial_satisfied_options=self.initial_predicate_states,
         )
 

--- a/OmniGibson/omnigibson/sensors/tiled_sensor.py
+++ b/OmniGibson/omnigibson/sensors/tiled_sensor.py
@@ -112,8 +112,18 @@ class TiledVisionSensor:
 
     def _create_buffers(self, device: str = "cuda:0") -> None:
         self._output_buffer = dict()
+        self._output_warp_buffer = dict()
+        self._reshape_dims = dict()
+        self._num_tiles_x = dict()
         for sensor_name in self._camera_prims:
             self._output_buffer[sensor_name] = dict()
+            self._output_warp_buffer[sensor_name] = dict()
+            self._reshape_dims[sensor_name] = (
+                self._camera_count(sensor_name=sensor_name),
+                self._camera_resolution[sensor_name][1],
+                self._camera_resolution[sensor_name][0],
+            )
+            self._num_tiles_x[sensor_name] = self._tiled_grid_shape(sensor_name=sensor_name)[0]
             for modality in self.modalities[sensor_name]:
                 if modality == "rgb":
                     self._output_buffer[sensor_name][modality] = th.zeros(
@@ -177,6 +187,11 @@ class TiledVisionSensor:
                     ).contiguous()
                 else:
                     raise ValueError(f"Unsupported modality {modality} for tiled vision sensor!")
+                # The output tensors are persistent. Cache their zero-copy Warp aliases instead of
+                # recreating Python/Warp wrappers on every rendered frame.
+                self._output_warp_buffer[sensor_name][modality] = lazy.warp.from_torch(
+                    self._output_buffer[sensor_name][modality]
+                )
 
     def _camera_count(self, sensor_name: str) -> int:
         return len(self._camera_prims[sensor_name])
@@ -203,16 +218,12 @@ class TiledVisionSensor:
                     tiled_data_buffer = tiled_data_buffer[:, :, :2].contiguous()
                 lazy.warp.launch(
                     kernel=reshape_tiled_image,
-                    dim=(
-                        self._camera_count(sensor_name=sensor_name),
-                        self._camera_resolution[sensor_name][1],
-                        self._camera_resolution[sensor_name][0],
-                    ),
+                    dim=self._reshape_dims[sensor_name],
                     inputs=[
                         tiled_data_buffer.flatten(),
-                        lazy.warp.from_torch(self._output_buffer[sensor_name][modality]),  # zero-copy alias
+                        self._output_warp_buffer[sensor_name][modality],
                         *list(self._output_buffer[sensor_name][modality].shape[1:]),  # height, width, num_channels
-                        self._tiled_grid_shape(sensor_name=sensor_name)[0],  # num_tiles_x
+                        self._num_tiles_x[sensor_name],
                     ],
                     device="cuda:0",
                 )

--- a/OmniGibson/omnigibson/tasks/behavior_task.py
+++ b/OmniGibson/omnigibson/tasks/behavior_task.py
@@ -169,6 +169,37 @@ class BehaviorTask(BaseTask):
 
         return evaluate_bddl_predicate(predicate_name, *[self.object_scope[env_idx][ent] for ent in entities])
 
+    def get_goal_option_satisfaction(self, env_idx):
+        """
+        Per-env, per-goal-option predicate satisfaction, evaluated against env @env_idx's own object
+        scope. This is the env-aware building block for the partial-success (Q-score) metric in
+        vectorized evaluation: each goal-state option is evaluated independently so partial credit can
+        be computed (see ``omnigibson.metrics.task_metric.compute_q_score`` and ``TaskMetric``).
+
+        Unlike reading ``ground_goal_state_options[*].evaluate()`` directly (which binds the single,
+        shared ``compiled_task`` scope and therefore returns env 0's result for every env), this routes
+        evaluation through ``_evaluate_predicate(env_idx, ...)`` so each env reports its own state.
+
+        Args:
+            env_idx (int): Index of the environment whose object scope to evaluate against.
+
+        Returns:
+            list[list[bool]]: Outer list is one entry per grounded goal-state option; each inner list
+                has one bool per grounded predicate in that option (True iff currently satisfied for
+                this env).
+        """
+        from bddl.condition_evaluation import evaluate_state
+
+        def evaluate_fn(predicate_name, *entities):
+            return self._evaluate_predicate(env_idx, predicate_name, *entities)
+
+        option_masks = []
+        for option in self.ground_goal_state_options:
+            _, results = evaluate_state(option, evaluate_fn)
+            satisfied = set(results["satisfied"])
+            option_masks.append([i in satisfied for i in range(len(option))])
+        return option_masks
+
     def _create_termination_conditions(self):
         # Initialize termination conditions dict and fill in with Timeout and PredicateGoal
         terminations = dict()

--- a/OmniGibson/tests/test_evaluator.py
+++ b/OmniGibson/tests/test_evaluator.py
@@ -1,18 +1,27 @@
+from types import SimpleNamespace
+
 import pytest
+import torch as th
 
-from omnigibson.eval.evaluator import evaluate_instances_batched
+from omnigibson.eval.evaluator import (
+    BatchedEvaluator,
+    InstanceEnvAccessor,
+    InstanceEvaluationState,
+    evaluate_instances_batched,
+)
+from omnigibson.metrics import TaskMetric
 
 
-def test_evaluate_instances_batched_tracks_slots_and_requires_one_instance_per_slot():
+def test_evaluate_instances_batched_tracks_environments_and_requires_equal_batch_size():
     loaded_batches = []
-    active_slot_history = []
+    active_env_history = []
 
-    def load_fn(slot_to_instance):
-        loaded_batches.append(slot_to_instance)
+    def load_fn(env_idx_to_instance):
+        loaded_batches.append(env_idx_to_instance)
 
-    def step_fn(active_slots):
-        active_slot_history.append(active_slots)
-        if len(active_slot_history) == 1:
+    def step_fn(active_env_indices):
+        active_env_history.append(active_env_indices)
+        if len(active_env_history) == 1:
             return [True, False], [False, False]
         return [False, True], [False, False]
 
@@ -28,11 +37,11 @@ def test_evaluate_instances_batched_tracks_slots_and_requires_one_instance_per_s
     )
 
     assert loaded_batches == [{0: 101, 1: 202}]
-    assert active_slot_history == [[0, 1], [1]]
-    assert results[101] == {"slot": 0, "instance": 101, "step": 1, "terminated": True, "truncated": False}
-    assert results[202] == {"slot": 1, "instance": 202, "step": 2, "terminated": True, "truncated": False}
+    assert active_env_history == [[0, 1], [1]]
+    assert results[101] == {"env_idx": 0, "instance": 101, "step": 1, "terminated": True, "truncated": False}
+    assert results[202] == {"env_idx": 1, "instance": 202, "step": 2, "terminated": True, "truncated": False}
 
-    with pytest.raises(ValueError, match="exactly one instance per environment slot"):
+    with pytest.raises(ValueError, match="exactly one instance per logical environment"):
         evaluate_instances_batched(
             instances=[101],
             num_envs=2,
@@ -40,3 +49,129 @@ def test_evaluate_instances_batched_tracks_slots_and_requires_one_instance_per_s
             step_fn=step_fn,
             record_fn=record_fn,
         )
+
+
+def test_instance_evaluation_state_owns_one_logical_environment():
+    robots = [object(), object()]
+    scenes = [SimpleNamespace(robots=[robot]) for robot in robots]
+    task = SimpleNamespace(
+        object_scope=[{"object": 0}, {"object": 1}],
+        success=th.tensor([False, True]),
+        get_goal_option_satisfaction=lambda env_idx: [[env_idx == 1]],
+    )
+    shared_env = SimpleNamespace(scenes=scenes, task=task)
+
+    states = [
+        InstanceEvaluationState(InstanceEnvAccessor(shared_env=shared_env, env_idx=env_idx)) for env_idx in range(2)
+    ]
+    states[0].instance_id = 101
+    states[0].obs = {"value": 1}
+    states[0].active = True
+
+    assert states[0].env_accessor.scene is scenes[0]
+    assert states[1].env_accessor.robot is robots[1]
+    assert states[1].env_accessor.object_scope == {"object": 1}
+    assert states[1].env_accessor.success
+    assert states[1].env_accessor.get_goal_option_satisfaction() == [[True]]
+    assert states[1].instance_id is None
+    assert states[1].obs is None
+    assert not states[1].active
+    assert states[0].metrics is not states[1].metrics
+
+
+def test_batched_evaluator_steps_shared_resources_once_and_freezes_finished_environments():
+    class FakeMetric:
+        def __init__(self):
+            self.steps = []
+
+        def step(self, **kwargs):
+            self.steps.append(kwargs)
+
+    class FakePolicy:
+        def __init__(self):
+            self.observations = []
+
+        def forward(self, obs):
+            self.observations.append(obs)
+            return th.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    class FakeEnv:
+        def __init__(self):
+            self.step_calls = []
+            self.scenes = [
+                SimpleNamespace(robots=[SimpleNamespace(action_dim=2)]),
+                SimpleNamespace(robots=[SimpleNamespace(action_dim=2)]),
+            ]
+            self.task = SimpleNamespace(activity_name="not_a_light_task")
+
+        def step(self, actions, n_render_iterations):
+            self.step_calls.append((actions.clone(), n_render_iterations))
+            obs = [{"value": th.tensor([10.0])}, {"value": th.tensor([20.0])}]
+            return obs, None, th.tensor([False, False]), th.tensor([False, False]), [{}, {}]
+
+    shared_env = FakeEnv()
+    metrics = [FakeMetric(), FakeMetric()]
+    evaluator = BatchedEvaluator.__new__(BatchedEvaluator)
+    evaluator.num_envs = 2
+    evaluator.env = shared_env
+    evaluator.policy = FakePolicy()
+    evaluator.instance_eval_states = [
+        InstanceEvaluationState(
+            env_accessor=InstanceEnvAccessor(shared_env=shared_env, env_idx=env_idx),
+            metrics=[metrics[env_idx]],
+            obs={"value": th.tensor([float(env_idx)])},
+            active=env_idx == 0,
+        )
+        for env_idx in range(2)
+    ]
+    evaluator._preprocess_obs = lambda obs, instance_eval_state: obs
+
+    evaluator._step_fn(active_env_indices=[0])
+
+    assert len(evaluator.policy.observations) == 1
+    assert evaluator.policy.observations[0]["value"].shape == (2, 1)
+    assert len(shared_env.step_calls) == 1
+    assert th.equal(shared_env.step_calls[0][0], th.tensor([[1.0, 2.0], [0.0, 0.0]]))
+    assert shared_env.step_calls[0][1] == 1
+    assert th.equal(evaluator.instance_eval_states[0].obs["value"], th.tensor([10.0]))
+    assert th.equal(evaluator.instance_eval_states[1].obs["value"], th.tensor([1.0]))
+    assert len(metrics[0].steps) == 1
+    assert metrics[1].steps == []
+
+
+def test_task_metrics_are_isolated_by_instance_environment_accessor(monkeypatch):
+    scenes = [object(), object()]
+
+    class FakeTask:
+        def __init__(self):
+            self.success = th.tensor([False, True])
+            self.goal_options = [[[False, False]], [[False, False]]]
+
+        def get_goal_option_satisfaction(self, env_idx):
+            return self.goal_options[env_idx]
+
+    task = FakeTask()
+    shared_env = SimpleNamespace(scenes=scenes, task=task)
+    monkeypatch.setattr("omnigibson.metrics.task_metric.og.sim", SimpleNamespace(get_rendering_dt=lambda: 0.1))
+    metrics = [
+        TaskMetric(
+            {"length": 10},
+            env_accessor=InstanceEnvAccessor(shared_env=shared_env, env_idx=env_idx),
+        )
+        for env_idx in range(2)
+    ]
+
+    for metric in metrics:
+        metric.reset()
+        metric.step(action=None, obs={}, reward=0.0, terminated=False, truncated=False, info={})
+    task.goal_options = [[[True, False]], [[False, False]]]
+
+    assert metrics[0].aggregate()["q_score"]["final"] == 0.5
+    assert metrics[1].aggregate()["q_score"]["final"] == 1.0
+
+    task.goal_options[0] = [[False, False]]
+    legacy_metric = TaskMetric({"length": 10}, env_idx=0)
+    legacy_metric.reset(shared_env)
+    legacy_metric.step(shared_env, None, {}, 0.0, False, False, {})
+    task.goal_options[0] = [[True, False]]
+    assert legacy_metric.aggregate(shared_env)["q_score"]["final"] == 0.5

--- a/OmniGibson/tests/test_evaluator.py
+++ b/OmniGibson/tests/test_evaluator.py
@@ -1,0 +1,42 @@
+import pytest
+
+from omnigibson.eval.evaluator import evaluate_instances_batched
+
+
+def test_evaluate_instances_batched_tracks_slots_and_requires_one_instance_per_slot():
+    loaded_batches = []
+    active_slot_history = []
+
+    def load_fn(slot_to_instance):
+        loaded_batches.append(slot_to_instance)
+
+    def step_fn(active_slots):
+        active_slot_history.append(active_slots)
+        if len(active_slot_history) == 1:
+            return [True, False], [False, False]
+        return [False, True], [False, False]
+
+    def record_fn(**record):
+        return record
+
+    results = evaluate_instances_batched(
+        instances=[101, 202],
+        num_envs=2,
+        load_fn=load_fn,
+        step_fn=step_fn,
+        record_fn=record_fn,
+    )
+
+    assert loaded_batches == [{0: 101, 1: 202}]
+    assert active_slot_history == [[0, 1], [1]]
+    assert results[101] == {"slot": 0, "instance": 101, "step": 1, "terminated": True, "truncated": False}
+    assert results[202] == {"slot": 1, "instance": 202, "step": 2, "terminated": True, "truncated": False}
+
+    with pytest.raises(ValueError, match="exactly one instance per environment slot"):
+        evaluate_instances_batched(
+            instances=[101],
+            num_envs=2,
+            load_fn=load_fn,
+            step_fn=step_fn,
+            record_fn=record_fn,
+        )

--- a/OmniGibson/tests/test_tiled_rendering.py
+++ b/OmniGibson/tests/test_tiled_rendering.py
@@ -75,7 +75,7 @@ def _camera_sensor_name(robot):
 
 def _place_markers(env, distances):
     """Teleport each scene's marker cube directly in front of that env's camera at the given distance."""
-    for env_idx, scene in enumerate(env.scenes):
+    for env_idx, scene in enumerate(env._scenes):
         robot = scene.robots[0]
         cam = robot.sensors[_camera_sensor_name(robot)]
         cam_pos, cam_quat = cam.get_position_orientation()
@@ -102,13 +102,18 @@ def test_tiled_rendering_core():
             obs_modalities=["rgb", "depth_linear", "proprio"],
             objects_cfg=MARKER_CFG,
         )
-        robot_name = env.scenes[0].robots[0].name
-        cam_name = _camera_sensor_name(env.scenes[0].robots[0])
+        robot_name = env._scenes[0].robots[0].name
+        cam_name = _camera_sensor_name(env._scenes[0].robots[0])
 
         # --- Tiled sensor is active and covers the camera with the requested modalities ---
         assert env._tiled_sensor is not None, "Tiled sensor should be created when num_envs > 1"
         assert cam_name in env._tiled_sensor.modalities
         assert {"rgb", "depth_linear"} == set(env._tiled_sensor.modalities[cam_name])
+        for scene in env._scenes:
+            camera = scene.robots[0].sensors[cam_name]
+            assert (
+                not camera.render_product.hydra_texture.updates_enabled
+            ), "Individual camera render products must be paused when tiled rendering supplies observations"
 
         # --- Knob plumbing: default number of re-renders on reset ---
         assert env._num_rerenders_on_reset == 3
@@ -149,14 +154,26 @@ def test_tiled_rendering_core():
 
         # --- Parity with per-sensor rendering. Depth is the strict geometric check; rgb is loose since
         # the tiled and per-sensor render products denoise/accumulate samples differently ---
-        for i in range(NUM_ENVS):
-            sensor = env.scenes[i].robots[0].sensors[cam_name]
-            s_obs, _ = sensor.get_obs()
-            tiled_rgb = obs_list[i][robot_name][cam_name]["rgb"].float().cpu()
+        individual_sensors = [scene.robots[0].sensors[cam_name] for scene in env._scenes]
+        individual_obs = []
+        with og.sim.editing_usd():
+            for sensor in individual_sensors:
+                sensor.render_product.hydra_texture.updates_enabled = True
+        try:
+            for _ in range(8):
+                og.sim.render()
+            parity_tiled_obs, _ = env.get_obs()
+            individual_obs = [sensor.get_obs()[0] for sensor in individual_sensors]
+        finally:
+            with og.sim.editing_usd():
+                for sensor in individual_sensors:
+                    sensor.render_product.hydra_texture.updates_enabled = False
+        for i, s_obs in enumerate(individual_obs):
+            tiled_rgb = parity_tiled_obs[i][robot_name][cam_name]["rgb"].float().cpu()
             sensor_rgb = s_obs["rgb"].float().cpu()
             mean_diff = (tiled_rgb - sensor_rgb).abs().mean().item()
             assert mean_diff < 40.0, f"env {i}: tiled vs per-sensor rgb mean abs diff {mean_diff:.1f}"
-            tiled_depth_center = _center_patch(obs_list[i][robot_name][cam_name]["depth_linear"].cpu()).median()
+            tiled_depth_center = _center_patch(parity_tiled_obs[i][robot_name][cam_name]["depth_linear"].cpu()).median()
             sensor_depth_center = _center_patch(s_obs["depth_linear"].cpu()).median()
             assert abs(tiled_depth_center - sensor_depth_center) < 0.2, f"env {i}: tiled vs per-sensor depth mismatch"
 
@@ -174,12 +191,13 @@ def test_tiled_rendering_core():
 
         # --- step() returns tiled observations as well ---
         actions = th.stack(
-            [th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)]
+            [th.from_numpy(env._scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)]
         )
         obs_list, _, _, _, _ = env.step(actions)
         assert obs_list[0][robot_name][cam_name]["rgb"].shape == (128, 128, 4)
     finally:
-        og.clear()
+        if og.sim is not None:
+            og.clear()
 
 
 def test_tiled_rendering_empty_scene():
@@ -196,27 +214,28 @@ def test_tiled_rendering_empty_scene():
         assert env._num_rerenders_on_reset == 2
 
         # --- Scene offsets must be finite and strictly increasing along x ---
-        xs = [scene.get_position_orientation()[0][0].item() for scene in env.scenes]
+        xs = [scene.get_position_orientation()[0][0].item() for scene in env._scenes]
         assert all(th.isfinite(th.tensor(xs))), f"Non-finite scene positions: {xs}"
         assert xs[0] == pytest.approx(0.0, abs=1e-3)
         assert xs[1] > xs[0] and xs[2] > xs[1], f"Scene positions not increasing: {xs}"
 
         # --- Robots must be placed apart accordingly ---
-        robot_xs = [scene.robots[0].get_position_orientation()[0][0].item() for scene in env.scenes]
+        robot_xs = [scene.robots[0].get_position_orientation()[0][0].item() for scene in env._scenes]
         assert robot_xs[1] > robot_xs[0] and robot_xs[2] > robot_xs[1], f"Robot positions not increasing: {robot_xs}"
 
         # --- Stepping and tiled observations work in empty scenes ---
-        robot_name = env.scenes[0].robots[0].name
-        cam_name = _camera_sensor_name(env.scenes[0].robots[0])
+        robot_name = env._scenes[0].robots[0].name
+        cam_name = _camera_sensor_name(env._scenes[0].robots[0])
         actions = th.stack(
-            [th.from_numpy(env.scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)]
+            [th.from_numpy(env._scenes[i].robots[0].action_space.sample()).float() for i in range(env.num_envs)]
         )
         obs_list, _, _, _, _ = env.step(actions)
         for i in range(3):
             rgb = obs_list[i][robot_name][cam_name]["rgb"]
             assert rgb.shape == (128, 128, 4) and rgb.dtype == th.uint8
     finally:
-        og.clear()
+        if og.sim is not None:
+            og.clear()
 
 
 def test_tiled_rendering_unsupported_modality():

--- a/docs/challenge/evaluation.md
+++ b/docs/challenge/evaluation.md
@@ -60,11 +60,11 @@ Key arguments:
     </tr>
     <tr>
       <td><code>--instance-indices</code></td>
-      <td>Indices into the task's test instance list. Use indices <code>0 1 2 3 4 5 6 7 8 9</code> for reported evaluation results. Indices <code>0-19</code> are public test instances; indices <code>20-39</code> are hidden instances reserved for final evaluation. Select exactly one instance per parallel environment slot.</td>
+      <td>Indices into the task's test instance list. Use indices <code>0 1 2 3 4 5 6 7 8 9</code> for reported evaluation results. Indices <code>0-19</code> are public test instances; indices <code>20-39</code> are hidden instances reserved for final evaluation. Select exactly one instance per logical environment in the evaluation batch.</td>
     </tr>
     <tr>
       <td><code>--num-envs</code></td>
-      <td>Number of parallel environment slots. This must equal the number of values passed to <code>--instance-indices</code>.</td>
+      <td>Number of logical environments processed together as one evaluation batch. This must equal the number of values passed to <code>--instance-indices</code>.</td>
     </tr>
     <tr>
       <td><code>--num-rollouts</code></td>

--- a/docs/challenge/evaluation.md
+++ b/docs/challenge/evaluation.md
@@ -60,7 +60,11 @@ Key arguments:
     </tr>
     <tr>
       <td><code>--instance-indices</code></td>
-      <td>Indices into the task's test instance list. Use indices <code>0 1 2 3 4 5 6 7 8 9</code> for reported evaluation results. Indices <code>0-19</code> are public test instances; indices <code>20-39</code> are hidden instances reserved for final evaluation.</td>
+      <td>Indices into the task's test instance list. Use indices <code>0 1 2 3 4 5 6 7 8 9</code> for reported evaluation results. Indices <code>0-19</code> are public test instances; indices <code>20-39</code> are hidden instances reserved for final evaluation. Select exactly one instance per parallel environment slot.</td>
+    </tr>
+    <tr>
+      <td><code>--num-envs</code></td>
+      <td>Number of parallel environment slots. This must equal the number of values passed to <code>--instance-indices</code>.</td>
     </tr>
     <tr>
       <td><code>--num-rollouts</code></td>
@@ -94,6 +98,30 @@ Key arguments:
 </table>
 
 The evaluator sends flattened observations to the policy server. The server should return a msgpack-encoded response containing an `action` array with the robot action for the current step. The helper server implementation is `WebsocketPolicyServer` in `OmniGibson/omnigibson/eval/utils/network_utils.py`, and the evaluator-side client is `omnigibson.eval.policies.WebsocketPolicy`.
+
+### Optional action-chunk replay protocol
+
+Action-chunk replay is disabled by default. Setting <code>--replay-action-chunk-size K</code> with
+<code>K &gt; 1</code> asks a compatible policy server for <code>K</code> actions by adding the reserved
+<code>__action_chunk_size__</code> field to the observation request. The server response must contain:
+
+```python
+{
+    "action": ...,        # shape: (..., action_dim)
+    "action_chunk": ...,  # shape: (..., K, action_dim)
+}
+```
+
+The first action in <code>action_chunk</code> must exactly equal <code>action</code>. The client returns that first
+action immediately, then executes the remaining <code>K - 1</code> actions without another websocket request.
+The cached chunk is cleared on episode reset. If a server omits <code>action_chunk</code>, the client logs a warning
+and falls back to one request per simulator step. The generic <code>WebsocketPolicyServer</code> implements this
+fallback protocol; a chunk-capable policy server must implement the optional response field itself.
+
+Only enable replay when the server returns an action sequence intended to be executed open-loop from the current
+observation, such as one receding-horizon policy chunk, and choose <code>K</code> so replay never crosses the policy's
+replanning boundary. Do not enable it for temporal ensembling or for a server that repeatedly re-runs or blends the
+policy on the same stale observation; those actions are not equivalent to normal closed-loop evaluation.
 
 Each successful rollout produces a JSON result containing `q_score`, `time`, `agent_distance`, and normalized efficiency metrics. For challenge submissions, run evaluation with `--write-video`; this records the head and wrist camera videos that must be submitted with the rollout metrics.
 


### PR DESCRIPTION
## Summary

  This PR adds vectorized BEHAVIOR policy evaluation so multiple task instances can run concurrently in one OmniGibson process.

  It also removes redundant rendering and observation-processing work while preserving the policy’s per-step inputs.

  ## What changed

  ### Batched evaluation

  - Added `--num-envs` to evaluate multiple task instances in parallel.
  - Reworked the evaluator around one multi-environment OmniGibson environment.
  - Batch-loads, settles, resets, and steps task instances.
  - Sends one batched observation to the policy and receives one batched action tensor.
  - Tracks observations, metrics, videos, light synchronization, success, and termination independently for each environment slot.
  - Keeps finished slots inactive until the current group completes so loading another instance cannot disturb scenes that are still running.

  ### Correct per-environment metrics

  - Made task and agent metrics environment-aware.
  - Evaluates BDDL goal predicates against each environment’s own object scope.
  - Computes Q-score, simulator time, and agent distance independently for each slot.

  ### Camera and rendering improvements

  - Configures camera modalities and resolutions before environment construction, which is required because tiled-render dimensions are fixed when the sensor is created.
  - Uses the existing tiled renderer as the source of multi-environment robot-camera observations.
  - Pauses redundant individual robot-camera render products while tiled rendering is active.
  - Disables the unused 1280×720 debug viewer during headless evaluation.
  - Caches persistent Warp aliases and tiled-image reshape metadata.
  - Preserves opt-out environment variables for controlled A/B testing.

  ### Policy transport

  - Adds optional server-provided action-chunk replay.
  - Replay is disabled by default.
  - When enabled, the client validates chunk shape and verifies that the first chunk action exactly matches the server’s immediate action.
  - Servers that do not return a chunk fall back to one request per step.
  ## Why

  The previous evaluator processed task instances sequentially and repeated work that could be shared or batched:

  - simulation and rendering were run separately for every instance;
  - policy inference and websocket transport were called once per environment;
  - tiled rendering ran alongside unused individual camera products;
  - headless evaluation still constructed and rendered an unused debug viewer.

  These changes increase evaluation throughput while continuing to render and deliver fresh camera observations at every policy step. The earlier render-skipping experiment is not included because it changed policy inputs.

  ## Testing

  Local validation:

  - `OMNIGIBSON_HEADLESS=1 pytest -q tests/test_tiled_rendering.py`
    - 3 passed
  - `OMNIGIBSON_HEADLESS=1 pytest -q tests/test_multiple_envs_behavior_task.py`
    - 12 passed
  - Python compilation passed for all changed modules.
  - `git diff --check` passed.
  - Completed full-length real-GR00T rollout testing.
  - Compared tiled observations against temporarily re-enabled individual camera products for RGB and depth consistency.
  - Verified that the optimized path contains no skipped-render or stale-observation logic.