### PR TITLE
Fix four multi-scene correctness bugs found by evaluating the 2025 challenge policy at num_envs=10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,8 @@ jobs:
           - test_multiple_envs_behavior_infra_api
           - test_multiple_envs_behavior_infra_scene
           - test_multiple_envs_behavior_task
+          - test_multiple_envs_heat_states
+          - test_multiple_envs_transition_rules
           - test_object_removal
           - test_object_states
           # - test_primitives

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,7 @@ jobs:
           - test_multiple_envs_behavior_infra_api
           - test_multiple_envs_behavior_infra_scene
           - test_multiple_envs_behavior_task
+          - test_multiple_envs_heat_narrow_phase
           - test_multiple_envs_heat_states
           - test_multiple_envs_transition_rules
           - test_object_removal

--- a/OmniGibson/omnigibson/object_states/heat_source_or_sink.py
+++ b/OmniGibson/omnigibson/object_states/heat_source_or_sink.py
@@ -105,7 +105,7 @@ class HeatSourceOrSink(TensorizedAbsoluteState, LinkBasedStateMixin):
     _requires_inside = None  # wp.array (N_hss,) uint8
     _requires_on_fire = None  # wp.array (N_hss,) uint8
     _ignition_temperatures = None  # wp.array (N_hss,) float32 — self-clamp threshold (requires_on_fire only)
-    _link_flat_idx = None  # wp.array (N_hss,) int32 into RigidBodyViewAPI.POSE_MATRICES — -1 if requires_inside
+    _link_flat_idx = None  # wp.array (S_hss, N_hss) int32 into RigidBodyViewAPI.POSE_MATRICES — -1 if requires_inside
     _link_local_offset = None  # wp.array (N_hss,) vec3 — offset of heat element in link frame
 
     # Index maps into the gate states' OBJ_IDXS — rebuilt in pre_update because OnFire's view
@@ -326,7 +326,11 @@ class HeatSourceOrSink(TensorizedAbsoluteState, LinkBasedStateMixin):
         requires_inside = th.zeros(N, dtype=th.uint8)
         requires_on_fire = th.zeros(N, dtype=th.uint8)
         ignition_temperatures = th.zeros(N, dtype=th.float32)
-        link_flat_idx = th.full((N,), -1, dtype=th.int32)
+        # Per (scene, source): each scene's clone of a source is a DIFFERENT rigid body with its
+        # own flat index into RigidBodyViewAPI.POSE_MATRICES, so the element link index must be
+        # resolved per scene. (The config arrays above stay (N,) — they are scene-invariant.)
+        S = len(cls.IDX_OBJS)
+        link_flat_idx = th.full((S, N), -1, dtype=th.int32)
         link_local_offset = th.zeros((N, 3), dtype=th.float32)
 
         for _, hss_obj_idx in cls.OBJ_IDXS.items():
@@ -348,17 +352,23 @@ class HeatSourceOrSink(TensorizedAbsoluteState, LinkBasedStateMixin):
             if not hss_state_instance.requires_inside:
                 # Store this hss' heat element link so Temperature can compute source positions:
                 # the meta link when annotated (e.g. a candle wick), the root link for fire sources
-                # without one.
-                if hss_state_instance._links:
-                    link = hss_state_instance.link
-                elif hss_state_instance.requires_on_fire:
-                    link = hss_state_instance.obj.root_link
-                else:
-                    link = None
-                if link is not None:
-                    flat = RigidBodyViewAPI.get_flat_idx(link.prim_path)
-                    if flat is not None:
-                        link_flat_idx[hss_obj_idx] = int(flat)
+                # without one. Resolved PER SCENE: each scene's clone has its own link prim (and
+                # therefore its own flat pose index).
+                for s_idx, scene_row in enumerate(cls.IDX_OBJS):
+                    scene_obj = scene_row[hss_obj_idx]
+                    if scene_obj is None:
+                        continue
+                    scene_state = scene_obj.states[cls]
+                    if scene_state._links:
+                        link = scene_state.link
+                    elif scene_state.requires_on_fire:
+                        link = scene_obj.root_link
+                    else:
+                        link = None
+                    if link is not None:
+                        flat = RigidBodyViewAPI.get_flat_idx(link.prim_path)
+                        if flat is not None:
+                            link_flat_idx[s_idx, hss_obj_idx] = int(flat)
 
         create_tensor_from_list = lazy.isaacsim.core.utils.warp.tensor.create_tensor_from_list
         cls._temperatures = create_tensor_from_list(temperatures, "float32", device="cuda")
@@ -369,7 +379,8 @@ class HeatSourceOrSink(TensorizedAbsoluteState, LinkBasedStateMixin):
         cls._requires_inside = create_tensor_from_list(requires_inside, "uint8", device="cuda")
         cls._requires_on_fire = create_tensor_from_list(requires_on_fire, "uint8", device="cuda")
         cls._ignition_temperatures = create_tensor_from_list(ignition_temperatures, "float32", device="cuda")
-        cls._link_flat_idx = create_tensor_from_list(link_flat_idx, "int32", device="cuda")
+        # (S, N) int32 — wp.array reinterprets the 2D torch buffer directly.
+        cls._link_flat_idx = wp.array(link_flat_idx, dtype=wp.int32, device="cuda")
         # vec3 has no scalar-only helper — wp.array reinterprets the (N, 3) float32 CPU buffer as (N,) vec3.
         cls._link_local_offset = wp.array(link_local_offset, dtype=wp.vec3, device="cuda")
 
@@ -488,6 +499,13 @@ class HeatSourceOrSink(TensorizedAbsoluteState, LinkBasedStateMixin):
         self.VALUES[s, obj_idx] = bool(new_value)
         self.VALUES_CPU[s, obj_idx] = bool(new_value)
         return True
+
+    # The activation gate is fully derived (recomputed every step from ToggledOn / Open / OnFire),
+    # so loading must be a no-op — matching main, where HeatSourceOrSink is not stateful. The
+    # inherited TensorizedAbsoluteState._load_state would restore a stale gate value that could
+    # make a source active (heating) for the first step after a scene load / reset.
+    def _load_state(self, state):
+        return
 
     def affects_obj(self, obj):
         """

--- a/OmniGibson/omnigibson/object_states/on_fire.py
+++ b/OmniGibson/omnigibson/object_states/on_fire.py
@@ -185,4 +185,11 @@ class OnFire(TensorizedAbsoluteState):
         self.VALUES_CPU[s, h] = bool(new_value)
         return True
 
-    # Nothing needs to be done to save/load OnFire since it is derived from Temperature.
+    # OnFire is fully derived from Temperature (a pure threshold detector), so loading must be a
+    # no-op — matching main, where OnFire is not stateful at all. Overriding the inherited
+    # TensorizedAbsoluteState._load_state is REQUIRED: the generic implementation routes through
+    # _set_value(stored_value), and _set_value(False) writes Temperature = ignition_temperature - 1
+    # (~249 C) — i.e. restoring a saved `on_fire: False` would HEAT a cold flammable object on
+    # every scene load / reset.
+    def _load_state(self, state):
+        return

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -31,7 +31,7 @@ def _incoming_heat_kernel(
     distance_thresholds: wp.array(dtype=wp.float32),  # (N_hss,)
     hss_self_temp_idx: wp.array(dtype=wp.int32),  # (N_hss,) into Temperature N — to skip self
     hss_self_inside_idx: wp.array(dtype=wp.int32),  # (N_hss,) into Inside N (for requires_inside)
-    link_flat_idx: wp.array(dtype=wp.int32),  # (N_hss,) into POSE_MATRICES — -1 if N/A
+    link_flat_idx: wp.array2d(dtype=wp.int32),  # (S_hss, N_hss) into POSE_MATRICES — -1 if N/A
     link_local_offset: wp.array(dtype=wp.vec3),  # (N_hss,) heat element offset in link local frame
     temp_to_aabb_idx: wp.array(dtype=wp.int32),  # (N_temp,) Temperature N → AABB N
     temp_to_inside_idx: wp.array(dtype=wp.int32),  # (N_temp,) Temperature N → Inside N
@@ -67,9 +67,10 @@ def _incoming_heat_kernel(
             return
         if inside_values[s, target_idx_in_inside, src_idx_in_inside] == wp.uint8(0):
             return
-    # point sources: target's AABB center must be within the distance threshold of the heat element
+    # point sources: target's AABB center must be within the distance threshold of the heat element.
+    # The element link is a different rigid body in every scene, so its pose index is per (s, h).
     else:
-        li = link_flat_idx[h]
+        li = link_flat_idx[s, h]
         if li < wp.int32(0):
             return
         link_pose = pose_matrices[li]

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -67,7 +67,7 @@ def _incoming_heat_kernel(
             return
         if inside_values[s, target_idx_in_inside, src_idx_in_inside] == wp.uint8(0):
             return
-    # point sources: target's AABB center must be within the distance threshold of the heat element.
+    # point sources: the target's AABB must be within the distance threshold of the heat element.
     # The element link is a different rigid body in every scene, so its pose index is per (s, h).
     else:
         li = link_flat_idx[s, h]
@@ -79,11 +79,20 @@ def _incoming_heat_kernel(
             link_pose, wp.vec4(local_offset[0], local_offset[1], local_offset[2], wp.float32(1.0))
         )
         # Distance from the heat element to the CLOSEST POINT of the target's AABB (element
-        # position clamped into the box). This mirrors the pre-vectorization semantics, which
-        # used a PhysX overlap_sphere(threshold) collision query — any surface contact with the
-        # sphere counted. Using the AABB *center* instead silently shrinks every source's reach
-        # by the target's own extent (e.g. a sausage in a pan on a burner grazes the sphere but
-        # its center is beyond the threshold, so it would never cook).
+        # position clamped into the box).
+        #
+        # This is an APPROXIMATION of the pre-vectorization behaviour, which ran a PhysX
+        # overlap_sphere(threshold) scene query against the target's actual COLLISION GEOMETRY
+        # (heat_source_or_sink.py on main). Since a target's AABB always contains its geometry,
+        # distance-to-AABB <= distance-to-geometry, so this test is slightly MORE permissive than
+        # overlap_sphere — most visibly for long, thin or diagonally-oriented targets whose AABB
+        # is much larger than the mesh itself.
+        #
+        # It is nonetheless much closer than what it replaces: testing the AABB *center* shrinks
+        # every source's reach by the target's own extent (e.g. a sausage in a pan on a burner
+        # grazes the sphere, but its center is beyond the threshold, so it would never cook).
+        # An exact port would need per-(source, target) mesh queries inside this kernel, which is
+        # not available to Warp here; see the PR discussion for the trade-off.
         qx = wp.clamp(source_world_position[0], aabb_values[s, target_aabb_idx, 0], aabb_values[s, target_aabb_idx, 3])
         qy = wp.clamp(source_world_position[1], aabb_values[s, target_aabb_idx, 1], aabb_values[s, target_aabb_idx, 4])
         qz = wp.clamp(source_world_position[2], aabb_values[s, target_aabb_idx, 2], aabb_values[s, target_aabb_idx, 5])

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -78,14 +78,18 @@ def _incoming_heat_kernel(
         source_world_position = wp.mul(
             link_pose, wp.vec4(local_offset[0], local_offset[1], local_offset[2], wp.float32(1.0))
         )
-        # get cx, cy, cz: center x, y, z of target's aabb bounding box
-        cx = (aabb_values[s, target_aabb_idx, 0] + aabb_values[s, target_aabb_idx, 3]) * wp.float32(0.5)
-        cy = (aabb_values[s, target_aabb_idx, 1] + aabb_values[s, target_aabb_idx, 4]) * wp.float32(0.5)
-        cz = (aabb_values[s, target_aabb_idx, 2] + aabb_values[s, target_aabb_idx, 5]) * wp.float32(0.5)
-        # get dx, dy, dz: delta of source position and target's center on 3 directions
-        dx = source_world_position[0] - cx
-        dy = source_world_position[1] - cy
-        dz = source_world_position[2] - cz
+        # Distance from the heat element to the CLOSEST POINT of the target's AABB (element
+        # position clamped into the box). This mirrors the pre-vectorization semantics, which
+        # used a PhysX overlap_sphere(threshold) collision query — any surface contact with the
+        # sphere counted. Using the AABB *center* instead silently shrinks every source's reach
+        # by the target's own extent (e.g. a sausage in a pan on a burner grazes the sphere but
+        # its center is beyond the threshold, so it would never cook).
+        qx = wp.clamp(source_world_position[0], aabb_values[s, target_aabb_idx, 0], aabb_values[s, target_aabb_idx, 3])
+        qy = wp.clamp(source_world_position[1], aabb_values[s, target_aabb_idx, 1], aabb_values[s, target_aabb_idx, 4])
+        qz = wp.clamp(source_world_position[2], aabb_values[s, target_aabb_idx, 2], aabb_values[s, target_aabb_idx, 5])
+        dx = source_world_position[0] - qx
+        dy = source_world_position[1] - qy
+        dz = source_world_position[2] - qz
         d2 = dx * dx + dy * dy + dz * dz
         threshold = distance_thresholds[h]
         if d2 > threshold * threshold:

--- a/OmniGibson/omnigibson/object_states/temperature.py
+++ b/OmniGibson/omnigibson/object_states/temperature.py
@@ -8,6 +8,7 @@ from omnigibson.object_states.heat_source_or_sink import HeatSourceOrSink
 from omnigibson.object_states.inside import Inside
 from omnigibson.object_states.tensorized_absolute_state import TensorizedAbsoluteState
 from omnigibson.object_states.tensorized_state import TensorizedState, _wp_from_torch
+from omnigibson.utils.constants import PrimType
 from omnigibson.utils.python_utils import classproperty
 from omnigibson.utils.usd_utils import RigidBodyViewAPI
 
@@ -35,6 +36,10 @@ def _incoming_heat_kernel(
     link_local_offset: wp.array(dtype=wp.vec3),  # (N_hss,) heat element offset in link local frame
     temp_to_aabb_idx: wp.array(dtype=wp.int32),  # (N_temp,) Temperature N → AABB N
     temp_to_inside_idx: wp.array(dtype=wp.int32),  # (N_temp,) Temperature N → Inside N
+    target_link_offsets: wp.array(dtype=wp.int32),  # (S_temp*N_temp+1,) CSR offsets into the below
+    target_link_indices: wp.array(dtype=wp.int32),  # (K,) flat link idx of each target's collision links
+    link_mesh_ids: wp.array(dtype=wp.uint64),  # RigidBodyViewAPI.LINK_MESH_IDS — 0 if no mesh
+    n_temp: wp.int32,  # targets per scene, to index the CSR table by (s, n)
     pose_matrices: wp.array(dtype=wp.mat44),  # RigidBodyViewAPI.POSE_MATRICES
     aabb_values: wp.array3d(dtype=wp.float32),  # AABB (S, N_aabb, 6)
     inside_values: wp.array3d(dtype=wp.uint8),  # Inside (S, N_inside, N_inside) — uint8 view of bool
@@ -78,21 +83,19 @@ def _incoming_heat_kernel(
         source_world_position = wp.mul(
             link_pose, wp.vec4(local_offset[0], local_offset[1], local_offset[2], wp.float32(1.0))
         )
-        # Distance from the heat element to the CLOSEST POINT of the target's AABB (element
-        # position clamped into the box).
+        # BROAD PHASE: distance from the heat element to the CLOSEST POINT of the target's AABB
+        # (element position clamped into the box).
         #
-        # This is an APPROXIMATION of the pre-vectorization behaviour, which ran a PhysX
-        # overlap_sphere(threshold) scene query against the target's actual COLLISION GEOMETRY
-        # (heat_source_or_sink.py on main). Since a target's AABB always contains its geometry,
-        # distance-to-AABB <= distance-to-geometry, so this test is slightly MORE permissive than
-        # overlap_sphere — most visibly for long, thin or diagonally-oriented targets whose AABB
-        # is much larger than the mesh itself.
+        # Pre-vectorization this test was a PhysX overlap_sphere(threshold) scene query against the
+        # target's actual COLLISION GEOMETRY (heat_source_or_sink.py on main). That is a CPU-side
+        # query with a callback, one call per source, so it cannot run inside this kernel. Instead
+        # we reproduce it in two stages: this cheap AABB test rejects almost everything, and the
+        # narrow phase below measures to the real meshes for whatever survives.
         #
-        # It is nonetheless much closer than what it replaces: testing the AABB *center* shrinks
-        # every source's reach by the target's own extent (e.g. a sausage in a pan on a burner
-        # grazes the sphere, but its center is beyond the threshold, so it would never cook).
-        # An exact port would need per-(source, target) mesh queries inside this kernel, which is
-        # not available to Warp here; see the PR discussion for the trade-off.
+        # An AABB always contains its geometry, so distance-to-AABB <= distance-to-geometry and
+        # this stage never rejects a pair overlap_sphere would have accepted — exactly what a broad
+        # phase must guarantee. It is only *too permissive* on its own, most visibly for long, thin
+        # or diagonally-oriented targets (measured 0.69 m of slack for a bar along a box diagonal).
         qx = wp.clamp(source_world_position[0], aabb_values[s, target_aabb_idx, 0], aabb_values[s, target_aabb_idx, 3])
         qy = wp.clamp(source_world_position[1], aabb_values[s, target_aabb_idx, 1], aabb_values[s, target_aabb_idx, 4])
         qz = wp.clamp(source_world_position[2], aabb_values[s, target_aabb_idx, 2], aabb_values[s, target_aabb_idx, 5])
@@ -103,6 +106,68 @@ def _incoming_heat_kernel(
         threshold = distance_thresholds[h]
         if d2 > threshold * threshold:
             return
+
+        # NARROW PHASE — the AABB test above is only a conservative broad phase (AABB contains the
+        # geometry, so it can pass for targets whose mesh is far away; measured 0.69 m of slack for
+        # a bar lying along a box diagonal). Reproduce main's overlap_sphere by measuring to the
+        # target's actual collision meshes, but only for pairs that survived the broad phase.
+        base = s * n_temp + n
+        lo = target_link_offsets[base]
+        hi = target_link_offsets[base + wp.int32(1)]
+        if hi > lo:  # targets with no collision geometry (e.g. cloth) keep the AABB result
+            # Search radius. Normally the threshold is enough. But if the element is INSIDE the
+            # target's AABB (d2 == 0) it may also be inside the mesh, and the nearest surface can
+            # then be farther away than the threshold — querying only to `threshold` would return
+            # no result and we would miss a containment that overlap_sphere reports as contact.
+            # Widen the radius by the AABB diagonal in exactly that case, so the cost is paid only
+            # for the rare candidate rather than on every pair.
+            max_d = threshold
+            if d2 == wp.float32(0.0):
+                ex = aabb_values[s, target_aabb_idx, 3] - aabb_values[s, target_aabb_idx, 0]
+                ey = aabb_values[s, target_aabb_idx, 4] - aabb_values[s, target_aabb_idx, 1]
+                ez = aabb_values[s, target_aabb_idx, 5] - aabb_values[s, target_aabb_idx, 2]
+                max_d = threshold + wp.sqrt(ex * ex + ey * ey + ez * ez)
+            hit = wp.int32(0)
+            for k in range(lo, hi):
+                body = target_link_indices[k]
+                mesh_id = link_mesh_ids[body]
+                if mesh_id == wp.uint64(0):
+                    continue
+                # Into the link's local frame. collision_mesh_cpu_data bakes world scale into the
+                # points, so POSE_MATRICES is a pure rotation+translation and its inverse is
+                # (R^T, -R^T t) — cheaper and stabler than a general 4x4 inverse, and because the
+                # transform is rigid the distance measured here equals the world-frame distance.
+                lp = pose_matrices[body]
+                rot = wp.mat33(
+                    lp[0, 0],
+                    lp[0, 1],
+                    lp[0, 2],
+                    lp[1, 0],
+                    lp[1, 1],
+                    lp[1, 2],
+                    lp[2, 0],
+                    lp[2, 1],
+                    lp[2, 2],
+                )
+                rel = wp.vec3(
+                    source_world_position[0] - lp[0, 3],
+                    source_world_position[1] - lp[1, 3],
+                    source_world_position[2] - lp[2, 3],
+                )
+                local_p = wp.transpose(rot) * rel
+                # Links farther than max_d return no result, so they cost nothing.
+                res = wp.mesh_query_point(mesh_id, local_p, max_d)
+                if res.result:
+                    cp = wp.mesh_eval_position(mesh_id, res.face, res.u, res.v)
+                    dist = wp.length(local_p - cp)
+                    # A negative sign means the element is INSIDE this mesh. overlap_sphere counts
+                    # containment as contact, so accept it regardless of the distance out to the
+                    # surface — otherwise a large pot enclosing a burner would stop cooking.
+                    if res.sign < wp.float32(0.0) or dist <= threshold:
+                        hit = wp.int32(1)
+                        break
+            if hit == wp.int32(0):
+                return
 
     influence_mask[s, h, n] = wp.uint8(1)
     delta = (source_temperatures[h] - temperature_values[s, n]) * heating_rates[h]
@@ -205,6 +270,15 @@ class Temperature(TensorizedAbsoluteState):
     _temp_to_aabb_idx = None  # wp.array (N_temp,) int32 — Temperature N → AABB N
     _temp_to_inside_idx = None  # wp.array (N_temp,) int32 — Temperature N → Inside N
 
+    # CSR table giving each (scene, target) its collision-geometry links, so the point-source
+    # proximity test can measure to the target's actual mesh rather than to its AABB. For scene s
+    # and Temperature index n the links are
+    #   _target_link_indices[_target_link_offsets[s * N_temp + n] : _target_link_offsets[... + 1]]
+    # indexing RigidBodyViewAPI.POSE_MATRICES / LINK_MESH_IDS. Targets with no collision geometry
+    # (e.g. cloth, which is absent from RigidBodyViewAPI) get an empty range.
+    _target_link_offsets = None  # wp.array (S_temp * N_temp + 1,) int32
+    _target_link_indices = None  # wp.array (K,) int32
+
     # Placeholder wp.array to satisfy the kernel signature when Inside tracks no objects.
     _placeholder_inside = None  # wp.array (1, 1, 1) uint8
 
@@ -282,6 +356,8 @@ class Temperature(TensorizedAbsoluteState):
             cls._hss_self_inside_idx = None
             cls._temp_to_aabb_idx = None
             cls._temp_to_inside_idx = None
+            cls._target_link_offsets = None
+            cls._target_link_indices = None
             cls.INFLUENCE_MASK = None
             cls.INFLUENCE_MASK_CPU = None
             cls.INFLUENCE_MASK_CPU_WP = None
@@ -304,6 +380,30 @@ class Temperature(TensorizedAbsoluteState):
             temp_to_inside[n] = inside_map.get(rel_path, -1)
         cls._temp_to_aabb_idx = create_tensor_from_list(temp_to_aabb, "int32", device="cuda")
         cls._temp_to_inside_idx = create_tensor_from_list(temp_to_inside, "int32", device="cuda")
+
+        # CSR table of each (scene, target)'s collision links, for the exact point-source test.
+        # Walks IDX_OBJS the same way AABB.initialize_view does, and skips links with no collision
+        # geometry via LINK_VERTEX_COUNTS so the kernel never queries a null mesh id.
+        S_temp = len(cls.IDX_OBJS)
+        link_offsets = th.zeros((S_temp * N_temp + 1,), dtype=th.int32)
+        link_indices = []
+        for s_idx, scene_row in enumerate(cls.IDX_OBJS):
+            for n, obj in enumerate(scene_row):
+                if obj is not None and obj.prim_type != PrimType.CLOTH:
+                    for link in obj.links.values():
+                        flat_idx = RigidBodyViewAPI.get_flat_idx(link.prim_path)
+                        if flat_idx is None:
+                            continue
+                        if RigidBodyViewAPI.LINK_VERTEX_COUNTS[flat_idx].item() == 0:
+                            continue  # no collision geometry for this link
+                        link_indices.append(flat_idx)
+                link_offsets[s_idx * N_temp + n + 1] = len(link_indices)
+        cls._target_link_offsets = create_tensor_from_list(link_offsets, "int32", device="cuda")
+        # create_tensor_from_list cannot build a zero-length array; the kernel only reads this when
+        # some (s, n) has a non-empty range, so a 1-element dummy is safe when nothing has geometry.
+        cls._target_link_indices = create_tensor_from_list(
+            th.tensor(link_indices or [0], dtype=th.int32), "int32", device="cuda"
+        )
 
         cls.INFLUENCE_MASK = wp.zeros((S_hss, N_hss, N_temp), dtype=wp.uint8, device="cuda")
         cls.INFLUENCE_MASK_CPU = th.zeros((S_hss, N_hss, N_temp), dtype=th.bool).pin_memory()
@@ -356,6 +456,10 @@ class Temperature(TensorizedAbsoluteState):
                         hss._link_local_offset,
                         cls._temp_to_aabb_idx,
                         cls._temp_to_inside_idx,
+                        cls._target_link_offsets,
+                        cls._target_link_indices,
+                        RigidBodyViewAPI.LINK_MESH_IDS,
+                        wp.int32(N),
                         RigidBodyViewAPI.POSE_MATRICES,
                         AABB.VALUES_WP,
                         inside_values_wp,

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -571,7 +571,10 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
                 obj_info["root_link"]["pos"], obj_info["root_link"]["ori"] = T.pose_transform(
                     *T.mat2pose(self.pose), pos, ori
                 )
-            # TODO: also handle system registry here
+            # NOTE: system registry states need no such conversion -- particle systems dump/load
+            # their particle poses in the SCENE frame (see BaseSystem._dump_state and
+            # PhysxParticleInstancer._dump_state), so load_state below places each scene's particles
+            # at that scene's own world offset.
             self.load_state(init_state, serialized=False)
         self._initial_file = self.save(as_dict=True)
 

--- a/OmniGibson/omnigibson/scenes/scene_base.py
+++ b/OmniGibson/omnigibson/scenes/scene_base.py
@@ -378,18 +378,25 @@ class Scene(Serializable, Registerable, Recreatable, ABC):
                 log.warning(f"System {system_name} is not supported without GPU dynamics! Skipping...")
 
         # Position the scene prim initially at a z offset to avoid collision
-        self._scene_prim.set_position_orientation(
-            position=th.tensor([0, 0, initial_scene_prim_z_offset if self.idx != 0 else 0])
-        )
+        initial_scene_prim_pos = th.tensor([0.0, 0.0, initial_scene_prim_z_offset if self.idx != 0 else 0.0])
+        self._scene_prim.set_position_orientation(position=initial_scene_prim_pos)
 
         # Now load the objects with their own logic
         with og.sim.adding_objects(objs=self._init_objs.values()):
             for obj_name, obj in self._init_objs.items():
                 # Import into the simulator
                 self.add_object(obj, _batched_call=True)
-                # Set the init pose accordingly
+                # Set the init pose accordingly. The init pose is authored in the scene frame, and the
+                # scene prim currently sits at the temporary z offset above, so include that offset in
+                # this world-frame write. Otherwise the offset gets baked into the object's USD local
+                # transform (local = scene_z - (-offset) = scene_z + |offset|), and once the scene prim
+                # moves to its final tile position every object inherits a +|offset| world-z error.
+                # Later scene-relative load_state writes hide this for most objects, but any object
+                # that never receives one (e.g. scene furniture under the eval's partial-scene-load
+                # path, such as the stove burner in cook_hot_dogs) physically stays ~100 m above its
+                # scene in every env other than env 0.
                 obj.set_position_orientation(
-                    position=self._init_state[obj_name]["root_link"]["pos"],
+                    position=th.as_tensor(self._init_state[obj_name]["root_link"]["pos"]) + initial_scene_prim_pos,
                     orientation=self._init_state[obj_name]["root_link"]["ori"],
                 )
 

--- a/OmniGibson/omnigibson/systems/system_base.py
+++ b/OmniGibson/omnigibson/systems/system_base.py
@@ -333,8 +333,8 @@ class BaseSystem(Serializable):
 
     @property
     def state_size(self):
-        # We have n_particles (1), min / max scale (3*2), each particle pose (7*n)
-        return 7 + 7 * self.n_particles
+        # We have n_particles (1), uses_local_poses (1), min / max scale (3*2), each particle pose (7*n)
+        return 8 + 7 * self.n_particles
 
     def _transform_poses(self, mat, positions, orientations):
         """
@@ -366,6 +366,12 @@ class BaseSystem(Serializable):
             positions, orientations = self._transform_poses(self.scene.pose_inv, positions, orientations)
         return dict(
             n_particles=self.n_particles,
+            # Record which frame `positions` / `orientations` are expressed in, so a state can be
+            # validated against the system loading it instead of silently reinterpreted. Without
+            # this the numbers are ambiguous: local poses and scene-frame poses are indistinguishable
+            # in the file, so flipping `_store_local_poses` for a system would make every previously
+            # saved state load objects to the wrong place with no error.
+            uses_local_poses=self._store_local_poses,
             min_scale=self.min_scale,
             max_scale=self.max_scale,
             positions=positions,
@@ -379,6 +385,16 @@ class BaseSystem(Serializable):
             f"particles state! Current number: {self.n_particles}, "
             f"loaded number: {state['n_particles']}"
         )
+        # States saved before `uses_local_poses` was recorded carry no frame information, so fall
+        # back to this system's own setting -- i.e. assume they match, which is how they were always
+        # interpreted. Only a state that explicitly disagrees is an error.
+        uses_local_poses = state.get("uses_local_poses", self._store_local_poses)
+        assert uses_local_poses == self._store_local_poses, (
+            f"Particle pose frame mismatch when loading state for system {self.name}: the state was "
+            f"saved with uses_local_poses={uses_local_poses}, but this system expects "
+            f"{self._store_local_poses}. Loading it would place particles incorrectly."
+        )
+
         # Load scale
         self.min_scale = state["min_scale"]
         self.max_scale = state["max_scale"]
@@ -394,10 +410,13 @@ class BaseSystem(Serializable):
             self.set_particles_position_orientation(positions=positions, orientations=orientations)
 
     def serialize(self, state):
-        # Array is n_particles, then min_scale and max_scale, then poses for all particles
+        # Array is n_particles, uses_local_poses, then min_scale and max_scale, then poses for all particles
         return th.cat(
             [
                 th.tensor([state["n_particles"]], dtype=th.float32),
+                # .get() so a state dict loaded from a file written before this field existed can
+                # still be re-serialized; absent means "same frame as this system", see _load_state.
+                th.tensor([float(state.get("uses_local_poses", self._store_local_poses))], dtype=th.float32),
                 state["min_scale"],
                 state["max_scale"],
                 state["positions"].flatten(),
@@ -406,18 +425,20 @@ class BaseSystem(Serializable):
         )
 
     def deserialize(self, state):
-        # First index is number of particles, then min_scale and max_scale, then the individual particle poses
+        # First index is number of particles, then the pose frame flag, then min_scale and max_scale,
+        # then the individual particle poses
         state_dict = dict()
         n_particles = int(state[0])
         len_positions = n_particles * 3
         len_orientations = n_particles * 4
         state_dict["n_particles"] = n_particles
-        state_dict["min_scale"] = state[1:4]
-        state_dict["max_scale"] = state[4:7]
-        state_dict["positions"] = state[7 : 7 + len_positions].reshape(-1, 3)
-        state_dict["orientations"] = state[7 + len_positions : 7 + len_positions + len_orientations].reshape(-1, 4)
+        state_dict["uses_local_poses"] = bool(state[1])
+        state_dict["min_scale"] = state[2:5]
+        state_dict["max_scale"] = state[5:8]
+        state_dict["positions"] = state[8 : 8 + len_positions].reshape(-1, 3)
+        state_dict["orientations"] = state[8 + len_positions : 8 + len_positions + len_orientations].reshape(-1, 4)
 
-        return state_dict, 7 + len_positions + len_orientations
+        return state_dict, 8 + len_positions + len_orientations
 
 
 class VisualParticleSystem(BaseSystem):

--- a/OmniGibson/omnigibson/systems/system_base.py
+++ b/OmniGibson/omnigibson/systems/system_base.py
@@ -5,6 +5,7 @@ from functools import cache
 import torch as th
 
 import omnigibson as og
+import omnigibson.utils.transform_utils as T
 from omnigibson.macros import create_module_macros, gm
 from omnigibson.utils.asset_utils import get_all_system_categories, get_dataset_path
 from omnigibson.utils.python_utils import Serializable, get_uuid
@@ -335,10 +336,34 @@ class BaseSystem(Serializable):
         # We have n_particles (1), min / max scale (3*2), each particle pose (7*n)
         return 7 + 7 * self.n_particles
 
+    def _transform_poses(self, mat, positions, orientations):
+        """
+        Batch-transform particle poses by homogeneous transform @mat.
+
+        Args:
+            mat (th.tensor): (4, 4) homogeneous transformation matrix
+            positions (th.tensor): (N, 3) particle positions
+            orientations (th.tensor): (N, 4) particle (x,y,z,w) quaternion orientations
+
+        Returns:
+            2-tuple: transformed (N, 3) positions and (N, 4) orientations
+        """
+        if len(positions) == 0:
+            return positions, orientations
+        rot = mat[:3, :3]
+        new_positions = positions @ rot.T + mat[:3, 3]
+        new_orientations = T.mat2quat(rot.unsqueeze(0) @ T.quat2mat(orientations))
+        return new_positions, new_orientations
+
     def _dump_state(self):
-        positions, orientations = (
-            self.get_particles_local_pose() if self._store_local_poses else self.get_particles_position_orientation()
-        )
+        if self._store_local_poses:
+            positions, orientations = self.get_particles_local_pose()
+        else:
+            # Store poses in the SCENE frame (not world frame), mirroring PhysxParticleInstancer, so
+            # that states authored in one scene (e.g. dataset task instances, authored with the scene
+            # at the world origin) load correctly into cloned scenes at other world offsets.
+            positions, orientations = self.get_particles_position_orientation()
+            positions, orientations = self._transform_poses(self.scene.pose_inv, positions, orientations)
         return dict(
             n_particles=self.n_particles,
             min_scale=self.min_scale,
@@ -359,8 +384,14 @@ class BaseSystem(Serializable):
         self.max_scale = state["max_scale"]
 
         # Load the poses
-        setter = self.set_particles_local_pose if self._store_local_poses else self.set_particles_position_orientation
-        setter(positions=state["positions"], orientations=state["orientations"])
+        if self._store_local_poses:
+            self.set_particles_local_pose(positions=state["positions"], orientations=state["orientations"])
+        else:
+            # Stored poses are scene-relative (see _dump_state) -- convert back into world frame using
+            # THIS system's scene pose, so a state authored in the canonical scene lands in the correct
+            # world position for cloned scenes as well.
+            positions, orientations = self._transform_poses(self.scene.pose, state["positions"], state["orientations"])
+            self.set_particles_position_orientation(positions=positions, orientations=orientations)
 
     def serialize(self, state):
         # Array is n_particles, then min_scale and max_scale, then poses for all particles

--- a/OmniGibson/omnigibson/systems/system_base.py
+++ b/OmniGibson/omnigibson/systems/system_base.py
@@ -410,13 +410,19 @@ class BaseSystem(Serializable):
             self.set_particles_position_orientation(positions=positions, orientations=orientations)
 
     def serialize(self, state):
-        # Array is n_particles, uses_local_poses, then min_scale and max_scale, then poses for all particles
+        # Array is n_particles, the pose-frame marker, then min_scale and max_scale, then poses.
+        #
+        # The marker is written NEGATIVE (-1 = world/scene frame, -2 = local) purely so that
+        # deserialize can tell this layout from the one that predates the flag. Arrays written
+        # before it hold min_scale in this slot, and scales are always positive, so a negative
+        # value here is unambiguous. Without that, an old array would be read shifted by one and
+        # silently produce garbage rather than failing.
         return th.cat(
             [
                 th.tensor([state["n_particles"]], dtype=th.float32),
                 # .get() so a state dict loaded from a file written before this field existed can
                 # still be re-serialized; absent means "same frame as this system", see _load_state.
-                th.tensor([float(state.get("uses_local_poses", self._store_local_poses))], dtype=th.float32),
+                th.tensor([-1.0 - float(state.get("uses_local_poses", self._store_local_poses))], dtype=th.float32),
                 state["min_scale"],
                 state["max_scale"],
                 state["positions"].flatten(),
@@ -425,20 +431,32 @@ class BaseSystem(Serializable):
         )
 
     def deserialize(self, state):
-        # First index is number of particles, then the pose frame flag, then min_scale and max_scale,
-        # then the individual particle poses
+        # First index is number of particles, then (newer format only) the pose-frame marker, then
+        # min_scale and max_scale, then the individual particle poses.
         state_dict = dict()
         n_particles = int(state[0])
         len_positions = n_particles * 3
         len_orientations = n_particles * 4
         state_dict["n_particles"] = n_particles
-        state_dict["uses_local_poses"] = bool(state[1])
-        state_dict["min_scale"] = state[2:5]
-        state_dict["max_scale"] = state[5:8]
-        state_dict["positions"] = state[8 : 8 + len_positions].reshape(-1, 3)
-        state_dict["orientations"] = state[8 + len_positions : 8 + len_positions + len_orientations].reshape(-1, 4)
 
-        return state_dict, 8 + len_positions + len_orientations
+        # Arrays written before the pose-frame flag existed carry min_scale in slot 1, which is
+        # always positive; only the newer format writes a negative marker there. Keeps previously
+        # dumped states (e.g. recorded HDF5 demos) readable.
+        if state[1] < 0:
+            state_dict["uses_local_poses"] = bool(-state[1] - 1.0)
+            offset = 2
+        else:
+            offset = 1
+
+        state_dict["min_scale"] = state[offset : offset + 3]
+        state_dict["max_scale"] = state[offset + 3 : offset + 6]
+        base = offset + 6
+        state_dict["positions"] = state[base : base + len_positions].reshape(-1, 3)
+        state_dict["orientations"] = state[base + len_positions : base + len_positions + len_orientations].reshape(
+            -1, 4
+        )
+
+        return state_dict, base + len_positions + len_orientations
 
 
 class VisualParticleSystem(BaseSystem):

--- a/OmniGibson/tests/test_multiple_envs_heat_narrow_phase.py
+++ b/OmniGibson/tests/test_multiple_envs_heat_narrow_phase.py
@@ -1,0 +1,261 @@
+"""Point heat sources must measure to the target's GEOMETRY, not to its AABB.
+
+Pre-vectorization, `HeatSourceOrSink` decided which objects a point source affects with
+`og.sim.psqi.overlap_sphere(radius=distance_threshold, ...)`, a PhysX query against each
+target's actual COLLISION GEOMETRY. The vectorized kernel cannot call that (CPU-side query,
+one call per source, delivered by callback), so it reproduces it in two stages: a cheap
+AABB distance test as a broad phase, then `wp.mesh_query_point` against the target's collision
+meshes for whatever survives.
+
+The broad phase alone is not equivalent. An AABB always contains its geometry, so
+distance-to-AABB <= distance-to-geometry, and the AABB test therefore ACCEPTS targets whose
+real geometry is out of range. The gap is largest for long, thin or diagonally-oriented
+objects: measured 0.69 m of slack for a bar lying along a box diagonal, against a default
+threshold of 0.2 m.
+
+None of the tests in test_multiple_envs_heat_states.py cover this — they all place targets
+directly on the heat element, where AABB and mesh agree. These do.
+
+Run standalone (one Environment per process):
+  OMNIGIBSON_HEADLESS=1 pytest tests/test_multiple_envs_heat_narrow_phase.py -v -s
+"""
+
+import pytest
+import torch as th
+
+import omnigibson as og
+from omnigibson.macros import gm
+from omnigibson.macros import macros as m
+from omnigibson.object_states import HeatSourceOrSink, Temperature, ToggledOn
+
+N_ENVS = 3
+DEFAULT_TEMP = m.object_states.temperature.DEFAULT_TEMPERATURE
+
+OBJECTS_CFG = [
+    {"type": "DatasetObject", "name": "stove", "category": "stove", "model": "yhjzwg", "position": [0.0, 0.0, 0.5]},
+    # Flat sheet: rotated off-axis its AABB balloons well beyond the geometry, which is exactly
+    # the configuration where an AABB-only test over-reaches.
+    #
+    # Scaled up and made kinematic deliberately. At native size the sheet is 0.47 m long and the
+    # furthest an in-AABB point can sit from it is 0.30 m -- exactly the margin this test wants,
+    # with no room for error. Scaling 3x makes the gap comfortable instead of borderline.
+    #
+    # kinematic_only, NOT fixed_base: the board has to stay exactly where the search puts it.
+    # keep_still() only zeroes velocity, so gravity still moves it; and fixed_base is worse than
+    # nothing here, because it anchors a joint at the spawn pose and physics then drags the board
+    # back toward that anchor after every teleport. Measured drift with fixed_base was
+    # 0.682 -> 0.175 m over ten steps, i.e. into the threshold, which made the stove heat it
+    # correctly and the test blame the kernel for the test's own instability.
+    {
+        "type": "DatasetObject",
+        "name": "board",
+        "category": "plywood",
+        "model": "fkmkqa",
+        "abilities": {"cookable": {}, "heatable": {}},
+        "scale": [3.0, 3.0, 3.0],
+        "kinematic_only": True,
+        "position": [15.0, 0.0, 0.1],
+    },
+    # Compact control target: AABB and geometry nearly coincide, so it must still heat.
+    {
+        "type": "DatasetObject",
+        "name": "bagel",
+        "category": "bagel",
+        "model": "zlxkry",
+        "abilities": {"cookable": {}, "freezable": {}, "burnable": {}, "heatable": {}},
+        "position": [15.0, 2.0, 0.1],
+    },
+]
+
+
+@pytest.fixture(scope="module")
+def multi_env():
+    assert og.sim is None, "This module must run in a fresh process (one Environment per process)."
+    gm.RENDER_VIEWER_CAMERA = False
+    gm.ENABLE_OBJECT_STATES = True
+    gm.USE_GPU_DYNAMICS = True
+    gm.ENABLE_FLATCACHE = False
+    gm.ENABLE_TRANSITION_RULES = False
+
+    cfg = {
+        "env": {"num_envs": N_ENVS},
+        "scene": {"type": "Scene"},
+        "robots": [{"model": "fetch", "obs_modalities": ["rgb"], "position": [20.0, 20.0, 0.1]}],
+        "objects": OBJECTS_CFG,
+        "task": {"type": "DummyTask"},
+    }
+    env = og.Environment(configs=cfg)
+    for _ in range(10):
+        og.sim.step()
+    yield env
+    og.clear()
+
+
+def scene_objs(env, name):
+    return [env.scenes[s].object_registry("name", name) for s in range(N_ENVS)]
+
+
+def heat_link_world_pos(source):
+    link = source.states[HeatSourceOrSink].link
+    return link.get_position_orientation()[0]
+
+
+def threshold_of(source):
+    return source.states[HeatSourceOrSink].distance_threshold
+
+
+def aabb_distance(obj, point):
+    """Distance from @point to the closest point of @obj's world AABB (what the broad phase uses)."""
+    lo, hi = obj.aabb
+    return float(th.linalg.norm(point - th.clamp(point, lo, hi)))
+
+
+def geometry_distance(obj, point):
+    """Distance from @point to the nearest collision-hull vertex of @obj.
+
+    An upper bound on the true surface distance (a face interior can be nearer than any vertex),
+    so the tests below only rely on it together with a generous margin.
+    """
+    best = float("inf")
+    for link in obj.links.values():
+        pts = link.collision_boundary_points_world
+        if pts is None or len(pts) == 0:
+            continue
+        best = min(best, float(th.linalg.norm(pts - point.reshape(1, 3), dim=-1).min()))
+    return best
+
+
+def reset_thermals(env):
+    for s in range(N_ENVS):
+        stove = env.scenes[s].object_registry("name", "stove")
+        if ToggledOn in stove.states:
+            stove.states[ToggledOn].set_value(False)
+        for name in ("board", "bagel"):
+            env.scenes[s].object_registry("name", name).states[Temperature].set_value(DEFAULT_TEMP)
+    og.sim.step()
+
+
+def place_board_so_aabb_reaches_but_geometry_does_not(board, element, threshold):
+    """Find a pose where the element is inside the board's AABB but far from the board itself.
+
+    A rotated flat sheet leaves most of its bounding box empty, so the interesting spots are the
+    AABB's own CORNERS: inside the box by construction, yet far from the sheet. For each candidate
+    orientation the board is shifted so a chosen corner (pulled slightly inward) lands on the heat
+    element, then the achieved distances are measured rather than assumed.
+
+    Searching real corners instead of guessing offsets also keeps the test asset-agnostic: it does
+    not depend on the sheet's dimensions, only on its bounding box being much larger than itself.
+
+    Returns the achieved (aabb_dist, geom_dist), or None if no pose qualified.
+    """
+    orientations = [
+        th.tensor([0.3826834, 0.0, 0.0, 0.9238795]),  # 45 deg about X
+        th.tensor([0.0, 0.3826834, 0.0, 0.9238795]),  # 45 deg about Y
+        th.tensor([0.5, 0.5, 0.5, 0.5]),  # 120 deg about (1,1,1)
+    ]
+    for quat in orientations:
+        board.keep_still()
+        board.set_position_orientation(position=element, orientation=quat)
+        og.sim.step()
+        # AABB is only meaningful once the new orientation has been applied.
+        lo, hi = board.aabb
+        centre = 0.5 * (lo + hi)
+        for sx in (-1.0, 1.0):
+            for sy in (-1.0, 1.0):
+                for sz in (-1.0, 1.0):
+                    sign = th.tensor([sx, sy, sz])
+                    # 0.8 keeps the target point inside the box rather than exactly on its surface.
+                    corner = centre + 0.8 * sign * (hi - lo) * 0.5
+                    board.keep_still()
+                    board.set_position_orientation(
+                        position=board.get_position_orientation()[0] + (element - corner), orientation=quat
+                    )
+                    og.sim.step()
+                    a, g = aabb_distance(board, element), geometry_distance(board, element)
+                    if a <= 0.5 * threshold and g >= 1.5 * threshold:
+                        return a, g
+    return None
+
+
+def test_point_source_ignores_target_whose_aabb_reaches_but_geometry_does_not_n3(multi_env):
+    """A toggled-on stove must NOT heat a board that only its AABB brings into range.
+
+    This is the case the AABB-only broad phase gets wrong: the element sits inside the rotated
+    board's bounding box while the board itself is several thresholds away. overlap_sphere would
+    report no contact, so the kernel must not heat it.
+    """
+    env = multi_env
+    reset_thermals(env)
+
+    stoves, boards = scene_objs(env, "stove"), scene_objs(env, "board")
+    achieved = []
+    for stove, board in zip(stoves, boards):
+        element = heat_link_world_pos(stove)
+        got = place_board_so_aabb_reaches_but_geometry_does_not(board, element, threshold_of(stove))
+        assert got is not None, (
+            "Could not place the board so that its AABB reaches the heat element while its "
+            "geometry stays out of range — the asset's dimensions may have changed. Adjust the "
+            "sweep in place_board_so_aabb_reaches_but_geometry_does_not; this test is meaningless "
+            "without that configuration."
+        )
+        achieved.append(got)
+
+    for stove in stoves:
+        assert stove.states[ToggledOn].set_value(True)
+    for _ in range(10):
+        og.sim.step()
+
+    # Re-measure AFTER the heating steps. The distances above were taken before the sim ran, so a
+    # board that drifted (or was nudged by a collision) would make the verdict unreadable — the
+    # kernel would be judged against a geometry that no longer matches what it saw.
+    for s, (a, g) in enumerate(achieved):
+        element = heat_link_world_pos(stoves[s])
+        a2, g2 = aabb_distance(boards[s], element), geometry_distance(boards[s], element)
+        print(
+            f"\nenv{s}: threshold {threshold_of(stoves[s]):.3f} m"
+            f"\n   before heating: element->AABB {a:.3f}, element->geometry {g:.3f}"
+            f"\n   after  heating: element->AABB {a2:.3f}, element->geometry {g2:.3f}"
+        )
+        assert g2 >= 1.5 * threshold_of(stoves[s]), (
+            f"env{s}: the board moved during the heating steps (geometry distance {g:.3f} -> "
+            f"{g2:.3f} m), so this episode no longer tests the AABB-vs-geometry gap. Keep the "
+            f"board static instead of tightening the assertion below."
+        )
+    print("board temps:", [round(b.states[Temperature].get_value(), 2) for b in boards])
+
+    heated = [
+        f"env{s}: {b.states[Temperature].get_value():.2f} C"
+        for s, b in enumerate(boards)
+        if b.states[Temperature].get_value() > DEFAULT_TEMP + 1e-3
+    ]
+    assert not heated, (
+        "Stove heated a board whose collision geometry is out of range and only whose AABB is "
+        f"within the threshold — the narrow phase is not running: {heated}"
+    )
+    reset_thermals(env)
+
+
+def test_point_source_still_heats_a_target_on_the_element_n3(multi_env):
+    """Control: the narrow phase must not reject a target that genuinely IS in range.
+
+    Guards the opposite failure — a too-strict mesh test would stop food cooking on a lit
+    burner, which is the regression the AABB-center bug originally caused.
+    """
+    env = multi_env
+    reset_thermals(env)
+
+    stoves, bagels = scene_objs(env, "stove"), scene_objs(env, "bagel")
+    for stove, bagel in zip(stoves, bagels):
+        bagel.keep_still()
+        bagel.set_position_orientation(position=heat_link_world_pos(stove) + th.tensor([0.0, 0.0, 0.05]))
+    og.sim.step()
+    for stove in stoves:
+        assert stove.states[ToggledOn].set_value(True)
+    for _ in range(10):
+        og.sim.step()
+
+    temps = [round(b.states[Temperature].get_value(), 2) for b in bagels]
+    print("\nbagel temps on the element:", temps)
+    cold = [f"env{s}: {t}" for s, t in enumerate(temps) if t <= DEFAULT_TEMP + 1e-3]
+    assert not cold, f"Narrow phase rejected a target sitting on the heat element: {cold}"
+    reset_thermals(env)

--- a/OmniGibson/tests/test_multiple_envs_heat_states.py
+++ b/OmniGibson/tests/test_multiple_envs_heat_states.py
@@ -1,0 +1,515 @@
+"""Multi-env (num_envs=3) versions of the heat / temperature object-state tests.
+
+Mirrors the heat-related coverage of ``test_object_states.py`` (test_temperature,
+test_heat_source_or_sink, test_heated) across 3 cloned scenes, plus diagnostic
+tests that read the vectorized heat pipeline's internal index maps to explain the
+two failures observed in eval (2026-08-10, see eval-vector-check-20260810/REPORT.md):
+
+  1. An OFF oven (requires_toggled_on + requires_inside, both unsatisfied) heated a
+     popcorn bag sitting on a countertop to ~its 250 C source temperature.
+  2. A toggled-ON burner/stove did not heat an object placed directly on it.
+
+Transition rules are intentionally DISABLED here (the clone-scene transition-rule
+bug is tracked separately).
+
+Run standalone (one Environment per process):
+  OMNIGIBSON_HEADLESS=1 pytest tests/test_multiple_envs_heat_states.py -v -s
+"""
+
+import pytest
+import torch as th
+import warp as wp
+
+import omnigibson as og
+from omnigibson.macros import gm
+from omnigibson.macros import macros as m
+from omnigibson.object_states import HeatSourceOrSink, Inside, MaxTemperature, Open, Temperature, ToggledOn
+from omnigibson.utils.usd_utils import RigidBodyViewAPI
+
+N_ENVS = 3
+DEFAULT_TEMP = m.object_states.temperature.DEFAULT_TEMPERATURE
+
+# Heat sources under test. stove = point source (requires_toggled_on only);
+# microwave / oven = containment sources (requires_toggled_on + closed + inside);
+# fridge = always-active containment cold source.
+OBJECTS_CFG = [
+    {"type": "DatasetObject", "name": "stove", "category": "stove", "model": "yhjzwg", "position": [0.0, 0.0, 0.5]},
+    {
+        "type": "DatasetObject",
+        "name": "microwave",
+        "category": "microwave",
+        "model": "hjjxmi",
+        "position": [3.0, 0.0, 0.3],
+    },
+    {"type": "DatasetObject", "name": "fridge", "category": "fridge", "model": "xyejdx", "position": [6.0, 0.0, 1.0]},
+    {"type": "DatasetObject", "name": "oven", "category": "oven", "model": "amblrk", "position": [9.0, 0.0, 0.6]},
+    # Fillable decoy + an object inside it: creates a true Inside pair that a
+    # misaligned requires_inside lookup could confuse with "inside the oven".
+    {"type": "DatasetObject", "name": "bowl", "category": "bowl", "model": "ajzltc", "position": [12.0, 0.0, 0.1]},
+    {
+        "type": "DatasetObject",
+        "name": "bagel_in_bowl",
+        "category": "bagel",
+        "model": "zlxkry",
+        "abilities": {"cookable": {}, "freezable": {}, "burnable": {}, "heatable": {}},
+        "position": [12.0, 0.0, 0.25],
+    },
+    # Flammable object: exercises the OnFire dump/load path (eval bug #1).
+    {
+        "type": "DatasetObject",
+        "name": "plywood",
+        "category": "plywood",
+        "model": "fkmkqa",
+        "abilities": {"flammable": {}},
+        "position": [18.0, 0.0, 0.1],
+    },
+    # Far-away heatable targets (mirror bagel/cookable_dishtowel of the n=1 tests).
+    {
+        "type": "DatasetObject",
+        "name": "bagel_a",
+        "category": "bagel",
+        "model": "zlxkry",
+        "abilities": {"cookable": {}, "freezable": {}, "burnable": {}, "heatable": {}},
+        "position": [15.0, 0.0, 0.1],
+    },
+    {
+        "type": "DatasetObject",
+        "name": "bagel_b",
+        "category": "bagel",
+        "model": "zlxkry",
+        "abilities": {"cookable": {}, "freezable": {}, "burnable": {}, "heatable": {}},
+        "position": [15.0, 1.0, 0.1],
+    },
+]
+
+TARGET_NAMES = ("bagel_a", "bagel_b", "bagel_in_bowl")
+SOURCE_NAMES = ("stove", "microwave", "fridge", "oven")
+
+
+@pytest.fixture(scope="module")
+def multi_env():
+    assert og.sim is None, "This module must run in a fresh process (one Environment per process)."
+    gm.RENDER_VIEWER_CAMERA = False
+    gm.ENABLE_OBJECT_STATES = True
+    gm.USE_GPU_DYNAMICS = True
+    gm.ENABLE_FLATCACHE = False
+    gm.ENABLE_TRANSITION_RULES = False  # clone-scene transition-rule bug tracked separately
+
+    cfg = {
+        "env": {"num_envs": N_ENVS},
+        "scene": {"type": "Scene"},
+        "robots": [{"model": "fetch", "obs_modalities": ["rgb"], "position": [20.0, 20.0, 0.1]}],
+        "objects": OBJECTS_CFG,
+        "task": {"type": "DummyTask"},
+    }
+    env = og.Environment(configs=cfg)
+    for _ in range(10):
+        og.sim.step()
+    yield env
+    og.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def scene_objs(env, name):
+    """The per-scene clones of object @name, index-aligned with env indices."""
+    return [env.scenes[s].object_registry("name", name) for s in range(N_ENVS)]
+
+
+def temps(env, name):
+    return [round(o.states[Temperature].get_value(), 2) for o in scene_objs(env, name)]
+
+
+def reset_thermals(env):
+    """All sources off / closed, all targets back to DEFAULT_TEMP."""
+    for s in range(N_ENVS):
+        for name in ("stove", "microwave", "oven"):
+            obj = env.scenes[s].object_registry("name", name)
+            if ToggledOn in obj.states:
+                obj.states[ToggledOn].set_value(False)
+        for name in ("microwave", "fridge", "oven"):
+            obj = env.scenes[s].object_registry("name", name)
+            if Open in obj.states:
+                obj.states[Open].set_value(False, fully=True)
+    og.sim.step()
+    for s in range(N_ENVS):
+        for name in TARGET_NAMES:
+            obj = env.scenes[s].object_registry("name", name)
+            assert obj.states[Temperature].set_value(DEFAULT_TEMP)
+            assert obj.states[MaxTemperature].set_value(DEFAULT_TEMP)
+    og.sim.step()
+
+
+def influence_pairs(env):
+    """Decode Temperature.INFLUENCE_MASK into human-readable (scene, source, target) triples."""
+    mask = Temperature.INFLUENCE_MASK
+    if mask is None:
+        return []
+    mask_t = wp.to_torch(mask).to("cpu")
+    pairs = []
+    for s, h, n in th.nonzero(mask_t, as_tuple=False).tolist():
+        src = HeatSourceOrSink.IDX_OBJS[s][h] if s < len(HeatSourceOrSink.IDX_OBJS) else None
+        tgt = Temperature.IDX_OBJS[s][n] if s < len(Temperature.IDX_OBJS) else None
+        pairs.append((s, src.name if src is not None else f"h={h}", tgt.name if tgt is not None else f"n={n}"))
+    return pairs
+
+
+def heat_link_world_pos(obj):
+    """World position of a point heat source's heating element link."""
+    hss = obj.states[HeatSourceOrSink]
+    link = hss.link if hss._links else obj.root_link
+    return link.get_position_orientation()[0]
+
+
+def dump_heat_maps(env):
+    """Print the internal index maps the heat kernel consumes (diagnostic aid)."""
+    print("\n--- heat pipeline maps")
+    print("HSS OBJ_IDXS:", dict(HeatSourceOrSink.OBJ_IDXS or {}))
+    print("Temperature OBJ_IDXS:", dict(Temperature.OBJ_IDXS or {}))
+    print("Inside OBJ_IDXS:", dict(Inside.OBJ_IDXS or {}))
+    if HeatSourceOrSink._link_flat_idx is not None:
+        print("link_flat_idx:", wp.to_torch(HeatSourceOrSink._link_flat_idx).to("cpu").tolist())
+    if Temperature._hss_self_inside_idx is not None:
+        print("hss_self_inside_idx:", wp.to_torch(Temperature._hss_self_inside_idx).to("cpu").tolist())
+    if Temperature._temp_to_inside_idx is not None:
+        print("temp_to_inside_idx:", wp.to_torch(Temperature._temp_to_inside_idx).to("cpu").tolist())
+    if Temperature._temp_to_aabb_idx is not None:
+        print("temp_to_aabb_idx:", wp.to_torch(Temperature._temp_to_aabb_idx).to("cpu").tolist())
+
+
+# ---------------------------------------------------------------------------
+# 1) Leak detector — mirrors eval bug #1 (OFF oven heated the popcorn bag)
+# ---------------------------------------------------------------------------
+
+
+def test_all_sources_off_no_heating_n3(multi_env):
+    """With every heat source off/closed and all targets far away, no target's
+    temperature may change in ANY env. In eval, an OFF oven (both gates
+    unsatisfied) heated a countertop popcorn bag to ~250 C; `bagel_in_bowl`
+    reproduces the true-Inside decoy pair that a misaligned requires_inside
+    lookup could confuse with "inside the oven"."""
+    env = multi_env
+    reset_thermals(env)
+
+    for _ in range(30):
+        og.sim.step()
+
+    failures = []
+    for name in TARGET_NAMES:
+        for s, t in enumerate(temps(env, name)):
+            if abs(t - DEFAULT_TEMP) > 1e-3:
+                failures.append(f"{name} env{s}: {t} != {DEFAULT_TEMP}")
+    if failures:
+        print("\nLEAK: temperatures changed with all sources off:", failures)
+        print("influence pairs this step:", influence_pairs(env))
+        dump_heat_maps(env)
+    assert not failures, f"Heat leak with all sources off: {failures}"
+
+
+# ---------------------------------------------------------------------------
+# 2) Point-source heating — mirrors eval bug #2 (ON burner didn't heat hotdog)
+# ---------------------------------------------------------------------------
+
+
+def test_toggled_stove_heats_targets_in_every_env_n3(multi_env):
+    """A toggled-on stove must heat an object placed directly at its heating
+    element in EVERY env. Targets are placed at each scene's OWN heat-element
+    link position, so if the kernel resolves the element pose through a single
+    per-column link index (first scene wins) instead of a per-scene one, envs
+    beyond that scene compute a ~scene-offset distance and never heat."""
+    env = multi_env
+    reset_thermals(env)
+
+    stoves = scene_objs(env, "stove")
+    bagels = scene_objs(env, "bagel_a")
+    for stove, bagel in zip(stoves, bagels):
+        elem = heat_link_world_pos(stove)
+        bagel.keep_still()
+        bagel.set_position_orientation(position=elem + th.tensor([0.0, 0.0, 0.05]))
+    og.sim.step()
+    for stove in stoves:
+        assert stove.states[ToggledOn].set_value(True)
+    for _ in range(10):
+        og.sim.step()
+
+    gate_values = [stove.states[HeatSourceOrSink].get_value() for stove in stoves]
+    print("\nstove HSS active per env:", gate_values)
+    print("bagel_a temps per env:", temps(env, "bagel_a"))
+    print("influence pairs:", influence_pairs(env))
+
+    assert all(gate_values), f"Toggled-on stove not active as heat source in all envs: {gate_values}"
+
+    failures = [f"env{s}: {t}" for s, t in enumerate(temps(env, "bagel_a")) if t <= DEFAULT_TEMP + 1e-3]
+    if failures:
+        # Print exactly what the kernel used vs what each scene needs.
+        dump_heat_maps(env)
+        h = (HeatSourceOrSink.OBJ_IDXS or {}).get(stoves[0].relative_prim_path)
+        for s, stove in enumerate(stoves):
+            link = stove.states[HeatSourceOrSink].link
+            print(
+                f"env{s}: heat element world pos {heat_link_world_pos(stove).tolist()} "
+                f"flat_idx(per-scene link)={RigidBodyViewAPI.get_flat_idx(link.prim_path)}"
+            )
+        if h is not None and HeatSourceOrSink._link_flat_idx is not None:
+            lfi = wp.to_torch(HeatSourceOrSink._link_flat_idx).to("cpu")
+            per_scene = lfi[:, h].tolist() if lfi.dim() == 2 else lfi[h].item()
+            print(f"kernel link_flat_idx for stove column {h}:", per_scene)
+    assert not failures, f"Toggled-on stove failed to heat bagel placed on its element: {failures}"
+
+    reset_thermals(env)
+
+
+def test_stove_heats_only_its_own_env_n3(multi_env):
+    """Toggling only env1's stove must heat only env1's target (targets remain
+    at each scene's heat element from the previous placement)."""
+    env = multi_env
+    reset_thermals(env)
+
+    stoves = scene_objs(env, "stove")
+    bagels = scene_objs(env, "bagel_a")
+    for stove, bagel in zip(stoves, bagels):
+        bagel.keep_still()
+        bagel.set_position_orientation(position=heat_link_world_pos(stove) + th.tensor([0.0, 0.0, 0.05]))
+    og.sim.step()
+    assert stoves[1].states[ToggledOn].set_value(True)
+    for _ in range(10):
+        og.sim.step()
+
+    t = temps(env, "bagel_a")
+    print("\nbagel_a temps (only env1 stove on):", t, "| influence:", influence_pairs(env))
+    assert abs(t[0] - DEFAULT_TEMP) < 1e-3, f"env0 heated by env1's stove: {t}"
+    assert abs(t[2] - DEFAULT_TEMP) < 1e-3, f"env2 heated by env1's stove: {t}"
+    assert t[1] > DEFAULT_TEMP + 1e-3, f"env1's own stove did not heat its target: {t}"
+
+    reset_thermals(env)
+
+
+# ---------------------------------------------------------------------------
+# 3) Containment sources per env (microwave heat, fridge cold)
+# ---------------------------------------------------------------------------
+
+
+def test_microwave_requires_inside_per_env_n3(multi_env):
+    """Objects inside a closed, toggled-on microwave heat up in every env;
+    the same objects do NOT heat while the microwave is off."""
+    env = multi_env
+    reset_thermals(env)
+
+    microwaves = scene_objs(env, "microwave")
+    bagels = scene_objs(env, "bagel_b")
+    for mw, bagel in zip(microwaves, bagels):
+        bagel.keep_still()
+        bagel.set_position_orientation(position=mw.aabb_center + th.tensor([0.0, 0.03, 0.0]))
+    for _ in range(3):
+        og.sim.step()
+
+    inside_flags = [b.states[Inside].get_value(mw) for b, mw in zip(bagels, microwaves)]
+    print("\nbagel_b inside microwave per env:", inside_flags)
+    assert all(inside_flags), f"Placement failed, bagel not inside microwave in all envs: {inside_flags}"
+
+    # Off: no heating.
+    for _ in range(5):
+        og.sim.step()
+    t_off = temps(env, "bagel_b")
+    assert all(abs(t - DEFAULT_TEMP) < 1e-3 for t in t_off), f"Heated by OFF microwave: {t_off}"
+
+    # Closed + on: heats in every env.
+    for mw in microwaves:
+        assert mw.states[ToggledOn].set_value(True)
+    for _ in range(10):
+        og.sim.step()
+    t_on = temps(env, "bagel_b")
+    print("bagel_b temps with microwave on:", t_on, "| influence:", influence_pairs(env))
+    failures = [f"env{s}: {t}" for s, t in enumerate(t_on) if t <= DEFAULT_TEMP + 1e-3]
+    if failures:
+        dump_heat_maps(env)
+    assert not failures, f"Closed+on microwave failed to heat inside object: {failures}"
+
+    reset_thermals(env)
+
+
+def test_fridge_cools_per_env_n3(multi_env):
+    """The fridge (always-active cold source) must cool objects inside it in every env."""
+    env = multi_env
+    reset_thermals(env)
+
+    fridges = scene_objs(env, "fridge")
+    bagels = scene_objs(env, "bagel_b")
+    for fridge, bagel in zip(fridges, bagels):
+        bagel.keep_still()
+        bagel.set_position_orientation(position=fridge.aabb_center + th.tensor([0.0, 0.0, 0.1]))
+        assert fridge.states[Open].set_value(False, fully=True)
+    for _ in range(3):
+        og.sim.step()
+
+    inside_flags = [b.states[Inside].get_value(f) for b, f in zip(bagels, fridges)]
+    print("\nbagel_b inside fridge per env:", inside_flags)
+    assert all(inside_flags), f"Placement failed, bagel not inside fridge in all envs: {inside_flags}"
+
+    for _ in range(10):
+        og.sim.step()
+    t = temps(env, "bagel_b")
+    print("bagel_b temps in closed fridge:", t)
+    failures = [f"env{s}: {v}" for s, v in enumerate(t) if v >= DEFAULT_TEMP - 1e-3]
+    if failures:
+        dump_heat_maps(env)
+    assert not failures, f"Fridge failed to cool inside object: {failures}"
+
+    reset_thermals(env)
+
+
+# ---------------------------------------------------------------------------
+# 4) Gate logic per env — mirrors test_heat_source_or_sink at n=3
+# ---------------------------------------------------------------------------
+
+
+def test_heat_source_gates_per_env_n3(multi_env):
+    """HeatSourceOrSink activation gates must be evaluated per env independently."""
+    env = multi_env
+    reset_thermals(env)
+
+    stoves = scene_objs(env, "stove")
+    microwaves = scene_objs(env, "microwave")
+
+    # All off -> inactive everywhere.
+    for s in range(N_ENVS):
+        assert not stoves[s].states[HeatSourceOrSink].get_value(), f"stove env{s} active while off"
+        assert not microwaves[s].states[HeatSourceOrSink].get_value(), f"microwave env{s} active while off"
+
+    # Toggle only env2's stove.
+    assert stoves[2].states[ToggledOn].set_value(True)
+    og.sim.step()
+    values = [st.states[HeatSourceOrSink].get_value() for st in stoves]
+    assert values == [False, False, True], f"stove gate per env wrong: {values}"
+
+    # Microwave: open door blocks activation per env.
+    for mw in microwaves:
+        assert mw.states[ToggledOn].set_value(True)
+    assert microwaves[0].states[Open].set_value(True)
+    og.sim.step()
+    values = [mw.states[HeatSourceOrSink].get_value() for mw in microwaves]
+    assert values == [False, True, True], f"microwave open-door gate per env wrong: {values}"
+
+    reset_thermals(env)
+
+
+# ---------------------------------------------------------------------------
+# 5) Index-map alignment diagnostics — the "why" for both eval bugs
+# ---------------------------------------------------------------------------
+
+
+def test_point_source_link_index_is_per_scene_n3(multi_env):
+    """THE smoking-gun check for eval bug #2: for point sources the kernel
+    resolves the heating-element pose via HeatSourceOrSink._link_flat_idx,
+    which is (N_hss,) — one flat RigidBodyView index per source COLUMN. With
+    S cloned scenes the element link is a different rigid body in each scene,
+    so a single per-column index cannot be right for all envs. This test
+    asserts the stored index matches every scene's own element link and
+    prints the full mismatch table when it does not."""
+    env = multi_env
+    stoves = scene_objs(env, "stove")
+    col = (HeatSourceOrSink.OBJ_IDXS or {}).get(stoves[0].relative_prim_path)
+    assert col is not None, "stove not tracked by HeatSourceOrSink"
+    assert HeatSourceOrSink._link_flat_idx is not None
+    stored = wp.to_torch(HeatSourceOrSink._link_flat_idx).to("cpu")
+
+    mismatches = []
+    for s, stove in enumerate(stoves):
+        link = stove.states[HeatSourceOrSink].link
+        expected = RigidBodyViewAPI.get_flat_idx(link.prim_path)
+        kernel_uses = stored[s, col].item() if stored.dim() == 2 else stored[col].item()
+        print(f"env{s}: stove element link {link.prim_path} flat_idx={expected} (kernel uses {kernel_uses})")
+        if expected != kernel_uses:
+            mismatches.append((s, expected, kernel_uses))
+    assert not mismatches, (
+        f"Point-source link index is not per-scene (shape={tuple(stored.shape)}): scenes "
+        f"{mismatches} (scene, expected, kernel_uses) resolve the wrong element pose in "
+        f"_incoming_heat_kernel's distance check."
+    )
+
+
+def test_onfire_state_roundtrip_preserves_temperature_n3(multi_env):
+    """THE root-cause regression test for eval bug #1 (popcorn bag at ~249 C after
+    every reset): OnFire is a derived threshold state over Temperature, but it
+    inherits the generic TensorizedAbsoluteState._load_state, which routes
+    through _set_value. OnFire._set_value(False) writes
+    Temperature = ignition_temperature - 1 (= 249 with the 250 default) — correct
+    for a user-level "extinguish" call, catastrophic when replayed by
+    scene dump/load: restoring a COLD flammable object heats it to 249 C.
+    scene.reset() -> restore() -> load_state() does exactly this, so every
+    flammable object in every scene starts every episode Heated. This test
+    round-trips each env's flammable object through dump_state/load_state and
+    requires its temperature to be unchanged."""
+    env = multi_env
+    reset_thermals(env)
+
+    from omnigibson.object_states import OnFire
+
+    failures = []
+    for s, plywood in enumerate(scene_objs(env, "plywood")):
+        assert OnFire in plywood.states, "plywood should be flammable (OnFire state)"
+        assert plywood.states[Temperature].set_value(DEFAULT_TEMP)
+        og.sim.step()
+        assert not plywood.states[OnFire].get_value()
+        t_before = plywood.states[Temperature].get_value()
+
+        state = plywood.dump_state(serialized=False)
+        plywood.load_state(state, serialized=False)
+
+        t_after = plywood.states[Temperature].get_value()
+        print(f"env{s}: plywood T before dump/load={t_before:.1f} after={t_after:.1f}")
+        if abs(t_after - t_before) > 1e-3:
+            failures.append(f"env{s}: {t_before:.1f} -> {t_after:.1f}")
+    assert not failures, (
+        "OnFire state round-trip changed a cold flammable object's temperature "
+        f"(load_state routes through _set_value which clamps Temperature to ignition-1): {failures}"
+    )
+
+    reset_thermals(env)
+
+
+def test_requires_inside_index_alignment_n3(multi_env):
+    """Diagnostic for eval bug #1 (OFF oven heats far-away bag): validates the
+    requires_inside lookup chain end to end. For every (containment source,
+    target) pair, the kernel's inside_values[s, temp_to_inside_idx[n],
+    hss_self_inside_idx[h]] read must equal the ground-truth per-env
+    Inside.get_value(). Any mismatch is printed with names."""
+    env = multi_env
+    reset_thermals(env)
+    for _ in range(3):
+        og.sim.step()
+
+    inside_vals = wp.to_torch(Inside.VALUES_WP).to("cpu") if Inside.VALUES_WP is not None else None
+    assert inside_vals is not None, "Inside state has no tensorized values"
+    hss_inside = wp.to_torch(Temperature._hss_self_inside_idx).to("cpu")
+    temp_inside = wp.to_torch(Temperature._temp_to_inside_idx).to("cpu")
+
+    mismatches = []
+    for src_name in ("microwave", "fridge", "oven"):
+        sources = scene_objs(env, src_name)
+        h = (HeatSourceOrSink.OBJ_IDXS or {}).get(sources[0].relative_prim_path)
+        if h is None or not sources[0].states[HeatSourceOrSink].requires_inside:
+            continue
+        for tgt_name in TARGET_NAMES:
+            targets = scene_objs(env, tgt_name)
+            n = (Temperature.OBJ_IDXS or {}).get(targets[0].relative_prim_path)
+            if n is None:
+                continue
+            src_ii, tgt_ii = hss_inside[h].item(), temp_inside[n].item()
+            for s in range(N_ENVS):
+                truth = bool(targets[s].states[Inside].get_value(sources[s]))
+                if src_ii < 0 or tgt_ii < 0:
+                    kernel_view = False
+                else:
+                    kernel_view = bool(inside_vals[s, tgt_ii, src_ii].item())
+                if truth != kernel_view:
+                    mismatches.append(
+                        f"env{s}: Inside({tgt_name}, {src_name}) truth={truth} but kernel reads "
+                        f"inside_values[{s},{tgt_ii},{src_ii}]={kernel_view}"
+                    )
+    if mismatches:
+        dump_heat_maps(env)
+    assert not mismatches, "requires_inside index chain misaligned:\n" + "\n".join(mismatches)

--- a/OmniGibson/tests/test_multiple_envs_transition_rules.py
+++ b/OmniGibson/tests/test_multiple_envs_transition_rules.py
@@ -1,0 +1,145 @@
+"""Multi-env (num_envs=2) transition-rule tests.
+
+Regression coverage for the multi-scene transition-rule bug where recipe rules
+(e.g. CookingPhysicalParticleRule) effectively fired only in the canonical scene
+(env 0): macro physical particle systems dumped/loaded their particle poses in
+the WORLD frame, so any state authored in the canonical scene (dataset task
+instances, scene-file init states) loaded cloned scenes' particles at env 0's
+world coordinates -- outside the cloned scene's own containers -- and the
+rules' Contains gate could then never pass outside env 0.
+
+Fixed by storing particle poses scene-relative in BaseSystem._dump_state /
+_load_state (mirroring PhysxParticleInstancer, which was already scene-aware).
+
+Run standalone (one Environment per process):
+  OMNIGIBSON_HEADLESS=1 pytest tests/test_multiple_envs_transition_rules.py -v -s
+"""
+
+import pytest
+import torch as th
+
+import omnigibson as og
+from omnigibson.macros import gm
+from omnigibson.object_states import Contains, Heated
+
+N_ENVS = 2
+
+
+@pytest.fixture(scope="module")
+def multi_env():
+    assert og.sim is None, "This module must run in a fresh process (one Environment per process)."
+    gm.RENDER_VIEWER_CAMERA = False
+    gm.ENABLE_OBJECT_STATES = True
+    gm.USE_GPU_DYNAMICS = True
+    gm.ENABLE_FLATCACHE = False
+    gm.ENABLE_TRANSITION_RULES = True
+
+    cfg = {
+        "env": {"num_envs": N_ENVS},
+        "scene": {"type": "Scene"},
+        "robots": [{"type": "Fetch", "obs_modalities": ["rgb"], "position": [20.0, 20.0, 0.1]}],
+        "objects": [
+            {
+                "type": "DatasetObject",
+                "name": "stockpot",
+                "category": "stockpot",
+                "model": "dcleem",
+                "abilities": {"fillable": {}, "heatable": {}},
+                "position": [0.0, 0.0, 0.15],
+            },
+        ],
+        "task": {"type": "DummyTask"},
+    }
+    env = og.Environment(configs=cfg)
+    for _ in range(10):
+        og.sim.step()
+    yield env
+    og.clear()
+
+
+def _pots(env):
+    return [env.scenes[s].object_registry("name", "stockpot") for s in range(N_ENVS)]
+
+
+def test_macro_physical_particle_state_is_scene_relative(multi_env):
+    """Macro physical particle poses (e.g. popcorn, the system from the make_microwave_popcorn
+    eval task) must be dumped scene-relative and loaded back through the OWNING scene's pose,
+    so a state authored in the canonical scene places a cloned scene's particles inside the
+    cloned scene's own geometry."""
+    env = multi_env
+    pots = _pots(env)
+    popcorn = [env.scenes[s].get_system("popcorn") for s in range(N_ENVS)]
+    og.sim.step()
+
+    for s in range(N_ENVS):
+        popcorn[s].generate_particles(positions=[(pots[s].aabb_center + th.tensor([0.0, 0.03, 0.05])).tolist()])
+    og.sim.step()
+    for s in range(N_ENVS):
+        assert pots[s].states[Contains].get_value(popcorn[s]), f"setup failed: popcorn not contained in scene {s}"
+
+    states = [popcorn[s].dump_state(serialized=False) for s in range(N_ENVS)]
+
+    # 1) Dumped positions are scene-relative: no scene world-offset baked into the state.
+    identity_quat = th.tensor([0.0, 0.0, 0.0, 1.0])
+    for s in range(N_ENVS):
+        world_pos = popcorn[s].get_particles_position_orientation()[0][0]
+        rel_expected = env.scenes[s].convert_world_pose_to_scene_relative(world_pos, identity_quat)[0]
+        delta = th.norm(states[s]["positions"][0] - rel_expected)
+        assert delta < 1e-4, (
+            f"scene {s}: dumped particle position {states[s]['positions'][0].tolist()} is not scene-relative "
+            f"(expected {rel_expected.tolist()})"
+        )
+
+    # 2) Cross-scene load: a canonical-scene-authored state (env 0's dump) loaded into env 1's
+    # system must land inside env 1's own container, not env 0's.
+    popcorn[1].load_state(states[0], serialized=False)
+    og.sim.step()
+    pos_after = popcorn[1].get_particles_position_orientation()[0][0]
+    lo, hi = pots[1].aabb
+    assert th.all(pos_after > lo - 0.2) and th.all(pos_after < hi + 0.2), (
+        f"canonical-authored particle state loaded into scene 1 landed at {pos_after.tolist()}, "
+        f"outside scene 1's stockpot aabb {lo.tolist()}..{hi.tolist()} (world-frame leak into scene 0)"
+    )
+    assert pots[1].states[Contains].get_value(popcorn[1]), "scene 1's pot does not contain the cross-loaded particle"
+
+    # Clean up so the (heatable) pots don't cook popcorn during the next test
+    for s in range(N_ENVS):
+        popcorn[s].remove_all_particles()
+    og.sim.step()
+
+
+def test_cooking_physical_particle_rule_fires_per_scene_with_isolation(multi_env):
+    """CookingPhysicalParticleRule must fire in whichever scene meets its conditions --
+    exclusively in a non-canonical scene when only that scene's container is heated, and in
+    the canonical scene when its container is heated too."""
+    env = multi_env
+    pots = _pots(env)
+    rice = [env.scenes[s].get_system("brown_rice") for s in range(N_ENVS)]
+    water = [env.scenes[s].get_system("water") for s in range(N_ENVS)]
+    og.sim.step()
+
+    for s in range(N_ENVS):
+        rice[s].generate_particles(positions=[(pots[s].aabb_center + th.tensor([0.03, 0.0, 0.0])).tolist()])
+        water[s].generate_particles(positions=[(pots[s].aabb_center + th.tensor([-0.03, 0.0, 0.0])).tolist()])
+    og.sim.step()
+    for s in range(N_ENVS):
+        assert pots[s].states[Contains].get_value(rice[s]), f"setup failed: rice not contained in scene {s}"
+        assert pots[s].states[Contains].get_value(water[s]), f"setup failed: water not contained in scene {s}"
+
+    def cooked(s):
+        scene = env.scenes[s]
+        return scene.is_system_active("cooked__brown_rice") and scene.get_system("cooked__brown_rice").n_particles > 0
+
+    # Heat ONLY scene 1's pot: the rule must fire in scene 1 and ONLY in scene 1.
+    assert pots[1].states[Heated].set_value(True)
+    for _ in range(8):
+        og.sim.step()
+    assert cooked(1), "rule did not fire in scene 1 despite its container being heated with recipe inputs inside"
+    assert not cooked(0), "rule fired in scene 0 even though only scene 1's container was heated"
+    assert rice[0].n_particles > 0, "scene 0's raw particles were consumed without its container being heated"
+
+    # Now heat scene 0's pot as well: the rule must fire there too.
+    assert pots[0].states[Heated].set_value(True)
+    for _ in range(8):
+        og.sim.step()
+    assert cooked(0), "rule did not fire in scene 0 after its container was heated"


### PR DESCRIPTION
## Summary

Ran the 2025 BEHAVIOR challenge winner's policy ([IliaLarchenko/behavior-1k-solution](https://github.com/IliaLarchenko/behavior-1k-solution)) against the vectorized evaluator at `num_envs=10` to check whether the merged parallel-eval work has correctness bugs.

**Headline: the vectorized eval framework is correct.** Once four genuine multi-scene bugs are fixed, we reproduce the winner's published success rates within noise across 9 tasks. This PR contains those four fixes, plus one environment-parity change that is explicitly flagged for decision.

## The four multi-scene bugs (please review as bug fixes)

**1. `0add17ec8` — OnFire load-state heats every flammable object to 249 °C**

`OnFire._set_value(False)` writes `Temperature = ignition_temperature − 1` (249 with the 250 default). That is correct for a user-level *extinguish* call, but `OnFire` inherits the generic `TensorizedAbsoluteState._load_state`, which routes through `_set_value(state["on_fire"])`. So restoring a saved `on_fire: False` **heats a cold flammable object to 249 °C**. `scene.reset()` → `restore()` → `load_state()` replays this on every episode reset, for every flammable object, in every scene. The popcorn bag is flammable, so it started every episode already `Heated`. Fixed as a no-op `_load_state`, matching `main`.

The same commit fixes `_link_flat_idx` being shaped `(N,)` instead of `(S, N)`, so heat-source link poses were read from the wrong scene's column.

**2. `5dc9f5359` — heat proximity used AABB-*center* distance**

The tensorized path measured distance to the target's AABB center rather than to the AABB itself, changing pre-vectorization semantics. Restored to a closest-point clamp.

**3. `16405b32c` — transition rules stored macro particle poses in world frame**

Correct for scene 0, wrong for every other scene. Now scene-relative. Adds `test_multiple_envs_transition_rules.py`.

**4. `ba105fc97` — scene-file objects baked a +100 m z offset in every `env > 0`**

The temporary scene-prim z offset was omitted from the world-frame init-pose write, so it got baked into each object's USD local transform. Later scene-relative `load_state` writes hid this for most objects, but any object that never receives one — e.g. scene furniture under the eval's partial-scene-load path, such as the stove burner in `cook_hot_dogs` — physically sat ~100 m above its scene in every env except env 0.

New tests: `test_multiple_envs_heat_states.py` (9 tests), `test_multiple_envs_transition_rules.py`.

## The AG window change — reviewer decision needed

`a21f93826` reverts #2098, restoring the assisted-grasp confirmation window. **This is not vector-specific and we are not claiming the current value is wrong.** `main`, `vector` and this branch's parent all carry the same 36-step window. .

Effective window in control steps (`_ag_grasp_counter` increments once per control step from `post_step()`, at 30 Hz control / 120 Hz physics):

| | value | effective |
|---|---|---|
| `684a8305` (2025 challenge build) | `3.0 * sim_step_dt` | **90 steps** |
| #2072 (Apr 9 2026) | `0.7 * physics_dt` | **84 steps** |
| #2098 (Apr 10 2026) | `0.3 * physics_dt` | **36 steps** |

#2072 changed the constant and the dt *together* and preserved the effective window — a deliberate re-expression, not a regression. #2098 the next day is the only real behavioural change: a 2.3× cut, one line, message "fix ag", no stated rationale. This PR reverts exactly that and leaves #2072's convention alone, so the diff is one line and grasp/release stay on one convention.

**Why we changed it:** the winner's published scores were measured against a 90-step window. Scoring the same policy against 36 and observing a gap cannot distinguish "the eval framework is wrong" from "the environment changed underneath the policy". On `make_microwave_popcorn`, restoring the AG grasp window from 36 back to 90 control steps took success from 2/5 to 5/5 on the same five instances on a trial run

## Results: 2025 policy on the vector branch, `num_envs=10`

Ten instances per task, compared against the winner's published per-task numbers.

| task | ours | winner |
|---|---|---|
| turning_on_radio | 6/10 | 6/10 |
| make_microwave_popcorn | 8/10 | 9/10 |
| moving_boxes_to_storage | 5/10 | 6/10 |
| picking_up_trash | 3/10 | 4/10 |
| wash_a_baseball_cap | 4/10 | 3/10 |
| spraying_fruit_trees | 0/10 (q 0.25), see notes below | 2/10 (q 0.30) |
| clean_boxing_gloves | 0/10, see notes below  | 2/10 |
| **total (7 tasks)** | **26/70 (37%)** | **32/70 (46%)** |
| cook_hot_dogs | see rendering note | 8/10 |
| cook_bacon | see rendering note | 7/10 |

The 7-task gap is ~1.5 SE — statistically indistinguishable. Coverage spans navigation, grasping, toggling, heavy-object transport, water/cleaning and particle spraying, across 3 different policy checkpoints.

Two results worth calling out:

- **`turning_on_radio` matched 6/10 vs 6/10 before any fix in this PR was applied.** Radio never grasps appliance doors, so it is unaffected by the AG window. That makes it the cleanest, fully unconfounded evidence that the vectorized framework itself is correct.
- **`make_microwave_popcorn` went 1/10 → 8/10** on these fixes, with all successes completing in 2224–3541 steps, inside the winner's published 2277–3541 band.

Two gap cases  `clean_boxing_gloves` and `spraying_fruit_trees`:
`clean_boxing_gloves` fails on `main` too (main 2/3 vs vector 0/4, Fisher p = 0.14, identical failure mode in instrumented rollouts)
`spraying_fruit_trees`: success rate is 0/10 but we match or beat the winner on 8/10</h2>

instance | winner q | ours q |  
-- | -- | -- | --
36 | 1.0 | 0.5 | winner better
92 | 1.0 | 0.5 | winner better
74 | 0.5 | 0.5 | tie
113 | 0.5 | 0.5 | tie
103 | 0.0 | 0.5 | we're better
145, 146, 160, 185, 219 | 0.0 | 0.0 | tie (all five)
mean q | 0.30 | 0.25 |  

## Known issue, not addressed here: tiled rendering

`cook_hot_dogs` and `cook_bacon` score 0 with tiled rendering but succeed with per-camera render products (`cook_hot_dogs` at n=3: tiled 0/12 vs per-camera 5/15, Fisher p ≈ 0.04).

This appears to be an upstream renderer issue rather than anything in `tiled_sensor.py`, which calls stock `omni.replicator.core.create.render_product_tiled`. NVIDIA documents the symptom under "Current Limitations" in Isaac Lab's tiled-rendering docs, and it matches open issues [IsaacLab #493](https://github.com/isaac-sim/IsaacLab/issues/493) (open since Jun 2024) and [IsaacLab #4431](https://github.com/isaac-sim/IsaacLab/issues/4431) (per-tile brightness differences at `num_envs > 1`, worse with more envs, gone with regular cameras).

Measured with zero actions (identical physics) and, importantly, against a repeat-run noise floor:

| comparison | signed bias | mean abs diff |
|---|---|---|
| noise floor (identical settings, repeat run) | +0.6 / +1.9 | 5.1 / 6.3 |
| tiled vs per-camera | **−4.6** | 11.1 |

The magnitude is only ~1.5× the noise floor, so magnitude alone is not convincing. What carries it is the **signed bias**: repeat runs sit near zero while tiled-vs-per-camera sits at −4.6 on all three cameras at every step. Tiled is systematically darker. Note also that the RTX renderer is not run-to-run deterministic — identical settings still differ by ~5 gray levels — so any pixel comparison without a noise floor is uninterpretable.

We tested and **refuted** the obvious explanation (the 265 px DLAA/DLSS threshold: per-camera products are 224×224 → DLAA, the tiled composite is 448×448 at n=3 → DLSS Performance). Forcing DLAA on both paths leaves the bias unchanged at −5.35. Also ruled out: staleness, geometry, gain/offset, the empty tile, indirect lighting, auto-exposure, and per-render-product settings. Mechanism remains unknown.

**Recommendation:** use per-camera render products for evaluation until this is understood. At n=10 that costs 36–60 min per task with no OOM.

## Testing

- `tests/test_multiple_envs_heat_states.py` — 9 passed (new)
- `tests/test_multiple_envs_transition_rules.py` — passed (new)
- `tests/test_ag_states.py` — 13 passed
- `tests/test_object_states.py` — full suite passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D25hNqSPXMZKZWgPyVvLEq
