### PR TITLE
Require a real one-to-one pairing in forpairs and fornpairs

### DIFF
--- a/bddl3/bddl/condition_evaluation.py
+++ b/bddl3/bddl/condition_evaluation.py
@@ -75,6 +75,45 @@ def _bind_variable(scope, param_label, obj_name):
     return new_scope
 
 
+#################### MATCHING HELPERS ####################
+
+
+def _maximum_matching_size(satisfaction_matrix):
+    """Size of a maximum bipartite matching in a boolean satisfaction matrix.
+
+    ``satisfaction_matrix[i][j]`` is truthy when row instance *i* may be
+    paired with column instance *j*.  Returns the largest number of true
+    entries that can be chosen such that no two share a row or a column,
+    via Kuhn's augmenting-path algorithm.
+
+    Counting rows and columns that hold at least one true entry is *not*
+    equivalent: several rows can share a single column and still keep both
+    counts high, which would accept a state that admits no such pairing.
+    """
+    matrix = np.asarray(satisfaction_matrix, dtype=bool)
+    if matrix.ndim != 2 or matrix.size == 0:
+        return 0
+    n_rows, n_cols = matrix.shape
+    # For each column, the row it is currently matched to (-1 if free).
+    match_for_col = [-1] * n_cols
+
+    def _try_augment(row, visited):
+        for col in range(n_cols):
+            if not matrix[row][col] or visited[col]:
+                continue
+            visited[col] = True
+            if match_for_col[col] == -1 or _try_augment(match_for_col[col], visited):
+                match_for_col[col] = row
+                return True
+        return False
+
+    matching_size = 0
+    for row in range(n_rows):
+        if _try_augment(row, [False] * n_cols):
+            matching_size += 1
+    return matching_size
+
+
 #################### RECURSIVE PREDICATES ####################
 
 # -JUNCTIONS
@@ -371,9 +410,7 @@ class ForPairs(Expression):
         )
 
         L = min(len(self.children), len(self.children[0]))
-        return (np.sum(np.any(self.child_values, axis=1), axis=0) >= L) and (
-            np.sum(np.any(self.child_values, axis=0), axis=0) >= L
-        )
+        return _maximum_matching_size(self.child_values) >= L
 
     def get_ground_options(self):
         self.flattened_condition_options = []
@@ -451,9 +488,7 @@ class ForNPairs(Expression):
                 for child in self.children
             ]
         )
-        return (np.sum(np.any(self.child_values, axis=1), axis=0) >= self.N) and (
-            np.sum(np.any(self.child_values, axis=0), axis=0) >= self.N
-        )
+        return _maximum_matching_size(self.child_values) >= self.N
 
     def get_ground_options(self):
         self.flattened_condition_options = []

--- a/bddl3/tests/test_knowledgebase.py
+++ b/bddl3/tests/test_knowledgebase.py
@@ -3,7 +3,11 @@
 import pytest
 
 from bddl.knowledge_base import KnowledgeBase, Task, Synset
-from bddl.condition_evaluation import compile_state, evaluate_state
+from bddl.condition_evaluation import (
+    _maximum_matching_size,
+    compile_state,
+    evaluate_state,
+)
 from bddl.logic_base import Expression
 from bddl.predicates import (
     Predicate,
@@ -388,6 +392,106 @@ class TestConditionEvaluation:
         # No bowls covered -> forall succeeds
         ok, _ = evaluate_state(compiled, lambda cls, *e: False)
         assert ok is True
+
+    def test_evaluate_forpairs_requires_one_to_one_pairing(self):
+        """forpairs needs a real matching, not just non-empty rows and columns.
+
+        Glasses 1 and 2 are next to plate 1 only; glass 3 is next to plates 2
+        and 3. Every glass has some plate and every plate has some glass, so
+        counting satisfied rows and columns reaches 3 either way, but the
+        largest set of pairs sharing no glass and no plate has size 2.
+        """
+        scope = {
+            "wineglass.n.01_1", "wineglass.n.01_2", "wineglass.n.01_3",
+            "plate.n.04_1", "plate.n.04_2", "plate.n.04_3",
+        }
+        object_map = {
+            "wineglass.n.01": [
+                "wineglass.n.01_1", "wineglass.n.01_2", "wineglass.n.01_3",
+            ],
+            "plate.n.04": ["plate.n.04_1", "plate.n.04_2", "plate.n.04_3"],
+        }
+        parsed = [
+            [
+                "forpairs",
+                ["?glass", "-", "wineglass.n.01"],
+                ["?plate", "-", "plate.n.04"],
+                ["ontop", "?glass", "?plate"],
+            ]
+        ]
+        compiled = compile_state(parsed, scope=scope, object_map=object_map)
+
+        no_perfect_matching = {
+            ("wineglass.n.01_1", "plate.n.04_1"),
+            ("wineglass.n.01_2", "plate.n.04_1"),
+            ("wineglass.n.01_3", "plate.n.04_2"),
+            ("wineglass.n.01_3", "plate.n.04_3"),
+        }
+        ok, _ = evaluate_state(
+            compiled, lambda cls, *e: tuple(e) in no_perfect_matching
+        )
+        assert ok is False
+
+        # Give glass 2 its own plate and a full pairing exists.
+        perfect_matching = no_perfect_matching | {
+            ("wineglass.n.01_2", "plate.n.04_2")
+        }
+        ok, _ = evaluate_state(
+            compiled, lambda cls, *e: tuple(e) in perfect_matching
+        )
+        assert ok is True
+
+    def test_evaluate_fornpairs_requires_one_to_one_pairing(self):
+        """fornpairs needs N pairs that share no instance on either side."""
+        scope = {
+            "wineglass.n.01_1", "wineglass.n.01_2", "wineglass.n.01_3",
+            "plate.n.04_1", "plate.n.04_2", "plate.n.04_3",
+        }
+        object_map = {
+            "wineglass.n.01": [
+                "wineglass.n.01_1", "wineglass.n.01_2", "wineglass.n.01_3",
+            ],
+            "plate.n.04": ["plate.n.04_1", "plate.n.04_2", "plate.n.04_3"],
+        }
+        parsed = [
+            [
+                "fornpairs",
+                ["3"],
+                ["?glass", "-", "wineglass.n.01"],
+                ["?plate", "-", "plate.n.04"],
+                ["ontop", "?glass", "?plate"],
+            ]
+        ]
+        compiled = compile_state(parsed, scope=scope, object_map=object_map)
+
+        only_two_disjoint_pairs = {
+            ("wineglass.n.01_1", "plate.n.04_1"),
+            ("wineglass.n.01_2", "plate.n.04_1"),
+            ("wineglass.n.01_3", "plate.n.04_2"),
+            ("wineglass.n.01_3", "plate.n.04_3"),
+        }
+        ok, _ = evaluate_state(
+            compiled, lambda cls, *e: tuple(e) in only_two_disjoint_pairs
+        )
+        assert ok is False
+
+        three_disjoint_pairs = only_two_disjoint_pairs | {
+            ("wineglass.n.01_2", "plate.n.04_2")
+        }
+        ok, _ = evaluate_state(
+            compiled, lambda cls, *e: tuple(e) in three_disjoint_pairs
+        )
+        assert ok is True
+
+    def test_maximum_matching_size(self):
+        """The matching helper agrees with hand-computed matchings."""
+        assert _maximum_matching_size([[1, 0, 0], [1, 0, 0], [0, 1, 1]]) == 2
+        assert _maximum_matching_size([[1, 0, 0], [1, 1, 0], [0, 1, 1]]) == 3
+        assert _maximum_matching_size([[0, 0], [0, 0]]) == 0
+        assert _maximum_matching_size([[1, 1], [1, 1]]) == 2
+        # A single column cannot serve two rows.
+        assert _maximum_matching_size([[1], [1]]) == 1
+        assert _maximum_matching_size([]) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`ForPairs.evaluate` and `ForNPairs.evaluate` decide satisfaction by counting how many rows and how many columns of the satisfaction matrix hold at least one satisfied entry, then comparing each count against the number of pairs required. That is weaker than it looks: a matrix can pass both counts without containing that many satisfied entries that share no row and no column. So a state gets accepted in which several instances of one category share a single instance of the other, as long as the remaining entries keep both counts up.

The documentation asks for something stricter. `docs/activity_definition.md:90` defines the operator as "some one-to-one mapping of object instances of `mycat` to object instances of `othercat` that covers all instances of at least one of the two categories", line 91 says the same for `fornpairs` with `n` pairs, and the `ForPairs` class docstring says "Satisfied when a perfect matching (bipartite) of size `min(|cat1|, |cat2|)` exists" in the same class as the return that does not check for one.

The inconsistency is visible inside the library. `get_ground_options` builds one-to-one mappings out of `itertools.permutations`, and `get_reward` scores against those, so for one state `bddl` could report the goal satisfied and a reward below 1 at the same time. From the issue's repro, with three glasses and three plates where glasses 1 and 2 are both next to plate 1 only and glass 3 covers plates 2 and 3:

```
goal satisfied: True
reward        : 0.6666666666666666
```

Every glass has a plate and every plate has a glass, so both counts reach 3, but the largest set of pairs sharing no glass and no plate has size 2. This also reaches a shipped definition — `laying_restaurant_table_for_dinner/problem0.bddl` has a `forpairs` over four wineglasses and four plates — and it reaches episode termination, since `check_goal` feeds `PredicateGoal` in OmniGibson.

## What changed

Both `evaluate` methods now compute the size of a maximum bipartite matching over the satisfaction matrix and compare that against the pairs required. The matching lives in a new `_maximum_matching_size` helper using Kuhn's augmenting-path algorithm; it is self-contained, so this adds no dependency. I fixed `ForNPairs` alongside `ForPairs` because it is the identical rule against `self.N` rather than `min(M, N)` — fixing only the reported one would leave the same hole one class down.

For a matrix that does admit a full pairing the two rules agree, so definitions that were passing for the right reason keep passing.

## Testing

Ran against the issue's reproduction script, which needs `bddl` only:

```
goal satisfied: False
reward        : 0.6666666666666666
```

Satisfaction and reward now agree.

Added two regression tests to `TestConditionEvaluation` in `tests/test_knowledgebase.py`, one for `forpairs` and one for `fornpairs`, each asserting both directions — the no-perfect-matching state is rejected, and the state that gains one more pair is accepted — plus a small unit test for the helper. To confirm the tests actually bind to this change I restored the old counting rule in the two `evaluate` bodies while keeping the helper defined, and both fail:

```
FAILED tests/test_knowledgebase.py::TestConditionEvaluation::test_evaluate_forpairs_requires_one_to_one_pairing
FAILED tests/test_knowledgebase.py::TestConditionEvaluation::test_evaluate_fornpairs_requires_one_to_one_pairing
E       assert True is False
2 failed in 0.26s
```

With the fix in place, `pytest tests/` gives 56 passed, 5 failed. The 5 failures are all `tests/test_taxonomy.py` (`ObjectTaxonomy` has no `is_valid_class`, `get_parent`, …) and they fail identically on an unmodified checkout of `main`, so they are pre-existing and unrelated.

I also checked the helper against a brute-force maximum matching over 4000 random boolean matrices up to 4x4, with no disagreement; 13 of those matrices were cases where the old counting rule disagreed with the true matching size, which is the bug class this fixes.

`ruff check` on the two changed files reports the same 23 pre-existing findings before and after the change, with identical per-rule tallies — nothing new introduced.

Fixes #2333
