### PR TITLE
Fix reset crash after transition rules fire on an episode's final step; report skipped instances

### DIFF
--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -148,14 +148,20 @@ def main() -> None:
         os.makedirs(video_dir, exist_ok=True)
 
     results = []
+    failed_instances = []
     with Evaluator(cfg) as evaluator:
         for instance_id in instance_ids:
             try:
                 evaluator.reset()
                 evaluator.load_task_instance(int(instance_id))
             except Exception:
-                logger.exception(f"Failed to load task instance {instance_id}.")
-                raise
+                # One instance failing to load must not abort the remaining instances of this task:
+                # record it and move on. The failure is reported in eval_summary.json below because the
+                # process exit status cannot carry it (Evaluator.__exit__ -> og.shutdown() -> app.close()
+                # terminates the process with status 0 before any sys.exit() after the block would run).
+                logger.exception(f"Failed to load task instance {instance_id}; skipping it.")
+                failed_instances.append(int(instance_id))
+                continue
             for rollout_id in range(args.num_rollouts):
                 video_path = os.path.join(video_dir, f"{args.task_name}_{instance_id}_{rollout_id}.mp4")
                 try:
@@ -192,16 +198,34 @@ def main() -> None:
                     )
                     results.append(result)
                 except Exception:
-                    logger.exception(f"Instance {instance_id} rollout {rollout_id} failed.")
-                    raise
+                    logger.exception(f"Instance {instance_id} rollout {rollout_id} failed; skipping it.")
+                    failed_instances.append(int(instance_id))
+                    break
                 finally:
                     if args.write_video:
                         evaluator.stop_recording()
 
-    n = len(results)
-    n_success = sum(r["success"] for r in results)
-    mean_q = (sum(r.get("q_score", {}).get("final", 0.0) for r in results) / n) if n else 0.0
-    logger.info(f"Eval summary: {n_success}/{n} success | mean q_score={mean_q:.3f} | task={args.task_name}")
+        n = len(results)
+        n_success = sum(r["success"] for r in results)
+        mean_q = (sum(r.get("q_score", {}).get("final", 0.0) for r in results) / n) if n else 0.0
+        logger.info(f"Eval summary: {n_success}/{n} success | mean q_score={mean_q:.3f} | task={args.task_name}")
+        if failed_instances:
+            logger.error(f"{len(failed_instances)} instance(s) failed and were skipped: {sorted(set(failed_instances))}")
+        # Written while the simulator is still up: the process exit status is always 0 (see above).
+        with open(os.path.join(os.path.expanduser(args.output_dir), "eval_summary.json"), "w") as f:
+            json.dump(
+                {
+                    "task": args.task_name,
+                    "mode": args.mode,
+                    "requested_instance_ids": [int(i) for i in instance_ids],
+                    "completed_instance_ids": sorted({int(r["instance_id"]) for r in results}),
+                    "failed_instance_ids": sorted(set(failed_instances)),
+                    "n_success": int(n_success),
+                    "mean_q_score": mean_q,
+                },
+                f,
+                indent=2,
+            )
 
 
 if __name__ == "__main__":

--- a/OmniGibson/omnigibson/eval/eval.py
+++ b/OmniGibson/omnigibson/eval/eval.py
@@ -210,7 +210,9 @@ def main() -> None:
         mean_q = (sum(r.get("q_score", {}).get("final", 0.0) for r in results) / n) if n else 0.0
         logger.info(f"Eval summary: {n_success}/{n} success | mean q_score={mean_q:.3f} | task={args.task_name}")
         if failed_instances:
-            logger.error(f"{len(failed_instances)} instance(s) failed and were skipped: {sorted(set(failed_instances))}")
+            logger.error(
+                f"{len(failed_instances)} instance(s) failed and were skipped: {sorted(set(failed_instances))}"
+            )
         # Written while the simulator is still up: the process exit status is always 0 (see above).
         with open(os.path.join(os.path.expanduser(args.output_dir), "eval_summary.json"), "w") as f:
             json.dump(

--- a/OmniGibson/omnigibson/simulator.py
+++ b/OmniGibson/omnigibson/simulator.py
@@ -978,6 +978,13 @@ def _launch_simulator(*args, **kwargs):
             """
             playing = self.is_playing()
             if playing:
+                # A transition rule may have deleted prims during the last physics step of an episode
+                # (omni.physx.tensors: "prim ... was deleted while being used by a shape in a tensor view.
+                # The physics.tensors simulationView was invalidated."). If the episode ended on that very
+                # step -- e.g. cooking / slicing satisfied the goal -- nothing refreshed the handles before
+                # the next reset, and dump_state() below reads None joint states from the dead views
+                # (`AttributeError: 'NoneType' object has no attribute 'view'`). Rebuild the handles first.
+                self.update_handles()
                 state = self.dump_state()
 
                 # Omniverse has a strange bug where if GPU dynamics is on and the object to remove is in contact with


### PR DESCRIPTION
## Problem

During official evaluation (`python -m omnigibson.eval.eval`), tasks whose episodes trigger transition rules (cooking, slicing, dicing — e.g. `make_microwave_popcorn`, `slicing_vegetables`, `cook_cabbage`) crash on the **next** `evaluator.reset()` after an episode in which the transition fired on the final step:

```
Failed to load task instance 303.
  ... omnigibson/scenes/scene_base.py, line 930, in restore
    og.sim.batch_remove_objects(objects_to_remove)
  ... omnigibson/simulator.py, line 981, in removing_objects
    state = self.dump_state()
  ... omnigibson/prims/entity_prim.py, line 859, in get_joint_positions
    joint_positions = self._articulation_view.get_joint_positions().view(self.n_dof)
AttributeError: 'NoneType' object has no attribute 'view'
```

Preceded by `[omni.physx.tensors.plugin] prim '/World/scene_0/half_zucchini_208_0/...' was deleted while being used by a shape in a tensor view. The physics.tensors simulationView was invalidated.`

Because `eval.py` re-raises, the whole process exits and every remaining instance of that task is lost. Reproduced on OmniGibson `22d19cd2f` (current `main`) on two 8×RTX 5880 machines; in our runs every successful popcorn/slicing/cabbage episode was followed by a crashing reset, so each task needed one process restart per instance.

## Root cause

A transition rule deletes prims during the last physics step of an episode, invalidating the PhysX tensor views. When the episode ends on that very step (the transition satisfied the goal), nothing rebuilds the handles before the next reset. `Scene.restore()` then calls `batch_remove_objects()` → `removing_objects()`, which snapshots the whole scene with `dump_state()` while the objects to be removed still hold dead views, and `get_joint_positions()` returns `None`.

## Fix

* `simulator.py` — `removing_objects()`: call `self.update_handles()` before `dump_state()` so the views are rebuilt first. With this change 3/3 post-success resets that previously crashed succeed (repro script: one instance that ends by cooking/slicing, then `reset()` + `load_task_instance(next)`).
* `eval.py` — a failing instance is logged and skipped instead of aborting the remaining instances, and the outcome is written to `<output-dir>/eval_summary.json` (`requested_instance_ids`, `completed_instance_ids`, `failed_instance_ids`, `n_success`, `mean_q_score`). The exit status cannot carry the failure: `Evaluator.__exit__` → `og.shutdown()` → `app.close()` terminates the process with status 0 before any `sys.exit()` after the block runs.

Neither change touches scoring: the metrics JSON per rollout is unchanged, and `update_handles()` only refreshes PhysX views.

## Testing

* Reproduced the crash on `main` with `make_microwave_popcorn`, `slicing_vegetables`, `cook_cabbage` (public instances 301–310, official R1Pro config, headless).
* With the patch, the previously crashing post-success resets succeed (3/3 in the repro), so a task's 10 instances no longer need one process restart per instance.
