### PR TITLE
Fix challenge update list formatting

### DIFF
--- a/docs/challenge/updates.md
+++ b/docs/challenge/updates.md
@@ -13,6 +13,7 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
 **Bug fixes:**
 
 1. Corrected the arm, gripper, and trunk velocity observations in the 2026 challenge demonstration dataset. These fields now use the raw simulator joint velocities from the original HDF5 demonstrations, and `meta/stats.json` has been recomputed accordingly. The affected fields are:
+
     - `state[10:17]`: `arm_left_qvel`
     - `state[26:28]`: `gripper_left_qvel`
     - `state[35:42]`: `arm_right_qvel`
@@ -20,8 +21,11 @@ On this page, we provide updates regarding the **2026 BEHAVIOR Challenge**, incl
     - `state[57:61]`: `trunk_qvel`
 
     Actions and all other dataset fields are unchanged.
+
 2. Updated partial-scene evaluation to load the exact room instances specified for each task in `B100_task_misc.csv`. This keeps the evaluation scene consistent with the challenge task metadata.
+
 3. Fixed observation loading with `RGBDFullResWrapper` by refreshing simulator handles after changing camera resolutions and before rebuilding the observation space.
+
 4. Fixed bugs affecting the challenge leaderboard and submission form.
 
 **New features:**


### PR DESCRIPTION
## Summary

- add the missing Markdown list boundaries in the August 2026 challenge update
- ensure all four bug fixes render as separate numbered entries

## Testing

- `git diff --check`
- `mkdocs build`
- verified the rendered Bug fixes `<ol>` contains four top-level `<li>` elements