### PR TITLE
Update data retention limits to 1 day

### DIFF
--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -98,6 +98,7 @@ jobs:
           name: profiling-${{ matrix.name }}
           path: OmniGibson/output.json
           if-no-files-found: warn
+          retention-days: 1
 
       - name: Upload deep profile outputs
         uses: actions/upload-artifact@v4
@@ -116,6 +117,7 @@ jobs:
             OmniGibson/non_physics_step.prof
             OmniGibson/non_physics_step.html
           if-no-files-found: warn
+          retention-days: 1
 
   report:
     name: Compile Profiling Report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           name: ${{ github.run_id }}-tests-bddl
           path: bddl3/bddl_tests.xml
           overwrite: true
+          retention-days: 1
 
   check_example_list:
     name: Check Example List Up To Date
@@ -171,6 +172,7 @@ jobs:
           name: ${{ github.run_id }}-snapshots
           path: OmniGibson/tests/snapshots/actual/
           overwrite: true
+          retention-days: 1
 
       - name: Deploy artifact
         if: always()
@@ -179,6 +181,7 @@ jobs:
           name: ${{ github.run_id }}-tests-${{ matrix.test_file }}${{ matrix.example && format('-{0}', matrix.example) || '' }}
           path: OmniGibson/${{ matrix.test_file }}${{ matrix.example && format('_{0}', matrix.example) || '' }}.xml
           overwrite: true
+          retention-days: 1
 
   upload_report:
     name: Test Report


### PR DESCRIPTION
We already dropped the settings for logs to 1 day retention, so there probably isn't a good use case for keeping these artifacts past then as well.

Also we seem to be hitting storage limit issues, likely due to the webpage build that we upload.