### PR TITLE
Add August 2026 challenge update

### DIFF
--- a/OmniGibson/omnigibson/__init__.py
+++ b/OmniGibson/omnigibson/__init__.py
@@ -52,7 +52,7 @@ builtins.ISAAC_LAUNCHED_FROM_JUPYTER = (
     os.getenv("ISAAC_JUPYTER_KERNEL") is not None
 )  # We set this in the kernel.json file
 
-__version__ = "3.9.1"
+__version__ = "3.9.2"
 
 root_path = os.path.dirname(os.path.realpath(__file__))
 

--- a/OmniGibson/omnigibson/action_primitives/curobo.py
+++ b/OmniGibson/omnigibson/action_primitives/curobo.py
@@ -119,7 +119,7 @@ class CuRoboMotionGenerator:
         # TODO [Wensi]: Check whether this is still true for future releases.
         print(
             """
-            NOTE: Currently (v3.9.1), for cuda architecture 12.0 (e.g. RTX 50-series), using Default embodiment for Tiago or non-DEFAULT embodiment for R1Pro
+            NOTE: Currently (v3.9.2), for cuda architecture 12.0 (e.g. RTX 50-series), using Default embodiment for Tiago or non-DEFAULT embodiment for R1Pro
                 will raise CUDA illegal memory access error during mg.warmup() due to cuRobo compatibility issues. 
                 Therefore, we automatically exclude these incompatible embodiments when we detect such GPU is being used. 
             """

--- a/OmniGibson/omnigibson/omnigibson_5_1_0.kit
+++ b/OmniGibson/omnigibson/omnigibson_5_1_0.kit
@@ -1,7 +1,7 @@
 [package]
 description = "A platform for accelerating Embodied AI research"
 title = "OmniGibson"
-version = "3.9.1"
+version = "3.9.2"
 
 keywords = ["experience", "app", "usd", "isaacsim"] # That makes it browsable in UI with "experience" filter
 
@@ -15,7 +15,7 @@ keywords = ["experience", "app", "usd", "isaacsim"] # That makes it browsable in
 
 [settings.app]
 name = "OmniGibson"
-version = "3.9.1"
+version = "3.9.2"
 settings.persistent = false       # settings reset on each run with this app
 window.title = "OmniGibson"
 vulkan = true # Explicitly enable Vulkan (on by default on Linux, off by default on Windows)

--- a/OmniGibson/omnigibson/omnigibson_5_1_0_vr.kit
+++ b/OmniGibson/omnigibson/omnigibson_5_1_0_vr.kit
@@ -1,7 +1,7 @@
 [package]
 description = "A platform for accelerating Embodied AI research"
 title = "OmniGibson"
-version = "3.9.1"
+version = "3.9.2"
 
 keywords = ["experience", "app", "usd", "isaacsim"] # That makes it browsable in UI with "experience" filter
 
@@ -15,7 +15,7 @@ keywords = ["experience", "app", "usd", "isaacsim"] # That makes it browsable in
 
 [settings.app]
 name = "OmniGibson"
-version = "3.9.1"
+version = "3.9.2"
 settings.persistent = false       # settings reset on each run with this app
 window.title = "OmniGibson"
 vulkan = true # Explicitly enable Vulkan (on by default on Linux, off by default on Windows)

--- a/OmniGibson/setup.py
+++ b/OmniGibson/setup.py
@@ -13,7 +13,7 @@ long_description = "".join(lines)
 
 setup(
     name="omnigibson",
-    version="3.9.1",
+    version="3.9.2",
     author="Stanford University",
     long_description_content_type="text/markdown",
     long_description=long_description,

--- a/OmniGibson/tests/test_curobo.py
+++ b/OmniGibson/tests/test_curobo.py
@@ -271,7 +271,7 @@ def test_curobo():
     for robot_cfg in robot_cfgs:
         if th.cuda.is_available() and th.cuda.get_device_capability(0) == (12, 0):
             # TODO [Wensi]: Check whether this is still true for future releases.
-            # Currently (v3.9.1), for cuda architecture 12.0 (e.g. RTX 50-series), using Default embodiment for Tiago or non-DEFAULT embodiment for R1Pro
+            # Currently (v3.9.2), for cuda architecture 12.0 (e.g. RTX 50-series), using Default embodiment for Tiago or non-DEFAULT embodiment for R1Pro
             #     will raise CUDA illegal memory access error during mg.warmup() due to cuRobo compatibility issues.
             # Therefore, we remove R1Pro for testing if we detect such GPU is being used.
             if robot_cfg["model"] == "r1pro":

--- a/docs/challenge/baselines.md
+++ b/docs/challenge/baselines.md
@@ -40,10 +40,10 @@ See the [dataset page](./dataset.md) for the full task list.
 
 ### Install BEHAVIOR-1K
 
-Clone the `v3.9.1` tag of BEHAVIOR-1K and run the setup script. It creates a `behavior` conda environment with OmniGibson, the simulation assets, and the evaluation dependencies. Do not use the older `v3.9.0` tag for challenge evaluation workflows because dataset and evaluator compatibility fixes are shipped in `v3.9.1`.
+Clone the `v3.9.2` tag of BEHAVIOR-1K and run the setup script. It creates a `behavior` conda environment with OmniGibson, the simulation assets, and the evaluation dependencies. Do not use the older `v3.9.0` tag for challenge evaluation workflows because dataset and evaluator compatibility fixes are shipped in `v3.9.2`.
 
 ```bash
-git clone -b v3.9.1 https://github.com/StanfordVL/BEHAVIOR-1K.git $PATH_TO_BEHAVIOR_1K
+git clone -b v3.9.2 https://github.com/StanfordVL/BEHAVIOR-1K.git $PATH_TO_BEHAVIOR_1K
 cd $PATH_TO_BEHAVIOR_1K
 ./setup.sh --new-env --omnigibson --bddl --joylo --dataset --eval
 ```

--- a/docs/challenge/evaluation.md
+++ b/docs/challenge/evaluation.md
@@ -31,8 +31,8 @@ There are no restrictions on the type of policy used. Methods such as IL, RL, or
 
 ## Running Evaluations
 
-!!! warning "Use the `v3.9.1` tag"
-    Run challenge evaluation from the `v3.9.1` tag of `BEHAVIOR-1K`, not the older `v3.9.0` tag. The challenge evaluator and dataset interfaces in `v3.9.1` include the latest compatibility fixes that the organizers will use for evaluation.
+!!! warning "Use the `v3.9.2` tag"
+    Run challenge evaluation from the `v3.9.2` tag of `BEHAVIOR-1K`, not the older `v3.9.0` tag. The challenge evaluator and dataset interfaces in `v3.9.2` include the latest compatibility fixes that the organizers will use for evaluation.
 
 We provide `OmniGibson/omnigibson/eval/eval.py` as the command-line entry point for running websocket-based evaluations. Start your policy server first, then run the evaluator from the repository root:
 

--- a/docs/challenge/updates.md
+++ b/docs/challenge/updates.md
@@ -8,7 +8,7 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 
 **Challenge rule clarifications:**
 
-1. Please use the latest `main` branch of the `BEHAVIOR-1K` repository for challenge evaluation. It includes the fixes below, which were merged after the `v3.9.1` tag.
+1. Please use the `v3.9.2` tag of the `BEHAVIOR-1K` repository for challenge evaluation. It includes the fixes below.
 
 **Bug fixes:**
 
@@ -34,7 +34,7 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 
 **Challenge rule clarifications:**
 
-1. Please use the `v3.9.1` tag of the `BEHAVIOR-1K` repository for evaluation and replay workflows, rather than the older `v3.9.0` tag. Since `v3.9.0`, `v3.9.1` includes important challenge updates, including LeRobot v3 / Hugging Face demo download instructions, evaluator Torch thread configuration, sponsor-page content, synchronized BDDL generated data, and synchronized asset synset metadata.
+1. Please use the `v3.9.2` tag of the `BEHAVIOR-1K` repository for evaluation and replay workflows, rather than the older `v3.9.0` tag. Since `v3.9.0`, `v3.9.2` includes important challenge updates, including LeRobot v3 / Hugging Face demo download instructions, evaluator Torch thread configuration, sponsor-page content, synchronized BDDL generated data, and synchronized asset synset metadata.
 
 **Bug fixes:**
 

--- a/docs/challenge/updates.md
+++ b/docs/challenge/updates.md
@@ -26,7 +26,7 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 
 **New features:**
 
-1. Introduced a participant registration form for the 2026 BEHAVIOR Challenge.
+1. Introduced a [participant registration form](https://forms.gle/Kf4ABLmDKbuK5Yhj6) for the 2026 BEHAVIOR Challenge.
 
 ---
 

--- a/docs/challenge/updates.md
+++ b/docs/challenge/updates.md
@@ -4,6 +4,23 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 
 ---
 
+### 08/24/2026 {#08242026}
+
+**Challenge rule clarifications:**
+
+1. Please use the latest `main` branch of the `BEHAVIOR-1K` repository for challenge evaluation. It includes the fixes below, which were merged after the `v3.9.1` tag.
+
+**Bug fixes:**
+
+1. Updated partial-scene evaluation to load the exact room instances specified for each task in `B100_task_misc.csv`. This keeps the evaluation scene consistent with the challenge task metadata.
+2. Fixed observation loading with `RGBDFullResWrapper` by refreshing simulator handles after changing camera resolutions and before rebuilding the observation space.
+
+**New features:**
+
+1. Added support for manually building and publishing branch-specific `behavior-dev` and `behavior-gha` Docker images through the container-build GitHub Actions workflow.
+
+---
+
 ### 07/27/2026 {#07272026}
 
 **Challenge rule clarifications:**

--- a/docs/challenge/updates.md
+++ b/docs/challenge/updates.md
@@ -12,12 +12,29 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 
 **Bug fixes:**
 
-1. Updated partial-scene evaluation to load the exact room instances specified for each task in `B100_task_misc.csv`. This keeps the evaluation scene consistent with the challenge task metadata.
-2. Fixed observation loading with `RGBDFullResWrapper` by refreshing simulator handles after changing camera resolutions and before rebuilding the observation space.
+1. Updated the 2026 challenge demonstration dataset to correct robot velocity observations in `observation.state`:
+    - `base_qvel` now uses the robot base velocity in the local robot frame.
+    - Arm, gripper, and trunk `qvel` fields now use raw simulator joint velocities from the original HDF5 demonstrations.
+    - `meta/stats.json` was recomputed to reflect the corrected velocity values.
+
+    The affected state fields are:
+
+    - `state[0:3]`: `base_qvel`
+    - `state[10:17]`: `arm_left_qvel`
+    - `state[26:28]`: `gripper_left_qvel`
+    - `state[35:42]`: `arm_right_qvel`
+    - `state[51:53]`: `gripper_right_qvel`
+    - `state[57:61]`: `trunk_qvel`
+
+    Actions, videos, annotations, episode metadata, and all non-velocity state dimensions are unchanged.
+2. Updated partial-scene evaluation to load the exact room instances specified for each task in `B100_task_misc.csv`. This keeps the evaluation scene consistent with the challenge task metadata.
+3. Fixed observation loading with `RGBDFullResWrapper` by refreshing simulator handles after changing camera resolutions and before rebuilding the observation space.
+4. Fixed bugs affecting the challenge leaderboard and submission form.
 
 **New features:**
 
-1. Added support for manually building and publishing branch-specific `behavior-dev` and `behavior-gha` Docker images through the container-build GitHub Actions workflow.
+1. Introduced a participant registration form for the 2026 BEHAVIOR Challenge.
+2. Added support for manually building and publishing branch-specific `behavior-dev` and `behavior-gha` Docker images through the container-build GitHub Actions workflow.
 
 ---
 

--- a/docs/challenge/updates.md
+++ b/docs/challenge/updates.md
@@ -12,21 +12,14 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 
 **Bug fixes:**
 
-1. Updated the 2026 challenge demonstration dataset to correct robot velocity observations in `observation.state`:
-    - `base_qvel` now uses the robot base velocity in the local robot frame.
-    - Arm, gripper, and trunk `qvel` fields now use raw simulator joint velocities from the original HDF5 demonstrations.
-    - `meta/stats.json` was recomputed to reflect the corrected velocity values.
-
-    The affected state fields are:
-
-    - `state[0:3]`: `base_qvel`
+1. Corrected the arm, gripper, and trunk velocity observations in the 2026 challenge demonstration dataset. These fields now use the raw simulator joint velocities from the original HDF5 demonstrations, and `meta/stats.json` has been recomputed accordingly. The affected fields are:
     - `state[10:17]`: `arm_left_qvel`
     - `state[26:28]`: `gripper_left_qvel`
     - `state[35:42]`: `arm_right_qvel`
     - `state[51:53]`: `gripper_right_qvel`
     - `state[57:61]`: `trunk_qvel`
 
-    Actions, videos, annotations, episode metadata, and all non-velocity state dimensions are unchanged.
+    Actions and all other dataset fields are unchanged.
 2. Updated partial-scene evaluation to load the exact room instances specified for each task in `B100_task_misc.csv`. This keeps the evaluation scene consistent with the challenge task metadata.
 3. Fixed observation loading with `RGBDFullResWrapper` by refreshing simulator handles after changing camera resolutions and before rebuilding the observation space.
 4. Fixed bugs affecting the challenge leaderboard and submission form.
@@ -34,7 +27,6 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 **New features:**
 
 1. Introduced a participant registration form for the 2026 BEHAVIOR Challenge.
-2. Added support for manually building and publishing branch-specific `behavior-dev` and `behavior-gha` Docker images through the container-build GitHub Actions workflow.
 
 ---
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -36,7 +36,7 @@ Choose your installation method:
             Clone the latest stable release (recommended):
 
             ```shell
-            git clone -b v3.9.1 https://github.com/StanfordVL/BEHAVIOR-1K.git
+            git clone -b v3.9.2 https://github.com/StanfordVL/BEHAVIOR-1K.git
             cd BEHAVIOR-1K
             ```
             

--- a/joylo/pyproject.toml
+++ b/joylo/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "joylo"
-version = "3.9.1"
+version = "3.9.2"
 description = "JoyLo for OmniGibson"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [{ name = "Stanford University" }]


### PR DESCRIPTION
## Summary

- add the August 24, 2026 challenge update and recommend the `v3.9.2` release
- document corrected arm, gripper, and trunk velocity fields in the 2026 demonstration dataset, including the affected `observation.state` slices and recomputed statistics
- summarize task-metadata room loading and the RGB-D observation handle refresh
- announce leaderboard and submission-form fixes and the participant registration form
- bump package, Kit, installation, evaluation, and baseline version references to `3.9.2`

## Testing

- `git diff --check`
- release-version consistency check
- Python syntax compilation for changed Python files
- Ruff and Ruff format commit hooks
- `mkdocs build` (passes with existing repository warnings)
- `mkdocs build --strict` (fails on 92 existing repository-wide warnings unrelated to this change)