### PR TITLE
Retry Isaac Sim wheel downloads and fail loudly on a bad one

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -374,19 +374,31 @@ if [ "$OMNIGIBSON" = true ]; then
                     "isaacsim_extscache_kit_sdk-5.1.0.0"
                 )
 
+                # --fail keeps an HTTP error page from being saved under a .whl name;
+                # --speed-limit/--speed-time abort a transfer that stalls without erroring.
+                local curl_opts=(-sS --location --fail --connect-timeout 30 --speed-limit 1024 --speed-time 60)
+
                 local wheel_files=()
                 for pkg in "${packages[@]}"; do
                     local pkg_name=${pkg%-*}
                     local filename="${pkg}-cp311-none-manylinux_2_35_${ARCH}.whl"
                     local url="https://pypi.nvidia.com/${pkg_name//_/-}/$filename"
                     local filepath="$temp_dir/$filename"
+                    local attempt
 
                     echo "Downloading $pkg..."
-                    if ! curl -sL "$url" -o "$filepath"; then
-                        echo "ERROR: Failed to download $pkg"
-                        rm -rf "$temp_dir"
-                        return 1
-                    fi
+                    for attempt in 1 2 3 4 5; do
+                        if curl "${curl_opts[@]}" "$url" -o "$filepath"; then
+                            break
+                        fi
+                        if [ "$attempt" -eq 5 ]; then
+                            echo "ERROR: Failed to download $pkg"
+                            rm -rf "$temp_dir"
+                            return 1
+                        fi
+                        echo "Retrying $pkg ($attempt/5)..."
+                        sleep 5
+                    done
 
                     # Rename for older GLIBC
                     if check_glibc_old; then


### PR DESCRIPTION
Thanks for BEHAVIOR-1K, and for keeping `setup.sh` a single entry point. This is a small change to the Isaac Sim wheel loop, which is the step that keeps costing us whole installs.

`docker/Dockerfile:85` runs `./setup.sh --new-env --omnigibson ...`, so this also affects image builds in this repo, not only people installing by hand.

## What happens now

At `eb3c012`, [`setup.sh:385`](https://github.com/StanfordVL/BEHAVIOR-1K/blob/eb3c01263b76f4404e8187c1bcd758d48d47a020/setup.sh#L385) downloads 26 Isaac Sim wheels in sequence:

```bash
if ! curl -sL "$url" -o "$filepath"; then
```

Two things follow from those flags.

A transport error part-way through any one wheel ends the whole install, and the wheels are large. One of our installs died about 20 minutes in with all but one already downloaded, and the log said only `ERROR: Failed to download <pkg>`, with no reason, because `-s` suppresses curl's. Every earlier wheel then has to be fetched again.

The second one surprised me more. Without `--fail`, curl writes an HTTP error response to disk under the wheel's name and still exits 0, so the `if !` guard never fires. Against the real index, with curl 7.81.0:

```console
$ curl -sL "https://pypi.nvidia.com/isaacsim/does-not-exist-9.9.9.whl" -o old.whl; echo "rc=$?"
rc=0
$ wc -c < old.whl
331
$ head -c 60 old.whl
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKe
```

That 331-byte XML document goes into `wheel_files` and reaches `pip install`, where it fails later with a message that does not point back at the download.

## The change

A five-attempt shell loop around the download, plus flags that make a failure look like one: `--fail`, `--connect-timeout 30`, `--speed-limit 1024 --speed-time 60` to bound a transfer that connects and then stalls, and `-sS` so curl still prints why it failed.

The retry is a shell loop rather than curl's `--retry` on purpose. `--retry` does not cover a reset or a truncated transfer, and `--retry-all-errors`, which does, needs curl >= 7.71. Ubuntu 20.04 ships curl 7.68, and `check_glibc_old` ten lines above this code is there to support glibc 2.31, so a curl-flag fix would have skipped exactly the users most likely to be on a flaky connection. The loop behaves the same on 7.68 and on 8.x.

Two things worth naming. A genuinely missing wheel is now retried before it fails, so a 404 costs about 20 seconds instead of failing at once. And a stalled transfer is bounded per attempt rather than overall, so the worst case is five stall windows rather than one. Both seemed like the better side to err on for a step that otherwise loses a 20-minute install, but say the word and I will lower the attempt count or skip the retry on a 404.

`setup.ps1` has the same gap around `Invoke-WebRequest` at line 412. It throws on an HTTP error, so it has no `--fail` problem, but it has no transport retry either. I kept this diff to one script to keep the review small, and I am happy to follow up there.

## How I verified it

`bash -n setup.sh` is clean, and the loop sits inside `install_isaac_packages`, so `local` is legal. `if curl ...; then` keeps the failing attempt out of `set -e`'s way, which I checked rather than assumed.

Against a local server rigged to fail twice and then succeed:

```
curl: (22) The requested URL returned error: 503
Retrying (attempt 1/5)...
curl: (22) The requested URL returned error: 503
Retrying (attempt 2/5)...
RECOVERED: 204 bytes, script still alive under set -e
```

Against the real index: a real wheel URL downloads and returns 0; a missing one exits 22, the guard fires after the attempts are spent, and no file is left behind, whereas the current flags leave the 331-byte XML above.

I have not re-run a full `setup.sh` install end to end since the change, so that part is unverified. I am asking you to review the download logic, not claiming an end-to-end install. If the current flags are deliberate, say so and I will close this.
