### PR TITLE
Add fail-closed pre-action guard wrapper

### DIFF
--- a/OmniGibson/omnigibson/envs/__init__.py
+++ b/OmniGibson/omnigibson/envs/__init__.py
@@ -1,3 +1,4 @@
+from omnigibson.envs.action_guard_wrapper import ActionGuardDecision, ActionGuardWrapper, ActionRejectedError
 from omnigibson.envs.data_wrapper import DataWrapper, DataPlaybackWrapper
 from omnigibson.envs.hdf5_data_wrapper import HDF5CollectionWrapper, HDF5PlaybackWrapper
 from omnigibson.envs.lerobot_data_wrapper import LeRobotDataWrapper, LeRobotPlaybackWrapper
@@ -9,6 +10,9 @@ from omnigibson.envs.vec_env_base import VectorEnvironment
 
 __all__ = [
     "create_wrapper",
+    "ActionGuardDecision",
+    "ActionGuardWrapper",
+    "ActionRejectedError",
     "DataWrapper",
     "DataPlaybackWrapper",
     "HDF5CollectionWrapper",

--- a/OmniGibson/omnigibson/envs/action_guard_wrapper.py
+++ b/OmniGibson/omnigibson/envs/action_guard_wrapper.py
@@ -1,0 +1,72 @@
+"""Fail-closed action guard for OmniGibson environments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+from omnigibson.envs.env_wrapper import EnvironmentWrapper
+
+
+@dataclass(frozen=True)
+class ActionGuardDecision:
+    """Result returned by a pre-action guard."""
+
+    allowed: bool
+    reason: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class ActionRejectedError(PermissionError):
+    """Raised before simulation when an action guard denies an action."""
+
+    def __init__(self, reason: str, metadata: Mapping[str, Any] | None = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.metadata = dict(metadata or {})
+
+
+class ActionGuardWrapper(EnvironmentWrapper):
+    """Evaluate a caller-supplied guard immediately before ``env.step``.
+
+    The guard receives ``(env, action)`` and may return a boolean or any object
+    with ``allowed``, optional ``reason``, and optional ``metadata`` attributes.
+    A denial, malformed result, or guard exception prevents the simulator from
+    stepping and raises :class:`ActionRejectedError`.
+    """
+
+    def __init__(self, env, guard: Callable[[Any, Any], Any]):
+        if not callable(guard):
+            raise TypeError("guard must be callable")
+        self._guard = guard
+        self.last_decision = None
+        super().__init__(env=env)
+
+    @staticmethod
+    def _normalize_decision(value: Any) -> ActionGuardDecision:
+        if isinstance(value, bool):
+            return ActionGuardDecision(value, "allowed" if value else "rejected")
+        allowed = getattr(value, "allowed", None)
+        if not isinstance(allowed, bool):
+            raise TypeError("guard result must be a bool or expose a boolean 'allowed' attribute")
+        reason = getattr(value, "reason", "")
+        metadata = getattr(value, "metadata", {})
+        if not isinstance(reason, str) or not isinstance(metadata, Mapping):
+            raise TypeError("guard result reason and metadata must be a string and mapping")
+        return ActionGuardDecision(allowed, reason, dict(metadata))
+
+    def step(self, action, n_render_iterations=1):
+        try:
+            decision = self._normalize_decision(self._guard(self.env, action))
+        except Exception as exc:
+            self.last_decision = ActionGuardDecision(
+                False,
+                "action_guard_error",
+                {"error_type": type(exc).__name__},
+            )
+            raise ActionRejectedError(self.last_decision.reason, self.last_decision.metadata) from exc
+
+        self.last_decision = decision
+        if not decision.allowed:
+            raise ActionRejectedError(decision.reason or "rejected", decision.metadata)
+        return self.env.step(action, n_render_iterations=n_render_iterations)

--- a/OmniGibson/tests/test_action_guard_wrapper.py
+++ b/OmniGibson/tests/test_action_guard_wrapper.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+import pytest
+
+from omnigibson.envs.action_guard_wrapper import ActionGuardWrapper, ActionRejectedError
+
+
+class FakeEnv:
+    def __init__(self):
+        self.steps = 0
+
+    def step(self, action, n_render_iterations=1):
+        self.steps += 1
+        return action, n_render_iterations
+
+
+@dataclass
+class StructuralDecision:
+    allowed: bool
+    reason: str
+    metadata: dict
+
+
+def make_wrapper(guard):
+    # Avoid launching Isaac Sim; the behavior under test only needs the wrapped
+    # env and guard attributes initialized by ActionGuardWrapper.__init__.
+    wrapper = object.__new__(ActionGuardWrapper)
+    wrapper.env = FakeEnv()
+    wrapper._guard = guard
+    wrapper.last_decision = None
+    return wrapper
+
+
+def test_guarded_action_steps_environment():
+    wrapper = make_wrapper(lambda env, action: True)
+
+    result = wrapper.step("move", n_render_iterations=2)
+
+    assert result == ("move", 2)
+    assert wrapper.env.steps == 1
+    assert wrapper.last_decision.allowed
+
+
+def test_denial_does_not_step_environment_and_preserves_metadata():
+    wrapper = make_wrapper(lambda env, action: StructuralDecision(False, "outside_workspace", {"zone": "restricted"}))
+
+    with pytest.raises(ActionRejectedError) as exc_info:
+        wrapper.step("move")
+
+    assert wrapper.env.steps == 0
+    assert exc_info.value.reason == "outside_workspace"
+    assert exc_info.value.metadata == {"zone": "restricted"}
+
+
+def test_guard_exception_fails_closed_without_leaking_exception_text():
+    def broken_guard(env, action):
+        raise RuntimeError("private backend detail")
+
+    wrapper = make_wrapper(broken_guard)
+
+    with pytest.raises(ActionRejectedError) as exc_info:
+        wrapper.step("move")
+
+    assert wrapper.env.steps == 0
+    assert exc_info.value.reason == "action_guard_error"
+    assert exc_info.value.metadata == {"error_type": "RuntimeError"}
+
+
+def test_malformed_guard_result_fails_closed():
+    wrapper = make_wrapper(lambda env, action: object())
+
+    with pytest.raises(ActionRejectedError):
+        wrapper.step("move")
+
+    assert wrapper.env.steps == 0


### PR DESCRIPTION
## Summary

- add `ActionGuardWrapper`, a generic pre-action policy hook for OmniGibson environments
- prevent the wrapped environment from stepping on denial, malformed guard output, or guard exceptions
- preserve structured rejection reasons and metadata for evaluation and auditing
- add focused tests that exercise the wrapper without launching Isaac Sim

## Motivation

Embodied-agent evaluation increasingly needs a boundary where safety policies, human approval, workspace constraints, or external authorization can reject an action before it reaches physics. A generic wrapper provides that boundary without coupling OmniGibson to any policy vendor, network service, or cryptography implementation.

## API

The guard has signature `guard(env, action)` and may return either a boolean or a structural result exposing:

- `allowed: bool`
- `reason: str`
- `metadata: Mapping[str, Any]`

Rejected actions raise `ActionRejectedError`; the wrapped environment is never stepped. The normalized result is retained as `last_decision` for logging and evaluation.

## Validation

- Python source compilation passed
- standalone allow, deny, and guard-exception validation passed
- tests avoid launching Isaac Sim and do not require a GPU

Full OmniGibson integration tests were not run locally because the required Isaac Sim / NVIDIA environment is not available. The change is intentionally limited to the generic simulator integration point.